### PR TITLE
Add Day 32 database helper module with dependency-injected patterns

### DIFF
--- a/Day_32_Other_Databases/other_databases.py
+++ b/Day_32_Other_Databases/other_databases.py
@@ -1,0 +1,150 @@
+"""Reusable helpers that demonstrate SQL and MongoDB connection patterns.
+
+The functions in this module deliberately receive their database clients as
+arguments so they can be easily tested without establishing real network
+connections.  The calling code is responsible for creating the client (or a
+stub implementation) and passing in the relevant credentials or connection
+configuration.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Optional, Sequence
+
+
+Credentials = Mapping[str, Any]
+ClientFactory = Callable[[Credentials], Any]
+
+
+def execute_sql_query(
+    client_factory: ClientFactory,
+    query: str,
+    *,
+    credentials: Credentials,
+    parameters: Optional[Sequence[Any]] = None,
+    commit: bool = False,
+) -> Sequence[Any]:
+    """Execute a SQL query using a dependency-injected client factory.
+
+    Parameters
+    ----------
+    client_factory:
+        Callable that accepts a credentials mapping and returns a DB-API style
+        connection object.  In production this could be ``mysql.connector.connect``
+        or ``psycopg2.connect``; in tests this can be a stub or mock.
+    query:
+        SQL string to execute.
+    credentials:
+        Mapping that contains the connection details (host, database, user,
+        password, etc.).
+    parameters:
+        Optional sequence of parameters to pass to ``cursor.execute``.
+    commit:
+        Whether to call ``commit`` on the connection after execution.  This is
+        useful for ``INSERT``/``UPDATE`` statements.
+
+    Returns
+    -------
+    Sequence[Any]
+        The rows returned by ``cursor.fetchall()``.  For statements that do not
+        return rows this will typically be an empty sequence.
+    """
+
+    connection = client_factory(credentials)
+    cursor = connection.cursor()
+    try:
+        if parameters is None:
+            cursor.execute(query)
+        else:
+            cursor.execute(query, parameters)
+
+        results = cursor.fetchall()
+
+        if commit and hasattr(connection, "commit"):
+            connection.commit()
+
+        return results
+    finally:
+        # Ensure resources are released even if ``execute`` raises an error.
+        if hasattr(cursor, "close"):
+            cursor.close()
+        if hasattr(connection, "close"):
+            connection.close()
+
+
+def upsert_sales_forecast(
+    client_factory: ClientFactory,
+    *,
+    credentials: Credentials,
+    forecast_rows: Iterable[Sequence[Any]],
+) -> None:
+    """Insert or update forecast data via an injected SQL client.
+
+    The function expects the ``forecast_rows`` iterable to contain tuples of the
+    form ``(region, forecast_month, revenue)``.  The specific SQL syntax is kept
+    intentionally generic so that the function remains database-agnostic.
+    """
+
+    merge_query = (
+        """
+        INSERT INTO sales_forecast (region, forecast_month, revenue)
+        VALUES (%s, %s, %s)
+        ON CONFLICT (region, forecast_month) DO UPDATE
+        SET revenue = EXCLUDED.revenue
+        """.strip()
+    )
+
+    connection = client_factory(credentials)
+    cursor = connection.cursor()
+    try:
+        for row in forecast_rows:
+            cursor.execute(merge_query, row)
+
+        if hasattr(connection, "commit"):
+            connection.commit()
+    finally:
+        if hasattr(cursor, "close"):
+            cursor.close()
+        if hasattr(connection, "close"):
+            connection.close()
+
+
+def find_documents(
+    mongo_client: MutableMapping[str, Any],
+    *,
+    database: str,
+    collection: str,
+    filter_query: Optional[Mapping[str, Any]] = None,
+    projection: Optional[Mapping[str, Any]] = None,
+) -> list[Any]:
+    """Query a MongoDB collection using an injected client object."""
+
+    filter_query = dict(filter_query or {})
+
+    db = mongo_client[database]
+    collection_handle = db[collection]
+
+    if projection is None:
+        cursor = collection_handle.find(filter_query)
+    else:
+        cursor = collection_handle.find(filter_query, projection)
+
+    return list(cursor)
+
+
+def insert_documents(
+    mongo_client: MutableMapping[str, Any],
+    *,
+    database: str,
+    collection: str,
+    documents: Sequence[Mapping[str, Any]],
+) -> Sequence[Any]:
+    """Insert multiple documents into a MongoDB collection."""
+
+    if not documents:
+        return []
+
+    db = mongo_client[database]
+    collection_handle = db[collection]
+    result = collection_handle.insert_many(list(documents))
+    return getattr(result, "inserted_ids", result)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Overview
 
-Coding for MBA is a curated set of fifty daily lessons that blend Python, data
-analysis, and introductory machine learning skills for business-minded
+Coding for MBA is a curated set of fifty daily lessons that blend Python,
+analytics, and introductory machine learning skills for business-minded
 learners. Each `Day_XX_*` directory contains self-contained scripts or
 notebooks that build progressively toward data fluency.
 
@@ -15,34 +15,51 @@ Use the following steps to create a local development environment:
 git clone https://github.com/your-username/Coding-For-MBA.git
 cd Coding-For-MBA
 python -m venv .venv
-source .venv/bin/activate  # On Windows use `.venv\\Scripts\\activate`
+source .venv/bin/activate  # On Windows use `.venv\Scripts\activate`
 pip install -r requirements.txt
 ```
 
-## Script Usage
+### Optional database extras
 
-Every lesson can be executed individually. For example, Day 31 demonstrates how
-to build and query a SQLite database:
+Some lessons showcase connectors that live in optional packages:
+
+- MySQL: `pip install mysql-connector-python`
+- PostgreSQL: `pip install psycopg2-binary`
+- MongoDB: `pip install pymongo`
+
+Installing these extras is only necessary if you want to run the examples
+against live services; the test suite uses mocks and runs without them.
+
+## Lesson scripts
+
+- [Day 31 – Relational Databases](Day_31_Databases/databases.py): builds and
+  queries a SQLite database, mirroring production-ready analysis workflows.
+- [Day 32 – Other Databases](Day_32_Other_Databases/other_databases.py):
+  demonstrates dependency-injected connection patterns for SQL and MongoDB
+  clients so that data access logic remains testable.
+
+Run a lesson directly with `python <path-to-script>`. For example, Day 31 can
+be executed via:
 
 ```bash
 python Day_31_Databases/databases.py
 ```
 
-The script creates a temporary `company_data.db` file, prints query results, and
-cleans up the database once it finishes.
-
 ## Running Pytest
 
-Automated tests cover selected lessons, including Day 31's database helpers.
-Run the full suite with:
+Automated tests cover key helpers from the curriculum. Execute the entire test
+suite with:
 
 ```bash
 pytest
 ```
 
-To focus on the Day 31 tests only, use:
+To focus on specific lessons:
 
 ```bash
 pytest tests/test_day_31.py
+pytest tests/test_day_32.py
 ```
 
+The Day 32 tests rely solely on the dependency-injected stubs so they can run
+without provisioning database services.

--- a/tests/test_day_32.py
+++ b/tests/test_day_32.py
@@ -1,0 +1,140 @@
+"""Unit tests for the Day 32 dependency-injected database helpers."""
+
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Day_32_Other_Databases.other_databases import (  # noqa: E402
+    execute_sql_query,
+    find_documents,
+    insert_documents,
+    upsert_sales_forecast,
+)
+
+
+def test_execute_sql_query_uses_client_factory_and_closes_resources():
+    credentials = {"host": "localhost", "user": "analyst"}
+    connection = mock.Mock()
+    cursor = connection.cursor.return_value
+    cursor.fetchall.return_value = [("North", 10)]
+    client_factory = mock.Mock(return_value=connection)
+
+    rows = execute_sql_query(
+        client_factory,
+        "SELECT * FROM sales WHERE region = %s",
+        credentials=credentials,
+        parameters=("North",),
+    )
+
+    assert rows == [("North", 10)]
+    client_factory.assert_called_once_with(credentials)
+    connection.cursor.assert_called_once()
+    cursor.execute.assert_called_once_with("SELECT * FROM sales WHERE region = %s", ("North",))
+    cursor.fetchall.assert_called_once()
+    cursor.close.assert_called_once()
+    connection.close.assert_called_once()
+    assert not connection.commit.called
+
+
+def test_execute_sql_query_commits_when_requested():
+    credentials = {"host": "localhost"}
+    connection = mock.Mock()
+    connection.cursor.return_value.fetchall.return_value = []
+    client_factory = mock.Mock(return_value=connection)
+
+    execute_sql_query(
+        client_factory,
+        "UPDATE sales SET revenue = revenue + 100",
+        credentials=credentials,
+        commit=True,
+    )
+
+    connection.commit.assert_called_once()
+
+
+def test_upsert_sales_forecast_executes_all_rows_and_commits():
+    credentials = {"host": "db.internal"}
+    connection = mock.Mock()
+    cursor = connection.cursor.return_value
+    client_factory = mock.Mock(return_value=connection)
+
+    forecast_rows = [
+        ("North", "2024-10", 125000),
+        ("South", "2024-10", 99000),
+    ]
+
+    upsert_sales_forecast(client_factory, credentials=credentials, forecast_rows=forecast_rows)
+
+    client_factory.assert_called_once_with(credentials)
+    assert cursor.execute.call_count == len(forecast_rows)
+    executed_queries = {call.args[1] for call in cursor.execute.call_args_list}
+    assert executed_queries == set(forecast_rows)
+    connection.commit.assert_called_once()
+    cursor.close.assert_called_once()
+    connection.close.assert_called_once()
+
+
+def test_find_documents_passes_filter_and_projection():
+    mongo_client = mock.MagicMock()
+    database = mongo_client.__getitem__.return_value
+    collection = database.__getitem__.return_value
+    expected_docs = [{"_id": 1, "region": "EMEA"}]
+    collection.find.return_value = iter(expected_docs)
+
+    docs = find_documents(
+        mongo_client,
+        database="analytics",
+        collection="sales",
+        filter_query={"region": "EMEA"},
+        projection={"_id": 1, "region": 1},
+    )
+
+    mongo_client.__getitem__.assert_called_once_with("analytics")
+    database.__getitem__.assert_called_once_with("sales")
+    collection.find.assert_called_once_with({"region": "EMEA"}, {"_id": 1, "region": 1})
+    assert docs == expected_docs
+
+
+def test_find_documents_defaults_to_empty_filter():
+    mongo_client = mock.MagicMock()
+    database = mongo_client.__getitem__.return_value
+    collection = database.__getitem__.return_value
+    collection.find.return_value = iter([{"region": "APAC"}])
+
+    docs = find_documents(mongo_client, database="analytics", collection="sales")
+
+    collection.find.assert_called_once_with({})
+    assert docs == [{"region": "APAC"}]
+
+
+def test_insert_documents_returns_inserted_ids_and_handles_empty_inputs():
+    mongo_client = mock.MagicMock()
+    database = mongo_client.__getitem__.return_value
+    collection = database.__getitem__.return_value
+    insert_result = mock.Mock(inserted_ids=[1, 2])
+    collection.insert_many.return_value = insert_result
+
+    inserted_ids = insert_documents(
+        mongo_client,
+        database="analytics",
+        collection="sales",
+        documents=[{"region": "North"}, {"region": "South"}],
+    )
+
+    mongo_client.__getitem__.assert_called_once_with("analytics")
+    database.__getitem__.assert_called_once_with("sales")
+    collection.insert_many.assert_called_once()
+    assert inserted_ids == [1, 2]
+
+    mongo_client_empty = mock.MagicMock()
+    result = insert_documents(
+        mongo_client_empty,
+        database="analytics",
+        collection="sales",
+        documents=[],
+    )
+
+    assert result == []
+    mongo_client_empty.__getitem__.assert_not_called()


### PR DESCRIPTION
## Summary
- add a reusable Day 32 helper module that demonstrates dependency-injected SQL and MongoDB patterns
- add unit tests that mock client interactions to verify credentials, method calls, and commits
- refresh the README with optional connector prerequisites and links to the new module and tests

## Testing
- pytest tests/test_day_32.py

------
https://chatgpt.com/codex/tasks/task_b_68da7af6e388832db1f9689eb7317d01