### PR TITLE
Refactor Day 29 Plotly helpers and add coverage

### DIFF
--- a/Day_29_Interactive_Visualization/interactive_visualization.ipynb
+++ b/Day_29_Interactive_Visualization/interactive_visualization.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f411359d",
+   "metadata": {},
+   "source": [
+    "# Day 29 – Interactive Visualization Walkthrough\n",
+    "\n",
+    "This notebook demonstrates the refactored helper functions in `interactive_visualization.py`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6eda911a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from Day_29_Interactive_Visualization import interactive_visualization as iv\n",
+    "\n",
+    "df = iv.load_sales_data()\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0deb47d9",
+   "metadata": {},
+   "source": [
+    "## Revenue by Region"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99d555bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "region_bar = iv.build_region_revenue_bar(df)\n",
+    "region_bar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb0aafef",
+   "metadata": {},
+   "source": [
+    "## Daily Revenue Trend"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d6f96e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "daily_line = iv.build_daily_revenue_line(df)\n",
+    "daily_line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b186e93",
+   "metadata": {},
+   "source": [
+    "## Price vs. Units Sold"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "848b981a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scatter_fig = iv.build_price_units_scatter(df)\n",
+    "scatter_fig"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ source .venv/bin/activate  # On Windows use `.venv\\Scripts\\activate`
 pip install -r requirements.txt
 ```
 
-## 2. Day 28 resources
+## 2. Day 29 resources
 
-### Run the advanced visualization script
+### Run the interactive visualization script
 
 Execute the refactored script to load the bundled `sales_data.csv` file and open the figures:
 
 ```bash
-python Day_28_Advanced_Visualization/advanced_visualization.py
+python Day_29_Interactive_Visualization/interactive_visualization.py
 ```
 
 ### Explore the interactive notebook
@@ -27,7 +27,7 @@ python Day_28_Advanced_Visualization/advanced_visualization.py
 Launch Jupyter and open the new walkthrough notebook:
 
 ```bash
-jupyter notebook Day_28_Advanced_Visualization/advanced_visualization.ipynb
+jupyter notebook Day_29_Interactive_Visualization/interactive_visualization.ipynb
 ```
 
 ### Execute the automated tests
@@ -35,7 +35,7 @@ jupyter notebook Day_28_Advanced_Visualization/advanced_visualization.ipynb
 Pytest checks validate the figure construction helpers:
 
 ```bash
-pytest tests/test_day_28.py
+pytest tests/test_day_29.py
 ```
 
 ## 3. Repository layout

--- a/tests/test_day_29.py
+++ b/tests/test_day_29.py
@@ -1,0 +1,86 @@
+import os
+import sys
+
+import pandas as pd
+import plotly.graph_objects as go
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Day_29_Interactive_Visualization import interactive_visualization as iv
+
+
+@pytest.fixture()
+def sample_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Date": pd.to_datetime([
+                "2024-01-01",
+                "2024-01-01",
+                "2024-01-02",
+                "2024-01-03",
+            ]),
+            "Region": ["North", "South", "North", "West"],
+            "Revenue": [100.0, 80.0, 120.0, 90.0],
+            "Product": ["A", "B", "A", "C"],
+            "Price": [10.0, 12.0, 11.0, 13.0],
+            "Units Sold": [10, 7, 11, 8],
+        }
+    )
+
+
+def test_build_region_revenue_bar(sample_df: pd.DataFrame) -> None:
+    fig = iv.build_region_revenue_bar(sample_df)
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data) == sample_df["Region"].nunique()
+    categories = [trace.x[0] for trace in fig.data]
+    assert categories == sorted(sample_df["Region"].unique())
+    for trace in fig.data:
+        assert isinstance(trace, go.Bar)
+        assert trace.name == trace.x[0]
+        assert trace.y[0] == pytest.approx(
+            sample_df.loc[sample_df["Region"] == trace.name, "Revenue"].sum()
+        )
+
+
+def test_build_daily_revenue_line(sample_df: pd.DataFrame) -> None:
+    fig = iv.build_daily_revenue_line(sample_df)
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data) == 1
+    trace = fig.data[0]
+    assert isinstance(trace, go.Scatter)
+    assert trace.mode == "lines+markers"
+    expected_dates = list(pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"]).to_pydatetime())
+    assert list(trace.x) == expected_dates
+    assert list(trace.y) == [180.0, 120.0, 90.0]
+
+
+def test_build_price_units_scatter(sample_df: pd.DataFrame) -> None:
+    fig = iv.build_price_units_scatter(sample_df)
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data) == sample_df["Product"].nunique()
+    products = {trace.name for trace in fig.data}
+    assert products == set(sample_df["Product"].unique())
+    assert fig.layout.legend.title.text == "Product"
+    for trace in fig.data:
+        assert isinstance(trace, go.Scatter)
+        assert all(size > 0 for size in trace.marker.size)
+
+
+def test_missing_columns_raise(sample_df: pd.DataFrame) -> None:
+    with pytest.raises(ValueError):
+        iv.build_region_revenue_bar(sample_df.drop(columns=["Region"]))
+    with pytest.raises(ValueError):
+        iv.build_daily_revenue_line(sample_df.drop(columns=["Date"]))
+    with pytest.raises(ValueError):
+        iv.build_price_units_scatter(sample_df.drop(columns=["Product"]))
+
+
+def test_empty_dataframe_raise(sample_df: pd.DataFrame) -> None:
+    empty_df = sample_df.iloc[0:0]
+    with pytest.raises(ValueError):
+        iv.build_region_revenue_bar(empty_df)
+    with pytest.raises(ValueError):
+        iv.build_daily_revenue_line(empty_df)
+    with pytest.raises(ValueError):
+        iv.build_price_units_scatter(empty_df)


### PR DESCRIPTION
## Summary
- refactor the Day 29 interactive visualization script into reusable Plotly helper functions
- add a companion notebook and pytest coverage validating the new figure builders
- document how to run the script, open the notebook, and execute the new tests in the README

## Testing
- pytest tests/test_day_29.py

------
https://chatgpt.com/codex/tasks/task_b_68da7296dbb4832d9cd8118045fe7f4d