### PR TITLE
Refactor Day 30 scraper for injectable HTTP and add tests

### DIFF
--- a/Day_30_Web_Scraping/web_scraping.py
+++ b/Day_30_Web_Scraping/web_scraping.py
@@ -15,19 +15,26 @@ Author: 50 Days of Python Course
 Purpose: Educational example for MBA students
 """
 
+import time
+from typing import Any, Dict, Optional, Tuple
+
+import bs4
+import pandas as pd
 import requests
 from bs4 import BeautifulSoup
-import pandas as pd
-import bs4
-from typing import List, Optional, Dict, Any
-import time
 
 # The URL of the website we want to scrape
 # This site is specifically designed for scraping practice.
 URL = "http://books.toscrape.com/"
 
 
-def scrape_books(url: str) -> Optional[pd.DataFrame]:
+class ScrapingError(Exception):
+    """Custom exception for scraping errors."""
+
+
+def scrape_books(
+    url: str, session: Optional[requests.Session] = None
+) -> Tuple[pd.DataFrame, pd.DataFrame, Dict[str, Any]]:
     """
     Scrape book data from the given URL.
 
@@ -35,7 +42,8 @@ def scrape_books(url: str) -> Optional[pd.DataFrame]:
         url (str): The URL to scrape
 
     Returns:
-        Optional[pd.DataFrame]: DataFrame with book data or None if scraping fails
+        Tuple containing the raw scraped DataFrame, the cleaned DataFrame, and
+        a dictionary of summary statistics.
     """
     # --- 1. Download the HTML Content ---
     # Use requests.get() to download the page.
@@ -44,30 +52,25 @@ def scrape_books(url: str) -> Optional[pd.DataFrame]:
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
     }
 
+    session = session or requests.Session()
+
     try:
-        print(f"🌐 Connecting to {url}...")
-        response = requests.get(url, headers=headers, timeout=10)
-        # Raise an exception if the request was unsuccessful (e.g., 404 Not Found)
+        response = session.get(url, headers=headers, timeout=10)
         response.raise_for_status()
-        print(f"✅ Successfully downloaded the content from {url}")
     except requests.exceptions.Timeout:
-        print("❌ Request timed out. The server might be slow or unresponsive.")
-        return None
+        raise
     except requests.exceptions.ConnectionError:
-        print("❌ Connection error. Please check your internet connection.")
-        return None
-    except requests.exceptions.HTTPError as e:
-        print(f"❌ HTTP error occurred: {e}")
-        return None
-    except requests.exceptions.RequestException as e:
-        print(f"❌ Error downloading the page: {e}")
-        return None
+        raise
+    except requests.exceptions.HTTPError:
+        raise
+    except requests.exceptions.RequestException as exc:
+        raise ScrapingError("Error downloading the page") from exc
 
     # If we get here, the request was successful
-    return process_book_data(response)
+    return process_book_data(response.content)
 
 
-def process_book_data(response: requests.Response) -> Optional[pd.DataFrame]:
+def process_book_data(html_content: bytes) -> Tuple[pd.DataFrame, pd.DataFrame, Dict[str, Any]]:
     """
     Process the HTML response and extract book data.
 
@@ -75,125 +78,84 @@ def process_book_data(response: requests.Response) -> Optional[pd.DataFrame]:
         response: The HTTP response object
 
     Returns:
-        Optional[pd.DataFrame]: Processed book data or None if processing fails
+        Tuple containing the raw scraped DataFrame, the cleaned DataFrame, and
+        a dictionary of summary statistics.
     """
-    try:
-        # --- 2. Create a BeautifulSoup Object ---
-        # This object parses the HTML content and makes it searchable.
-        soup = BeautifulSoup(response.content, "html.parser")
+    # --- 2. Create a BeautifulSoup Object ---
+    # This object parses the HTML content and makes it searchable.
+    soup = BeautifulSoup(html_content, "html.parser")
 
-        # --- 3. Find and Extract Data ---
-        # We inspected the page and found that book information is within <article> tags with the class 'product_pod'
-        books = soup.find_all("article", class_="product_pod")
+    # --- 3. Find and Extract Data ---
+    # We inspected the page and found that book information is within <article> tags with the class 'product_pod'
+    books = soup.find_all("article", class_="product_pod")
 
-        if not books:
-            print(
-                "❌ No books found on the page. The website structure may have changed."
-            )
-            return None
+    if not books:
+        raise ValueError("No books found in the provided HTML content")
 
-        titles = []
-        prices = []
+    titles = []
+    prices = []
 
-        # Loop through each book found on the page
-        for book in books:
-            # Type check to ensure book is a Tag
-            if not isinstance(book, bs4.element.Tag):
-                continue
+    # Loop through each book found on the page
+    for book in books:
+        # Type check to ensure book is a Tag
+        if not isinstance(book, bs4.element.Tag):
+            continue
 
-            try:
-                # The title is in an 'a' tag within an 'h3' tag.
-                # We access the 'title' attribute of the 'a' tag.
-                h3_tag = book.find("h3")
-                if isinstance(h3_tag, bs4.element.Tag):
-                    a_tag = h3_tag.find("a")
-                    if isinstance(a_tag, bs4.element.Tag):
-                        title = a_tag.get("title")
-                        if title:
-                            titles.append(str(title))
-                        else:
-                            titles.append("N/A")
-                    else:
-                        titles.append("N/A")
-                else:
-                    titles.append("N/A")
-
-                # The price is in a 'p' tag with the class 'price_color'
-                price_tag = book.find("p", attrs={"class": "price_color"})
-                if isinstance(price_tag, bs4.element.Tag):
-                    price_text = price_tag.get_text(strip=True)
-                    prices.append(price_text)
-                else:
-                    prices.append("N/A")
-
-            except Exception as e:
-                print(f"⚠️  Error processing book: {e}")
-                titles.append("Error")
-                prices.append("Error")
-                continue
-
-        # --- 4. Structure the Data in a DataFrame ---
-        if titles and prices and len(titles) == len(prices):
-            book_data = pd.DataFrame({"Title": titles, "Price": prices})
-
-            print(f"\n📊 Successfully scraped {len(book_data)} books")
-            print("\n--- Scraped Book Data ---")
-            print(book_data.head(10))
-
-            # --- 5. Data Cleaning (Bonus) ---
-            # The price is scraped as a string with '£'. Let's clean it.
-            try:
-                # Filter out error entries before processing
-                clean_data = book_data[book_data["Price"] != "Error"].copy()
-
-                if not clean_data.empty:
-                    clean_data["Price_Float"] = (
-                        clean_data["Price"]
-                        .str.replace("£", "", regex=False)
-                        .astype(float)
-                    )
-
-                    print("\n--- DataFrame After Cleaning Price ---")
-                    print(clean_data.head(10))
-
-                    # --- 6. Basic Analysis ---
-                    print("\n📈 Basic Price Analysis:")
-                    print(f"   Average price: £{clean_data['Price_Float'].mean():.2f}")
-                    print(f"   Minimum price: £{clean_data['Price_Float'].min():.2f}")
-                    print(f"   Maximum price: £{clean_data['Price_Float'].max():.2f}")
-                    print(f"   Number of books: {len(clean_data)}")
-
-                    # Find most expensive and cheapest books
-                    most_expensive = clean_data.loc[clean_data["Price_Float"].idxmax()]
-                    cheapest = clean_data.loc[clean_data["Price_Float"].idxmin()]
-
-                    print(
-                        f"\n💰 Most expensive: '{most_expensive['Title']}' - {most_expensive['Price']}"
-                    )
-                    print(f"💸 Cheapest: '{cheapest['Title']}' - {cheapest['Price']}")
-
-                    return clean_data
-                else:
-                    print("⚠️  No valid price data found for analysis")
-                    return book_data
-
-            except Exception as e:
-                print(f"❌ Error during data cleaning: {e}")
-                print("Raw data will be displayed without price analysis")
-                return book_data
-
-        elif not titles or not prices:
-            print(
-                "❌ Could not find book titles or prices. The website structure may have changed."
-            )
-            return None
+        # The title is in an 'a' tag within an 'h3' tag.
+        # We access the 'title' attribute of the 'a' tag.
+        h3_tag = book.find("h3")
+        if isinstance(h3_tag, bs4.element.Tag):
+            a_tag = h3_tag.find("a")
+            if isinstance(a_tag, bs4.element.Tag):
+                title = a_tag.get("title")
+                titles.append(str(title) if title else "N/A")
+            else:
+                titles.append("N/A")
         else:
-            print(f"❌ Data mismatch: {len(titles)} titles vs {len(prices)} prices")
-            return None
+            titles.append("N/A")
 
-    except Exception as e:
-        print(f"❌ Error processing book data: {e}")
-        return None
+        # The price is in a 'p' tag with the class 'price_color'
+        price_tag = book.find("p", attrs={"class": "price_color"})
+        if isinstance(price_tag, bs4.element.Tag):
+            price_text = price_tag.get_text(strip=True)
+            prices.append(price_text)
+        else:
+            prices.append("N/A")
+
+    # --- 4. Structure the Data in a DataFrame ---
+    if not titles or not prices or len(titles) != len(prices):
+        raise ValueError("Mismatch between titles and prices in the HTML content")
+
+    book_data = pd.DataFrame({"Title": titles, "Price": prices})
+
+    # --- 5. Data Cleaning (Bonus) ---
+    clean_data = book_data.copy()
+    clean_data["Price_Float"] = pd.to_numeric(
+        clean_data["Price"].str.replace("£", "", regex=False), errors="coerce"
+    )
+    clean_data = clean_data.dropna(subset=["Price_Float"]).copy()
+
+    if clean_data.empty:
+        return book_data, clean_data, {}
+
+    # --- 6. Basic Analysis ---
+    price_series = clean_data["Price_Float"]
+    analysis: Dict[str, Any] = {
+        "average_price": float(price_series.mean()),
+        "min_price": float(price_series.min()),
+        "max_price": float(price_series.max()),
+        "count": int(len(clean_data)),
+    }
+
+    most_expensive = clean_data.loc[price_series.idxmax()]
+    cheapest = clean_data.loc[price_series.idxmin()]
+
+    analysis["most_expensive_title"] = most_expensive["Title"]
+    analysis["most_expensive_price"] = most_expensive["Price"]
+    analysis["cheapest_title"] = cheapest["Title"]
+    analysis["cheapest_price"] = cheapest["Price"]
+
+    return book_data, clean_data, analysis
 
 
 def main():
@@ -209,23 +171,61 @@ def main():
     time.sleep(1)
 
     # Execute the scraping
-    book_df = scrape_books(URL)
-
-    if book_df is not None:
-        print("\n🎉 Web scraping completed successfully!")
-        print(f"📊 Total books scraped: {len(book_df)}")
-        print("\n💡 Next steps you could take:")
-        print("   • Save data to CSV: book_df.to_csv('books.csv')")
-        print("   • Filter books by price range")
-        print("   • Scrape additional pages for more data")
-        print("   • Add more data fields (ratings, availability, etc.)")
-    else:
-        print("\n❌ Web scraping failed. Please check the error messages above.")
+    try:
+        print(f"🌐 Connecting to {URL}...")
+        raw_df, clean_df, analysis = scrape_books(URL)
+    except requests.exceptions.Timeout:
+        print("❌ Request timed out. The server might be slow or unresponsive.")
+        return
+    except requests.exceptions.ConnectionError:
+        print("❌ Connection error. Please check your internet connection.")
+        return
+    except requests.exceptions.HTTPError as exc:
+        print(f"❌ HTTP error occurred: {exc}")
+        return
+    except ScrapingError as exc:
+        print(f"❌ {exc}")
         print("💡 This could be due to:")
         print("   • Network connectivity issues")
         print("   • Website being temporarily unavailable")
         print("   • Blocked by website's anti-bot protection")
         print("   • URL has changed or is incorrect")
+        return
+    except ValueError as exc:
+        print(f"❌ {exc}")
+        print("💡 The website structure may have changed. Try updating the parser.")
+        return
+
+    print("✅ Successfully downloaded the content!")
+    print(f"📊 Total books scraped: {len(raw_df)}")
+
+    if clean_df.empty:
+        print("⚠️  No valid price data found for analysis.")
+        return
+
+    print("\n--- Sample of Scraped Book Data ---")
+    print(raw_df.head(10))
+
+    print("\n--- Cleaned Price Data ---")
+    print(clean_df.head(10))
+
+    print("\n📈 Basic Price Analysis:")
+    print(f"   Average price: £{analysis['average_price']:.2f}")
+    print(f"   Minimum price: £{analysis['min_price']:.2f}")
+    print(f"   Maximum price: £{analysis['max_price']:.2f}")
+    print(f"   Number of books: {analysis['count']}")
+    print(
+        f"💰 Most expensive: '{analysis['most_expensive_title']}' - {analysis['most_expensive_price']}"
+    )
+    print(
+        f"💸 Cheapest: '{analysis['cheapest_title']}' - {analysis['cheapest_price']}"
+    )
+
+    print("\n💡 Next steps you could take:")
+    print("   • Save data to CSV: clean_df.to_csv('books.csv', index=False)")
+    print("   • Filter books by price range")
+    print("   • Scrape additional pages for more data")
+    print("   • Add more data fields (ratings, availability, etc.)")
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -1,49 +1,57 @@
 # Coding for MBA
 
-A guided collection of Python, data, and machine learning exercises designed for business-minded learners. Each `Day_XX_*` folder contains short lessons, scripts, and notebooks that build on one another.
+A guided collection of Python, analytics, and machine learning exercises designed for business-minded learners. Each `Day_XX_*` folder contains focused lessons, scripts, or notebooks that build toward practical data fluency.
 
-## 1. Installation
+## Prerequisites
+
+- Python 3.10 or later
+- `pip` for installing Python packages
+- A virtual environment tool such as `venv` or `conda`
+- (Optional) Google Chrome or another modern browser for exploring visualizations
+
+To create a local environment:
 
 ```bash
 git clone https://github.com/your-username/Coding-For-MBA.git
 cd Coding-For-MBA
 python -m venv .venv
-source .venv/bin/activate  # On Windows use `.venv\\Scripts\\activate`
+source .venv/bin/activate  # On Windows use `.venv\Scripts\activate`
 pip install -r requirements.txt
 ```
 
-## 2. Day 29 resources
+## Run the Day 30 Web Scraper
 
-### Run the interactive visualization script
-
-Execute the refactored script to load the bundled `sales_data.csv` file and open the figures:
+The refreshed Day 30 script now separates HTTP access from HTML parsing, which makes it easier to test and extend. To execute the scraper:
 
 ```bash
-python Day_29_Interactive_Visualization/interactive_visualization.py
+python Day_30_Web_Scraping/web_scraping.py
 ```
 
-### Explore the interactive notebook
+The command-line interface reports connection status, shows a preview of the scraped data, and prints summary statistics generated from the cleaned price column.
 
-Launch Jupyter and open the new walkthrough notebook:
+## Practice Responsible Scraping
+
+The project uses the `books.toscrape.com` sandbox, but the same etiquette applies to production websites:
+
+- Read the site's terms of service and `robots.txt` before scraping.
+- Identify your requests with a User-Agent string and keep the frequency reasonable.
+- Add delays between requests when crawling multiple pages.
+- Avoid collecting personal or sensitive information without consent.
+
+## Run the Automated Tests
+
+Pytest now includes coverage for the Day 30 parser, using deterministic HTML fixtures to verify the DataFrame schema and summary statistics. Execute the full suite or focus on the new tests with:
 
 ```bash
-jupyter notebook Day_29_Interactive_Visualization/interactive_visualization.ipynb
+pytest tests/test_day_30.py
 ```
 
-### Execute the automated tests
+## Repository Layout
 
-Pytest checks validate the figure construction helpers:
-
-```bash
-pytest tests/test_day_29.py
-```
-
-## 3. Repository layout
-
-- `Day_01_Introduction` ... `Day_50_MLOps` – daily folders covering Python, analytics, and machine learning topics.
+- `Day_01_Introduction` … `Day_50_MLOps` – daily folders covering Python, analytics, and machine learning topics.
 - `tests/` – lightweight unit tests for selected lessons.
 - `requirements.txt` – Python dependencies used across the curriculum.
 
-## 4. Contributing
+## Contributing
 
 Issues and pull requests are welcome. Please include tests and documentation updates alongside code changes.

--- a/tests/test_day_30.py
+++ b/tests/test_day_30.py
@@ -1,0 +1,90 @@
+"""Tests for Day 30 web scraping utilities."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Day_30_Web_Scraping.web_scraping import process_book_data, scrape_books
+
+
+HTML_FIXTURE = (
+    """
+    <html>
+        <body>
+            <article class="product_pod">
+                <h3><a title="Book One"></a></h3>
+                <p class="price_color">£10.00</p>
+            </article>
+            <article class="product_pod">
+                <h3><a title="Book Two"></a></h3>
+                <p class="price_color">£12.50</p>
+            </article>
+            <article class="product_pod">
+                <h3><a title="Book Three"></a></h3>
+                <p class="price_color">£7.25</p>
+            </article>
+        </body>
+    </html>
+    """
+).strip().encode("utf-8")
+
+
+class DummyResponse:
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+
+    def raise_for_status(self) -> None:  # pragma: no cover - simple stub
+        return None
+
+
+class DummySession:
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+        self.called_with = None
+
+    def get(self, url, headers=None, timeout=None):  # pragma: no cover - simple stub
+        self.called_with = {
+            "url": url,
+            "headers": headers,
+            "timeout": timeout,
+        }
+        return DummyResponse(self.content)
+
+
+def test_process_book_data_returns_clean_dataframe_and_summary():
+    raw_df, clean_df, analysis = process_book_data(HTML_FIXTURE)
+
+    assert list(raw_df.columns) == ["Title", "Price"]
+    assert list(clean_df.columns) == ["Title", "Price", "Price_Float"]
+    assert clean_df["Price"].tolist() == ["£10.00", "£12.50", "£7.25"]
+    assert clean_df["Price_Float"].tolist() == [10.0, 12.5, 7.25]
+    assert clean_df["Price_Float"].dtype.kind == "f"
+
+    assert analysis["average_price"] == pytest.approx(9.9166, rel=1e-3)
+    assert analysis["min_price"] == pytest.approx(7.25)
+    assert analysis["max_price"] == pytest.approx(12.5)
+    assert analysis["count"] == 3
+    assert analysis["most_expensive_title"] == "Book Two"
+    assert analysis["most_expensive_price"] == "£12.50"
+    assert analysis["cheapest_title"] == "Book Three"
+    assert analysis["cheapest_price"] == "£7.25"
+
+
+def test_scrape_books_uses_injected_session():
+    session = DummySession(HTML_FIXTURE)
+    raw_df, clean_df, analysis = scrape_books("http://example.com", session=session)
+
+    assert session.called_with["url"] == "http://example.com"
+    assert session.called_with["timeout"] == 10
+    assert "User-Agent" in session.called_with["headers"]
+    assert len(raw_df) == 3
+    assert analysis["count"] == 3
+
+
+def test_process_book_data_with_no_books_raises_value_error():
+    empty_html = "<html><body></body></html>".encode("utf-8")
+    with pytest.raises(ValueError):
+        process_book_data(empty_html)


### PR DESCRIPTION
## Summary
- refactor the Day 30 scraper to inject a requests session and return parsed data plus summary statistics
- keep command-line messaging in main while exposing clean data processing helpers for reuse
- add deterministic unit tests and refresh the README with instructions, etiquette, and test guidance

## Testing
- pytest tests/test_day_30.py

------
https://chatgpt.com/codex/tasks/task_b_68da74bb5ce0832da0d32e892e3fe2bf