### PR TITLE
Refactor Day 31 database utilities and add tests

### DIFF
--- a/Day_31_Databases/__init__.py
+++ b/Day_31_Databases/__init__.py
@@ -1,0 +1,10 @@
+"""Day 31 database lesson package."""
+
+from .databases import (  # noqa: F401
+    EMPLOYEE_ROWS,
+    cleanup_employee_db,
+    fetch_department_dataframe,
+    fetch_department_salaries,
+    initialize_employee_db,
+)
+

--- a/README.md
+++ b/README.md
@@ -1,57 +1,48 @@
 # Coding for MBA
 
-A guided collection of Python, analytics, and machine learning exercises designed for business-minded learners. Each `Day_XX_*` folder contains focused lessons, scripts, or notebooks that build toward practical data fluency.
+## Overview
 
-## Prerequisites
+Coding for MBA is a curated set of fifty daily lessons that blend Python, data
+analysis, and introductory machine learning skills for business-minded
+learners. Each `Day_XX_*` directory contains self-contained scripts or
+notebooks that build progressively toward data fluency.
 
-- Python 3.10 or later
-- `pip` for installing Python packages
-- A virtual environment tool such as `venv` or `conda`
-- (Optional) Google Chrome or another modern browser for exploring visualizations
+## Environment Setup
 
-To create a local environment:
+Use the following steps to create a local development environment:
 
 ```bash
 git clone https://github.com/your-username/Coding-For-MBA.git
 cd Coding-For-MBA
 python -m venv .venv
-source .venv/bin/activate  # On Windows use `.venv\Scripts\activate`
+source .venv/bin/activate  # On Windows use `.venv\\Scripts\\activate`
 pip install -r requirements.txt
 ```
 
-## Run the Day 30 Web Scraper
+## Script Usage
 
-The refreshed Day 30 script now separates HTTP access from HTML parsing, which makes it easier to test and extend. To execute the scraper:
-
-```bash
-python Day_30_Web_Scraping/web_scraping.py
-```
-
-The command-line interface reports connection status, shows a preview of the scraped data, and prints summary statistics generated from the cleaned price column.
-
-## Practice Responsible Scraping
-
-The project uses the `books.toscrape.com` sandbox, but the same etiquette applies to production websites:
-
-- Read the site's terms of service and `robots.txt` before scraping.
-- Identify your requests with a User-Agent string and keep the frequency reasonable.
-- Add delays between requests when crawling multiple pages.
-- Avoid collecting personal or sensitive information without consent.
-
-## Run the Automated Tests
-
-Pytest now includes coverage for the Day 30 parser, using deterministic HTML fixtures to verify the DataFrame schema and summary statistics. Execute the full suite or focus on the new tests with:
+Every lesson can be executed individually. For example, Day 31 demonstrates how
+to build and query a SQLite database:
 
 ```bash
-pytest tests/test_day_30.py
+python Day_31_Databases/databases.py
 ```
 
-## Repository Layout
+The script creates a temporary `company_data.db` file, prints query results, and
+cleans up the database once it finishes.
 
-- `Day_01_Introduction` … `Day_50_MLOps` – daily folders covering Python, analytics, and machine learning topics.
-- `tests/` – lightweight unit tests for selected lessons.
-- `requirements.txt` – Python dependencies used across the curriculum.
+## Running Pytest
 
-## Contributing
+Automated tests cover selected lessons, including Day 31's database helpers.
+Run the full suite with:
 
-Issues and pull requests are welcome. Please include tests and documentation updates alongside code changes.
+```bash
+pytest
+```
+
+To focus on the Day 31 tests only, use:
+
+```bash
+pytest tests/test_day_31.py
+```
+

--- a/tests/test_day_31.py
+++ b/tests/test_day_31.py
@@ -1,0 +1,67 @@
+"""Tests for the Day 31 database utilities."""
+
+import os
+import sqlite3
+import sys
+
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Day_31_Databases.databases import (
+    EMPLOYEE_ROWS,
+    cleanup_employee_db,
+    fetch_department_dataframe,
+    fetch_department_salaries,
+    initialize_employee_db,
+)
+
+
+def test_initialize_employee_db_creates_table(tmp_path):
+    db_path = tmp_path / "company.db"
+
+    initialize_employee_db(db_path)
+
+    with sqlite3.connect(db_path) as connection:
+        table_exists = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='employees'"
+        ).fetchone()
+        assert table_exists is not None
+
+        (row_count,) = connection.execute("SELECT COUNT(*) FROM employees").fetchone()
+        assert row_count == len(EMPLOYEE_ROWS)
+
+
+def test_fetch_department_salaries_returns_sorted_results(tmp_path):
+    db_path = tmp_path / "company.db"
+    initialize_employee_db(db_path)
+
+    sales_salaries = fetch_department_salaries(db_path, "Sales")
+
+    assert sales_salaries == [("Alice", 80_000.0), ("Charlie", 85_000.0)]
+
+
+def test_fetch_department_dataframe_returns_dataframe(tmp_path):
+    db_path = tmp_path / "company.db"
+    initialize_employee_db(db_path)
+
+    engineering_df = fetch_department_dataframe(db_path, "Engineering")
+
+    assert list(engineering_df.columns) == [
+        "employee_id",
+        "name",
+        "department",
+        "salary",
+    ]
+    assert engineering_df["name"].tolist() == ["Bob", "Eve"]
+    assert pd.api.types.is_float_dtype(engineering_df["salary"])
+
+
+def test_cleanup_employee_db_removes_file(tmp_path):
+    db_path = tmp_path / "company.db"
+    initialize_employee_db(db_path)
+
+    assert db_path.exists()
+    cleanup_employee_db(db_path)
+    assert not db_path.exists()
+


### PR DESCRIPTION
## Summary
- refactor the Day 31 database lesson into reusable helpers for initialization and querying
- add a package initializer and pytest coverage that exercises table creation, queries, and cleanup using a temporary SQLite database
- refresh the README with standard environment setup, script usage, and pytest instructions

## Testing
- pytest tests/test_day_31.py

------
https://chatgpt.com/codex/tasks/task_b_68da783ef928832d9686d72f263cc3ce