### PR TITLE
Fix table formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,74 +14,74 @@ Each day's folder contains a lesson, example code, and exercises to solidify you
 ## Table of Contents
 
 ### Part 1: Python Core Concepts
-| Day | Topic                                      | Folder                                                               |
-|-----|--------------------------------------------|----------------------------------------------------------------------|
-| 1   | Introduction                               | [Day_01_Introduction](./Day_01_Introduction/)                        |
-| 2   | Variables & Built-in Functions             | [Day_02_Variables_Builtin_Functions](./Day_02_Variables_Builtin_Functions/) |
-| 3   | Operators                                  | [Day_03_Operators](./Day_03_Operators/)                              |
-| 4   | Strings                                    | [Day_04_Strings](./Day_04_Strings/)                                  |
-| 5   | Lists                                      | [Day_05_Lists](./Day_05_Lists/)                                      |
-| 6   | Tuples                                     | [Day_06_Tuples](./Day_06_Tuples/)                                    |
-| 7   | Sets                                       | [Day_07_Sets](./Day_07_Sets/)                                        |
-| 8   | Dictionaries                               | [Day_08_Dictionaries](./Day_08_Dictionaries/)                        |
-| 9   | Conditionals                               | [Day_09_Conditionals](./Day_09_Conditionals/)                        |
-| 10  | Loops                                      | [Day_10_Loops](./Day_10_Loops/)                                      |
-| 11  | Functions                                  | [Day_11_Functions](./Day_11_Functions/)                              |
-| 12  | List Comprehension                         | [Day_12_List_Comprehension](./Day_12_List_Comprehension/)            |
-| 13  | Higher-Order Functions                     | [Day_13_Higher_Order_Functions](./Day_13_Higher_Order_Functions/)    |
-| 14  | Modules                                    | [Day_14_Modules](./Day_14_Modules/)                                  |
-| 15  | Exception Handling                         | [Day_15_Exception_Handling](./Day_15_Exception_Handling/)            |
-| 16  | File Handling                              | [Day_16_File_Handling](./Day_16_File_Handling/)                      |
-| 17  | Regular Expressions                        | [Day_17_Regular_Expressions](./Day_17_Regular_Expressions/)          |
-| 18  | Classes and Objects                        | [Day_18_Classes_and_Objects](./Day_18_Classes_and_Objects/)          |
-| 19  | Python Date & Time                         | [Day_19_Python_Date_Time](./Day_19_Python_Date_Time/)                |
+| Day | Topic                          | Folder                                                               |
+|-----|--------------------------------|----------------------------------------------------------------------|
+| 1   | Introduction                   | [Day_01_Introduction](./Day_01_Introduction/)                        |
+| 2   | Variables & Built-in Functions | [Day_02_Variables_Builtin_Functions](./Day_02_Variables_Builtin_Functions/) |
+| 3   | Operators                      | [Day_03_Operators](./Day_03_Operators/)                              |
+| 4   | Strings                        | [Day_04_Strings](./Day_04_Strings/)                                  |
+| 5   | Lists                          | [Day_05_Lists](./Day_05_Lists/)                                      |
+| 6   | Tuples                         | [Day_06_Tuples](./Day_06_Tuples/)                                    |
+| 7   | Sets                           | [Day_07_Sets](./Day_07_Sets/)                                        |
+| 8   | Dictionaries                   | [Day_08_Dictionaries](./Day_08_Dictionaries/)                        |
+| 9   | Conditionals                   | [Day_09_Conditionals](./Day_09_Conditionals/)                        |
+| 10  | Loops                          | [Day_10_Loops](./Day_10_Loops/)                                      |
+| 11  | Functions                      | [Day_11_Functions](./Day_11_Functions/)                              |
+| 12  | List Comprehension             | [Day_12_List_Comprehension](./Day_12_List_Comprehension/)            |
+| 13  | Higher-Order Functions         | [Day_13_Higher_Order_Functions](./Day_13_Higher_Order_Functions/)    |
+| 14  | Modules                        | [Day_14_Modules](./Day_14_Modules/)                                  |
+| 15  | Exception Handling             | [Day_15_Exception_Handling](./Day_15_Exception_Handling/)            |
+| 16  | File Handling                  | [Day_16_File_Handling](./Day_16_File_Handling/)                      |
+| 17  | Regular Expressions            | [Day_17_Regular_Expressions](./Day_17_Regular_Expressions/)          |
+| 18  | Classes and Objects            | [Day_18_Classes_and_Objects](./Day_18_Classes_and_Objects/)          |
+| 19  | Python Date & Time             | [Day_19_Python_Date_Time](./Day_19_Python_Date_Time/)                |
 
 ### Part 2: Data Science
-| Day | Topic                            | Folder                                                                 |
-|-----|----------------------------------|------------------------------------------------------------------------|
-| 20  | Python Package Manager           | [Day_20_Python_Package_Manager](./Day_20_Python_Package_Manager/)      |
-| 21  | Virtual Environments             | [Day_21_Virtual_Environments](./Day_21_Virtual_Environments/)          |
-| 22  | NumPy                            | [Day_22_NumPy](./Day_22_NumPy/)                                        |
-| 23  | Pandas                           | [Day_23_Pandas](./Day_23_Pandas/)                                      |
-| 24  | Advanced Pandas                  | [Day_24_Pandas_Advanced](./Day_24_Pandas_Advanced/)                    |
-| 25  | Data Cleaning                    | [Day_25_Data_Cleaning](./Day_25_Data_Cleaning/)                        |
-| 26  | Statistics                       | [Day_26_Statistics](./Day_26_Statistics/)                              |
-| 27  | Visualization                    | [Day_27_Visualization](./Day_27_Visualization/)                        |
-| 28  | Advanced Visualization           | [Day_28_Advanced_Visualization](./Day_28_Advanced_Visualization/)      |
-| 29  | Interactive Visualization        | [Day_29_Interactive_Visualization](./Day_29_Interactive_Visualization/) |
+| Day | Topic                     | Folder                                                                 |
+|-----|---------------------------|------------------------------------------------------------------------|
+| 20  | Python Package Manager    | [Day_20_Python_Package_Manager](./Day_20_Python_Package_Manager/)      |
+| 21  | Virtual Environments      | [Day_21_Virtual_Environments](./Day_21_Virtual_Environments/)          |
+| 22  | NumPy                     | [Day_22_NumPy](./Day_22_NumPy/)                                        |
+| 23  | Pandas                    | [Day_23_Pandas](./Day_23_Pandas/)                                      |
+| 24  | Advanced Pandas           | [Day_24_Pandas_Advanced](./Day_24_Pandas_Advanced/)                    |
+| 25  | Data Cleaning             | [Day_25_Data_Cleaning](./Day_25_Data_Cleaning/)                        |
+| 26  | Statistics                | [Day_26_Statistics](./Day_26_Statistics/)                              |
+| 27  | Visualization             | [Day_27_Visualization](./Day_27_Visualization/)                        |
+| 28  | Advanced Visualization    | [Day_28_Advanced_Visualization](./Day_28_Advanced_Visualization/)      |
+| 29  | Interactive Visualization | [Day_29_Interactive_Visualization](./Day_29_Interactive_Visualization/) |
 
 ### Part 3: Web and APIs
-| Day | Topic                      | Folder                                                               |
-|-----|----------------------------|----------------------------------------------------------------------|
-| 30  | Web Scraping               | [Day_30_Web_Scraping](./Day_30_Web_Scraping/)                        |
-| 31  | Databases                  | [Day_31_Databases](./Day_31_Databases/)                              |
-| 32  | Other Databases            | [Day_32_Other_Databases](./Day_32_Other_Databases/)                  |
-| 33  | API                        | [Day_33_API](./Day_33_API/)                                          |
-| 34  | Building an API            | [Day_34_Building_an_API](./Day_34_Building_an_API/)                  |
-| 35  | Flask Web Framework        | [Day_35_Flask_Web_Framework](./Day_35_Flask_Web_Framework/)          |
+| Day | Topic               | Folder                                                               |
+|-----|---------------------|----------------------------------------------------------------------|
+| 30  | Web Scraping        | [Day_30_Web_Scraping](./Day_30_Web_Scraping/)                        |
+| 31  | Databases           | [Day_31_Databases](./Day_31_Databases/)                              |
+| 32  | Other Databases     | [Day_32_Other_Databases](./Day_32_Other_Databases/)                  |
+| 33  | API                 | [Day_33_API](./Day_33_API/)                                          |
+| 34  | Building an API     | [Day_34_Building_an_API](./Day_34_Building_an_API/)                  |
+| 35  | Flask Web Framework | [Day_35_Flask_Web_Framework](./Day_35_Flask_Web_Framework/)          |
 
 ### Part 4: Conclusion
-| Day | Topic        | Folder                                         |
-|-----|--------------|------------------------------------------------|
-| 36  | Case Study   | [Day_36_Case_Study](./Day_36_Case_Study/)      |
-| 37  | Conclusion   | [Day_37_Conclusion](./Day_37_Conclusion/)      |
+| Day | Topic      | Folder                                         |
+|-----|------------|------------------------------------------------|
+| 36  | Case Study | [Day_36_Case_Study](./Day_36_Case_Study/)      |
+| 37  | Conclusion | [Day_37_Conclusion](./Day_37_Conclusion/)      |
 
 ### Part 5: Machine Learning
-| Day | Topic                                     | Folder                                                                |
-|-----|-------------------------------------------|-----------------------------------------------------------------------|
-| 38  | Math Foundations - Linear Algebra         | [Day_38_Linear_Algebra](./Day_38_Linear_Algebra/)                     |
-| 39  | Math Foundations - Calculus               | [Day_39_Calculus](./Day_39_Calculus/)                                 |
-| 40  | Introduction to ML & Core Concepts        | [Day_40_Intro_to_ML](./Day_40_Intro_to_ML/)                           |
-| 41  | Supervised Learning - Regression          | [Day_41_Supervised_Learning_Regression](./Day_41_Supervised_Learning_Regression/) |
-| 42  | Supervised Learning - Classification 1    | [Day_42_Supervised_Learning_Classification_Part_1](./Day_42_Supervised_Learning_Classification_Part_1/) |
-| 43  | Supervised Learning - Classification 2    | [Day_43_Supervised_Learning_Classification_Part_2](./Day_43_Supervised_Learning_Classification_Part_2/) |
-| 44  | Unsupervised Learning                     | [Day_44_Unsupervised_Learning](./Day_44_Unsupervised_Learning/)       |
-| 45  | Feature Engineering & Model Evaluation    | [Day_45_Feature_Engineering_and_Evaluation](./Day_45_Feature_Engineering_and_Evaluation/) |
-| 46  | Intro to Neural Networks & Frameworks     | [Day_46_Intro_to_Neural_Networks](./Day_46_Intro_to_Neural_Networks/) |
-| 47  | Convolutional Neural Networks (CNNs)      | [Day_47_Convolutional_Neural_Networks](./Day_47_Convolutional_Neural_Networks/) |
-| 48  | Recurrent Neural Networks (RNNs)          | [Day_48_Recurrent_Neural_Networks](./Day_48_Recurrent_Neural_Networks/) |
-| 49  | Natural Language Processing (NLP)         | [Day_49_NLP](./Day_49_NLP/)                                           |
-| 50  | MLOps - Model Deployment                  | [Day_50_MLOps](./Day_50_MLOps/)                                       |
+| Day | Topic                                  | Folder                                                                |
+|-----|----------------------------------------|-----------------------------------------------------------------------|
+| 38  | Math Foundations - Linear Algebra      | [Day_38_Linear_Algebra](./Day_38_Linear_Algebra/)                     |
+| 39  | Math Foundations - Calculus            | [Day_39_Calculus](./Day_39_Calculus/)                                 |
+| 40  | Introduction to ML & Core Concepts     | [Day_40_Intro_to_ML](./Day_40_Intro_to_ML/)                           |
+| 41  | Supervised Learning - Regression       | [Day_41_Supervised_Learning_Regression](./Day_41_Supervised_Learning_Regression/) |
+| 42  | Supervised Learning - Classification 1 | [Day_42_Supervised_Learning_Classification_Part_1](./Day_42_Supervised_Learning_Classification_Part_1/) |
+| 43  | Supervised Learning - Classification 2 | [Day_43_Supervised_Learning_Classification_Part_2](./Day_43_Supervised_Learning_Classification_Part_2/) |
+| 44  | Unsupervised Learning                  | [Day_44_Unsupervised_Learning](./Day_44_Unsupervised_Learning/)       |
+| 45  | Feature Engineering & Model Evaluation | [Day_45_Feature_Engineering_and_Evaluation](./Day_45_Feature_Engineering_and_Evaluation/) |
+| 46  | Intro to Neural Networks & Frameworks  | [Day_46_Intro_to_Neural_Networks](./Day_46_Intro_to_Neural_Networks/) |
+| 47  | Convolutional Neural Networks (CNNs)   | [Day_47_Convolutional_Neural_Networks](./Day_47_Convolutional_Neural_Networks/) |
+| 48  | Recurrent Neural Networks (RNNs)       | [Day_48_Recurrent_Neural_Networks](./Day_48_Recurrent_Neural_Networks/) |
+| 49  | Natural Language Processing (NLP)      | [Day_49_NLP](./Day_49_NLP/)                                           |
+| 50  | MLOps - Model Deployment               | [Day_50_MLOps](./Day_50_MLOps/)                                       |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- rewrite each table in the README so that every row is contained on a single line with consistent column counts
- ensure long link cells remain intact so the GitHub-rendered index is easy to read

## Testing
- python -m markdown README.md > /tmp/readme.html

------
https://chatgpt.com/codex/tasks/task_b_68d5972327808320b876f8f6156b820f