### PR TITLE
Use pathlib for lesson CSV paths

### DIFF
--- a/Day_24_Pandas_Advanced/pandas_adv.py
+++ b/Day_24_Pandas_Advanced/pandas_adv.py
@@ -5,12 +5,17 @@ This script demonstrates loading data from a CSV file and
 using advanced selection and cleaning techniques with Pandas.
 """
 
+from pathlib import Path
+
 import pandas as pd
 
 # --- Loading Data from a CSV File ---
+resource_dir = Path(__file__).resolve().parent
+data_path = resource_dir / "sales_data.csv"
+
 print("--- Loading and Inspecting sales_data.csv ---")
 # This command reads the CSV file in the same directory into a DataFrame.
-df = pd.read_csv(r"Day_24_Pandas_Advanced\sales_data.csv")
+df = pd.read_csv(data_path)
 
 # Always inspect after loading
 print("First 5 rows (df.head()):")

--- a/Day_25_Data_Cleaning/data_cleaning.py
+++ b/Day_25_Data_Cleaning/data_cleaning.py
@@ -5,18 +5,26 @@ This script demonstrates common data cleaning techniques on a
 messy, real-world-style dataset using Pandas.
 """
 
+from pathlib import Path
+
 import pandas as pd
 
 # --- Load the Messy Data ---
+resource_dir = Path(__file__).resolve().parent
+data_path = resource_dir / "messy_sales_data.csv"
+
 print("--- Loading and Inspecting Messy Data ---")
 try:
-    df = pd.read_csv(r"Day_25_Data_Cleaning\messy_sales_data.csv")
+    df = pd.read_csv(data_path)
     print("Original data types (df.info()):")
     df.info()
     print("\nOriginal data head:")
     print(df.head())
 except FileNotFoundError:
-    print("Error: messy_sales_data.csv not found.")
+    print(
+        "Error: messy_sales_data.csv not found in the Day_25_Data_Cleaning folder."
+        " Keep the CSV beside this script."
+    )
     df = pd.DataFrame()  # Create empty df to prevent crash
 
 if not df.empty:

--- a/Day_25_Data_Cleaning/solutions.py
+++ b/Day_25_Data_Cleaning/solutions.py
@@ -2,13 +2,18 @@
 Day 25: Solutions to Exercises
 """
 
+from pathlib import Path
+
 import pandas as pd
 
 # --- Exercise 1: Load and Initial Clean ---
 print("--- Solution to Exercise 1 ---")
+resource_dir = Path(__file__).resolve().parent
+data_path = resource_dir / "messy_sales_data.csv"
+
 try:
     # Load the data
-    df = pd.read_csv(r"Day_25_Data_Cleaning\messy_sales_data.csv")
+    df = pd.read_csv(data_path)
     print("Original DataFrame info:")
     df.info()
 
@@ -28,7 +33,10 @@ try:
     df.info()
 
 except FileNotFoundError:
-    print("Error: messy_sales_data.csv not found.")
+    print(
+        "Error: messy_sales_data.csv not found in the Day_25_Data_Cleaning folder."
+        " Keep the CSV beside this script."
+    )
     df = pd.DataFrame()
 print("-" * 20)
 

--- a/Day_26_Statistics/solutions.py
+++ b/Day_26_Statistics/solutions.py
@@ -2,13 +2,18 @@
 Day 26: Solutions to Exercises
 """
 
+from pathlib import Path
+
 import pandas as pd
 from scipy.stats import ttest_ind
 
 # --- Exercise 1: Descriptive Statistics of Sales ---
 print("--- Solution to Exercise 1 ---")
+resource_dir = Path(__file__).resolve().parent
+data_path = resource_dir / "sales_data.csv"
+
 try:
-    df = pd.read_csv(r"Day_24_Pandas_Advanced\sales_data.csv")
+    df = pd.read_csv(data_path)
     df.dropna(inplace=True)  # Clean the data first
 
     revenue = df["Revenue"]
@@ -20,7 +25,7 @@ try:
     print(f"Maximum Revenue: ${revenue.max():,.2f}")
 
 except FileNotFoundError:
-    print("Error: sales_data.csv not found in '17_Day_Pandas_Adv' directory.")
+    print("Error: sales_data.csv not found. Keep the CSV beside this script.")
     df = pd.DataFrame()
 print("-" * 20)
 

--- a/Day_26_Statistics/stats.py
+++ b/Day_26_Statistics/stats.py
@@ -5,13 +5,18 @@ This script demonstrates how to calculate descriptive statistics,
 correlation, and perform a simple hypothesis test (t-test).
 """
 
+from pathlib import Path
+
 import pandas as pd
 from scipy.stats import ttest_ind
 
 # --- 1. Descriptive Statistics with Pandas ---
+resource_dir = Path(__file__).resolve().parent
+data_path = resource_dir / "sales_data.csv"
+
 print("--- 1. Descriptive Statistics of Sales Data ---")
 try:
-    df = pd.read_csv(r"Day_24_Pandas_Advanced\sales_data.csv")
+    df = pd.read_csv(data_path)
     df.dropna(inplace=True)  # Clean the data first
 
     # Select the 'Revenue' column to analyze
@@ -27,7 +32,7 @@ try:
     print(df.describe())
 
 except FileNotFoundError:
-    print("Error: sales_data.csv not found in '17_Day_Pandas_Adv' directory.")
+    print("Error: sales_data.csv not found. Keep the CSV beside this script.")
     df = pd.DataFrame()
 print("-" * 20)
 

--- a/Day_27_Visualization/solutions.py
+++ b/Day_27_Visualization/solutions.py
@@ -2,20 +2,25 @@
 Day 27: Solutions to Exercises
 """
 
+from pathlib import Path
+
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
 
 # --- Load and Prepare Data ---
 # We use the cleaned data from Day 24 for reliable plotting.
+resource_dir = Path(__file__).resolve().parent
+data_path = resource_dir / "sales_data.csv"
+
 try:
     # We use the data from Day 24, so we need to reference its path
     # parse_dates=['Date'] tells pandas to automatically convert the 'Date' column
-    df = pd.read_csv(r"Day_24_Pandas_Advanced\sales_data.csv", parse_dates=["Date"])
+    df = pd.read_csv(data_path, parse_dates=["Date"])
     df.dropna(inplace=True)  # Drop rows with missing values for simplicity
     print("Data loaded successfully for exercises.")
 except FileNotFoundError:
-    print("Error: sales_data.csv not found in 'Day_24_Pandas_Advanced' directory.")
+    print("Error: sales_data.csv not found. Keep the CSV beside this script.")
     df = pd.DataFrame()
 
 

--- a/Day_27_Visualization/visualization.py
+++ b/Day_27_Visualization/visualization.py
@@ -5,19 +5,24 @@ This script demonstrates how to create common business charts
 using the Seaborn and Matplotlib libraries with a sample dataset.
 """
 
+from pathlib import Path
+
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
 
 # --- Load and Prepare Data ---
 # We use the cleaned data from Day 24 for reliable plotting.
+resource_dir = Path(__file__).resolve().parent
+data_path = resource_dir / "sales_data.csv"
+
 try:
     # parse_dates=['Date'] tells pandas to automatically convert the 'Date' column
-    df = pd.read_csv(r"Day_24_Pandas_Advanced\sales_data.csv", parse_dates=["Date"])
+    df = pd.read_csv(data_path, parse_dates=["Date"])
     df.dropna(inplace=True)  # Drop rows with missing values for simplicity
     print("Data loaded successfully.")
 except FileNotFoundError:
-    print("Error: sales_data.csv not found. Please run Day 24 first.")
+    print("Error: sales_data.csv not found. Keep the CSV beside this script.")
     df = pd.DataFrame()
 
 

--- a/Day_28_Advanced_Visualization/advanced_visualization.py
+++ b/Day_28_Advanced_Visualization/advanced_visualization.py
@@ -5,17 +5,22 @@ This script demonstrates how to customize plots for presentation
 and arrange multiple plots into a single dashboard figure.
 """
 
+from pathlib import Path
+
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
 
 # --- Load and Prepare Data ---
+resource_dir = Path(__file__).resolve().parent
+data_path = resource_dir / "sales_data.csv"
+
 try:
-    df = pd.read_csv(r"Day_24_Pandas_Advanced\sales_data.csv", parse_dates=["Date"])
+    df = pd.read_csv(data_path, parse_dates=["Date"])
     df.dropna(inplace=True)
     print("Data loaded successfully.")
 except FileNotFoundError:
-    print("Error: sales_data.csv not found in 'Day_24_Pandas_Advanced' directory.")
+    print("Error: sales_data.csv not found. Keep the CSV beside this script.")
     df = pd.DataFrame()
 
 if not df.empty:

--- a/Day_28_Advanced_Visualization/solutions.py
+++ b/Day_28_Advanced_Visualization/solutions.py
@@ -2,18 +2,23 @@
 Day 28: Solutions to Exercises
 """
 
+from pathlib import Path
+
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
 
 # --- Load and Prepare Data ---
 # We use the cleaned data from Day 24 for reliable plotting.
+resource_dir = Path(__file__).resolve().parent
+data_path = resource_dir / "sales_data.csv"
+
 try:
-    df = pd.read_csv(r"Day_24_Pandas_Advanced\sales_data.csv", parse_dates=["Date"])
+    df = pd.read_csv(data_path, parse_dates=["Date"])
     df.dropna(inplace=True)  # Drop rows with missing values for simplicity
     print("Data loaded successfully for exercises.")
 except FileNotFoundError:
-    print("Error: sales_data.csv not found in 'Day_24_Pandas_Advanced' directory.")
+    print("Error: sales_data.csv not found. Keep the CSV beside this script.")
     df = pd.DataFrame()
 
 

--- a/Day_29_Interactive_Visualization/interactive_visualization.py
+++ b/Day_29_Interactive_Visualization/interactive_visualization.py
@@ -5,16 +5,21 @@ This script demonstrates how to create interactive, web-based
 charts using the Plotly Express library.
 """
 
+from pathlib import Path
+
 import pandas as pd
 import plotly.express as px
 
 # --- Load and Prepare Data ---
+resource_dir = Path(__file__).resolve().parent
+data_path = resource_dir / "sales_data.csv"
+
 try:
-    df = pd.read_csv(r"Day_24_Pandas_Advanced\sales_data.csv", parse_dates=["Date"])
+    df = pd.read_csv(data_path, parse_dates=["Date"])
     df.dropna(inplace=True)
     print("Data loaded successfully.")
 except FileNotFoundError:
-    print("Error: sales_data.csv not found in '17_Day_Pandas_Adv' directory.")
+    print("Error: sales_data.csv not found. Keep the CSV beside this script.")
     df = pd.DataFrame()
 
 if not df.empty:

--- a/Day_29_Interactive_Visualization/solutions.py
+++ b/Day_29_Interactive_Visualization/solutions.py
@@ -2,16 +2,21 @@
 Day 29: Solutions to Exercises
 """
 
+from pathlib import Path
+
 import pandas as pd
 import plotly.express as px
 
 # --- Load and Prepare Data ---
+resource_dir = Path(__file__).resolve().parent
+data_path = resource_dir / "sales_data.csv"
+
 try:
-    df = pd.read_csv(r"Day_24_Pandas_Advanced\sales_data.csv", parse_dates=["Date"])
+    df = pd.read_csv(data_path, parse_dates=["Date"])
     df.dropna(inplace=True)  # Drop rows with missing values for simplicity
     print("Data loaded successfully for exercises.")
 except FileNotFoundError:
-    print("Error: sales_data.csv not found in '17_Day_Pandas_Adv' directory.")
+    print("Error: sales_data.csv not found. Keep the CSV beside this script.")
     df = pd.DataFrame()
 
 


### PR DESCRIPTION
## Summary
- load lesson CSV files with `pathlib.Path` objects so resources resolve relative to each script
- update FileNotFoundError guidance to direct learners to keep the CSV beside the scripts

## Testing
- python -m compileall Day_24_Pandas_Advanced Day_25_Data_Cleaning Day_26_Statistics Day_27_Visualization Day_28_Advanced_Visualization Day_29_Interactive_Visualization

------
https://chatgpt.com/codex/tasks/task_b_68d593eccd248320bff2282da344ed6b