### PR TITLE
Update workflow push condition to use default branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: true
 
       - name: Commit & Push changes if any
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main')
+        if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- align the Commit & Push workflow step with the repository's default branch

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68da71e3fad4832db5cc57f214480835