### PR TITLE
Add package installation prerequisites to ML and DL days

### DIFF
--- a/Day_40_Intro_to_ML/README.md
+++ b/Day_40_Intro_to_ML/README.md
@@ -2,6 +2,8 @@
 
 Welcome to Day 40! Today, we'll introduce the field of Machine Learning (ML) and discuss some of the core concepts that are essential for understanding how ML models are trained and evaluated.
 
+> **Prerequisites:** Install scikit-learn with `pip install scikit-learn` before running today's code samples. Need a refresher on package management? Revisit the Day 20 Python Package Manager lesson.
+
 ## What is Machine Learning?
 
 Machine Learning is a subfield of artificial intelligence that gives computers the ability to learn from data without being explicitly programmed. Instead of writing rules, we provide an algorithm with a large amount of data and let it learn the patterns itself.

--- a/Day_41_Supervised_Learning_Regression/README.md
+++ b/Day_41_Supervised_Learning_Regression/README.md
@@ -2,6 +2,8 @@
 
 Welcome to Day 41! Today, we focus on **Regression**, a type of supervised learning where the goal is to predict a continuous numerical value.
 
+> **Prerequisites:** Install scikit-learn with `pip install scikit-learn` before working through the exercises. If you need a refresher on using `pip`, revisit the Day 20 Python Package Manager lesson.
+
 ## Key Concepts
 
 ### What is Regression?

--- a/Day_42_Supervised_Learning_Classification_Part_1/README.md
+++ b/Day_42_Supervised_Learning_Classification_Part_1/README.md
@@ -2,6 +2,8 @@
 
 Welcome to Day 42! Today, we begin our exploration of **Classification**, a type of supervised learning where the goal is to predict a discrete class label. We'll start with two fundamental classification algorithms: Logistic Regression and K-Nearest Neighbors (KNN).
 
+> **Prerequisites:** Install scikit-learn with `pip install scikit-learn` so you can run the sample notebooks and scripts. Need a reminder on installing packages? Revisit the Day 20 Python Package Manager lesson.
+
 ## Key Concepts
 
 ### What is Classification?

--- a/Day_43_Supervised_Learning_Classification_Part_2/README.md
+++ b/Day_43_Supervised_Learning_Classification_Part_2/README.md
@@ -2,6 +2,8 @@
 
 Welcome to Day 43! We continue our journey into classification algorithms by exploring two more powerful and widely used models: **Support Vector Machines (SVMs)** and **Decision Trees**.
 
+> **Prerequisites:** Install scikit-learn with `pip install scikit-learn` before diving into the code examples. For a quick refresher on `pip`, revisit the Day 20 Python Package Manager lesson.
+
 ## Key Concepts
 
 ### 1. Support Vector Machines (SVM)

--- a/Day_44_Unsupervised_Learning/README.md
+++ b/Day_44_Unsupervised_Learning/README.md
@@ -2,6 +2,8 @@
 
 Welcome to Day 44! Today, we shift our focus to **Unsupervised Learning**, where we work with unlabeled data to discover hidden patterns and structures. We'll explore two fundamental techniques: **K-Means Clustering** for grouping data and **Principal Component Analysis (PCA)** for dimensionality reduction.
 
+> **Prerequisites:** Install scikit-learn with `pip install scikit-learn` to experiment with the clustering and PCA demos. Need a `pip` refresher? Revisit the Day 20 Python Package Manager lesson.
+
 ## Key Concepts
 
 ### What is Unsupervised Learning?

--- a/Day_45_Feature_Engineering_and_Evaluation/README.md
+++ b/Day_45_Feature_Engineering_and_Evaluation/README.md
@@ -2,6 +2,8 @@
 
 Welcome to Day 45! Today, we cover two critical aspects of the machine learning workflow: **Feature Engineering**, the art of creating better input features, and **Model Evaluation**, the science of assessing a model's performance beyond simple accuracy.
 
+> **Prerequisites:** Install scikit-learn with `pip install scikit-learn` so you can follow the preprocessing and evaluation walkthroughs. Need a reminder on managing packages? Revisit the Day 20 Python Package Manager lesson.
+
 ## 1. Feature Engineering
 
 Feature engineering is the process of using domain knowledge to create features that make machine learning algorithms work better. Good features can make the difference between a poor model and a highly accurate one.

--- a/Day_46_Intro_to_Neural_Networks/README.md
+++ b/Day_46_Intro_to_Neural_Networks/README.md
@@ -2,6 +2,8 @@
 
 Welcome to Day 46! Today, we begin our exploration of **Deep Learning** by introducing the fundamental building block: the **Artificial Neural Network (ANN)**. We'll also discuss the major frameworks used to build these powerful models.
 
+> **Prerequisites:** Install TensorFlow with `pip install tensorflow` to run today's neural-network examples (this installs the CPU build; GPU acceleration requires following TensorFlow's CUDA setup). You'll also need scikit-learn for data prep with `pip install scikit-learn`. Need a refresher on using `pip`? Revisit the Day 20 Python Package Manager lesson.
+
 ## Key Concepts
 
 ### What is a Neural Network?

--- a/Day_47_Convolutional_Neural_Networks/README.md
+++ b/Day_47_Convolutional_Neural_Networks/README.md
@@ -2,6 +2,8 @@
 
 Welcome to Day 47! Today, we dive into **Convolutional Neural Networks (CNNs)**, a specialized type of neural network that has revolutionized the field of **Computer Vision**.
 
+> **Prerequisites:** Ensure TensorFlow is installed with `pip install tensorflow` (CPU build by default; use TensorFlow's GPU installation guide if you have compatible hardware). Need to review package installation basics? Revisit the Day 20 Python Package Manager lesson.
+
 ## Key Concepts
 
 ### What are CNNs?

--- a/Day_48_Recurrent_Neural_Networks/README.md
+++ b/Day_48_Recurrent_Neural_Networks/README.md
@@ -2,6 +2,8 @@
 
 Welcome to Day 48! Today, we explore **Recurrent Neural Networks (RNNs)**, a class of neural networks designed specifically for handling **sequential data**, such as time series, text, or audio.
 
+> **Prerequisites:** Install TensorFlow with `pip install tensorflow` so you can build and train the RNN examples (CPU build by default; follow TensorFlow's GPU instructions if you have compatible hardware). Need to brush up on `pip` usage? Revisit the Day 20 Python Package Manager lesson.
+
 ## Key Concepts
 
 ### What are RNNs?


### PR DESCRIPTION
## Summary
- add scikit-learn installation prerequisites to Days 40-45 READMEs and reference the Day 20 pip lesson
- add TensorFlow installation guidance (with CPU/GPU note) to Days 46-48 READMEs and link back to the Day 20 pip lesson for package management help

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68d58f7029e08320b25d1c5186a67225