### PR TITLE
Add app factory and tests for Day 34 Flask API

### DIFF
--- a/Day_34_Building_an_API/README.md
+++ b/Day_34_Building_an_API/README.md
@@ -89,3 +89,34 @@ Now you can go to `/api/products/1` to get the laptop, or `/api/products/2` to g
     * If no employee with that ID is found, return a JSON error message with a 404 status code.
 
 🎉 **Incredible!** You've just learned how to build a web API. This is a massive step. It bridges the gap between performing analysis for yourself and providing data and services to others, forming the backbone of modern data applications and microservices.
+
+## Running the Development Server
+
+The lesson's reference implementation exposes a `create_app()` factory in `api_server.py`. You can start the local development server with:
+
+```bash
+export FLASK_APP=Day_34_Building_an_API.api_server:create_app
+flask run --debug
+```
+
+The `--debug` flag enables auto-reload and better error messages while you iterate on your API. Flask will serve the application on `http://127.0.0.1:5000/` by default.
+
+## Running the Tests
+
+Pytest is configured to exercise the API endpoints. From the repository root, run:
+
+```bash
+pytest tests/test_day_34.py
+```
+
+The tests use Flask's test client to verify that the root page and JSON endpoints respond with the expected payloads and HTTP status codes.
+
+## Why Use an Application Factory?
+
+The application factory pattern encapsulates all app configuration inside a function. This makes it easy to:
+
+- Create multiple instances of the app with different settings (e.g., testing versus production).
+- Avoid running application code at import time, which keeps tools like the Flask CLI and pytest fast.
+- Improve modularity by cleanly separating data configuration from route registration.
+
+Because `create_app()` returns a fully configured Flask instance, you can reuse it for development, testing, or even deployment without duplicating setup code.

--- a/Day_34_Building_an_API/__init__.py
+++ b/Day_34_Building_an_API/__init__.py
@@ -1,0 +1,5 @@
+"""Package initialization for Day 34 Flask API example."""
+
+from .api_server import create_app
+
+__all__ = ["create_app"]

--- a/Day_34_Building_an_API/api_server.py
+++ b/Day_34_Building_an_API/api_server.py
@@ -1,76 +1,53 @@
-"""
-Day 34: Building a Simple API with Flask
+"""Day 34: Building a Simple API with Flask.
 
-This script creates a simple web API that serves sample
+This module exposes a Flask application factory that serves sample
 business data in JSON format.
 """
 
 from flask import Flask, jsonify
 
-# 1. Create an instance of the Flask class
-# '__name__' is a special Python variable that gets the name of the current module.
-app = Flask(__name__)
+from Day_34_Building_an_API.data import EMPLOYEES, PRODUCTS
 
 
-# --- Sample Data ---
-# In a real application, this data would come from a database.
-PRODUCTS = [
-    {"id": 1, "name": "Laptop", "price": 1200, "category": "Electronics"},
-    {"id": 2, "name": "Mouse", "price": 25, "category": "Peripherals"},
-    {"id": 3, "name": "Keyboard", "price": 75, "category": "Peripherals"},
-]
+def create_app() -> Flask:
+    """Create and configure the Flask application for the sample API."""
+    app = Flask(__name__)
 
-EMPLOYEES = [
-    {"id": 101, "name": "Alice", "department": "Sales"},
-    {"id": 102, "name": "Bob", "department": "Engineering"},
-]
+    app.config["PRODUCTS"] = PRODUCTS
+    app.config["EMPLOYEES"] = EMPLOYEES
 
+    @app.route("/")
+    def home():
+        return (
+            "<h1>Welcome to the Company Data API</h1>"
+            "<p>Use endpoints like /api/v1/products to get data.</p>"
+        )
 
-# --- API Routes ---
+    @app.route("/api/v1/products", methods=["GET"])
+    def get_all_products():
+        """Return the full list of products as JSON."""
+        return jsonify(app.config["PRODUCTS"])
 
+    @app.route("/api/v1/products/<int:product_id>", methods=["GET"])
+    def get_single_product(product_id):
+        """Return a single product matching the given ID."""
+        products = app.config["PRODUCTS"]
+        product = next((p for p in products if p["id"] == product_id), None)
 
-# 2. Define a "route" for the home/root URL
-# This is the function that runs when someone visits the main page.
-@app.route("/")
-def home():
-    return "<h1>Welcome to the Company Data API</h1><p>Use endpoints like /api/products to get data.</p>"
-
-
-# Route to get all products
-@app.route("/api/v1/products", methods=["GET"])
-def get_all_products():
-    """Returns the full list of products as JSON."""
-    return jsonify(PRODUCTS)
-
-
-# Route to get a single product by its ID
-# The <int:product_id> part is a dynamic variable in the URL.
-@app.route("/api/v1/products/<int:product_id>", methods=["GET"])
-def get_single_product(product_id):
-    """Returns a single product matching the given ID."""
-    # Use a generator expression to find the product. Returns None if not found.
-    product = next((p for p in PRODUCTS if p["id"] == product_id), None)
-
-    if product:
-        return jsonify(product)
-    else:
-        # Return a standard 404 Not Found error if the ID doesn't exist
+        if product:
+            return jsonify(product)
         return jsonify({"error": "Product not found"}), 404
 
+    @app.route("/api/v1/employees", methods=["GET"])
+    def get_all_employees():
+        """Return the full list of employees as JSON."""
+        return jsonify(app.config["EMPLOYEES"])
 
-# Route to get all employees
-@app.route("/api/v1/employees", methods=["GET"])
-def get_all_employees():
-    """Returns the full list of employees as JSON."""
-    return jsonify(EMPLOYEES)
+    return app
 
 
-# 3. Run the app
-# The __name__ == '__main__' block ensures this code only runs when
-# you execute this script directly. It won't run if the script is imported
-# as a module into another script.
+app = create_app()
+
+
 if __name__ == "__main__":
-    # debug=True will auto-reload the server when you make changes.
-    # In a production environment, you would use a proper web server (like Gunicorn).
-    # Host '0.0.0.0' makes it accessible from other devices on the network.
     app.run(host="0.0.0.0", port=5000, debug=True)

--- a/Day_34_Building_an_API/data.py
+++ b/Day_34_Building_an_API/data.py
@@ -1,0 +1,12 @@
+"""Sample data used by the Day 34 Flask API."""
+
+PRODUCTS = [
+    {"id": 1, "name": "Laptop", "price": 1200, "category": "Electronics"},
+    {"id": 2, "name": "Mouse", "price": 25, "category": "Peripherals"},
+    {"id": 3, "name": "Keyboard", "price": 75, "category": "Peripherals"},
+]
+
+EMPLOYEES = [
+    {"id": 101, "name": "Alice", "department": "Sales"},
+    {"id": 102, "name": "Bob", "department": "Engineering"},
+]

--- a/tests/test_day_34.py
+++ b/tests/test_day_34.py
@@ -1,0 +1,50 @@
+"""Tests for the Day 34 Flask API example."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Day_34_Building_an_API.api_server import create_app  # noqa: E402
+from Day_34_Building_an_API.data import EMPLOYEES, PRODUCTS  # noqa: E402
+
+
+def _get_app_client():
+    app = create_app()
+    app.config.update(TESTING=True)
+    return app.test_client()
+
+
+def test_home_route():
+    client = _get_app_client()
+    response = client.get("/")
+    assert response.status_code == 200
+    assert b"Welcome to the Company Data API" in response.data
+
+
+def test_get_all_products():
+    client = _get_app_client()
+    response = client.get("/api/v1/products")
+    assert response.status_code == 200
+    assert response.get_json() == PRODUCTS
+
+
+def test_get_single_product():
+    client = _get_app_client()
+    response = client.get("/api/v1/products/1")
+    assert response.status_code == 200
+    assert response.get_json() == PRODUCTS[0]
+
+
+def test_get_single_product_not_found():
+    client = _get_app_client()
+    response = client.get("/api/v1/products/999")
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "Product not found"}
+
+
+def test_get_all_employees():
+    client = _get_app_client()
+    response = client.get("/api/v1/employees")
+    assert response.status_code == 200
+    assert response.get_json() == EMPLOYEES


### PR DESCRIPTION
## Summary
- refactor the Day 34 Flask example to expose a reusable create_app factory and pull sample data into a dedicated module
- expose the package for imports and document how to run the development server, tests, and the benefits of the app factory pattern
- add a pytest suite that exercises the home, product, and employee endpoints with the Flask test client

## Testing
- pytest tests/test_day_34.py

------
https://chatgpt.com/codex/tasks/task_b_68da7da9d970832d8e79e3cb945035ac