### PR TITLE
Add Day 37 recap helpers and documentation updates

### DIFF
--- a/Day_37_Conclusion/conclusion.py
+++ b/Day_37_Conclusion/conclusion.py
@@ -1,0 +1,111 @@
+"""Utility helpers for the Day 37 conclusion recap artifacts.
+
+The functions in this module return plain Python data structures so they can
+be easily unit tested or repurposed by downstream tooling. A small CLI is
+provided to render the recap in the terminal for quick reference.
+"""
+from __future__ import annotations
+
+from argparse import ArgumentParser, Namespace
+from typing import Iterable, List, Sequence
+
+
+def get_recap_checklist() -> List[str]:
+    """Return the high-level checklist summarising the program highlights."""
+
+    return [
+        "Review the Python foundations covered across the 50-day journey.",
+        "Revisit data analytics workflows, from cleaning through visualization.",
+        "Connect the dots between statistical thinking and business strategy.",
+        "Reflect on automation opportunities identified during the lessons.",
+    ]
+
+
+def get_next_steps() -> List[dict]:
+    """Return recommended actions after completing the curriculum."""
+
+    return [
+        {
+            "title": "Build a portfolio project",
+            "description": (
+                "Apply the analytics-to-insights pipeline on a business dataset "
+                "and document the impact for stakeholders."
+            ),
+        },
+        {
+            "title": "Deepen machine learning skills",
+            "description": (
+                "Experiment with supervised and unsupervised models using the "
+                "frameworks introduced in later lessons."
+            ),
+        },
+        {
+            "title": "Share knowledge with peers",
+            "description": (
+                "Host a lunch-and-learn or internal workshop to reinforce your "
+                "understanding and surface collaboration ideas."
+            ),
+        },
+    ]
+
+
+def _format_checklist(checklist: Sequence[str]) -> Iterable[str]:
+    for item in checklist:
+        yield f" - {item}"
+
+
+def _format_next_steps(next_steps: Sequence[dict]) -> Iterable[str]:
+    for index, step in enumerate(next_steps, start=1):
+        title = step.get("title", f"Step {index}")
+        description = step.get("description", "")
+        if description:
+            yield f"{index}. {title}: {description}"
+        else:
+            yield f"{index}. {title}"
+
+
+def build_parser() -> ArgumentParser:
+    parser = ArgumentParser(
+        description=(
+            "Render the Coding for MBA Day 37 recap including the core "
+            "checklist and suggested next steps."
+        )
+    )
+    parser.add_argument(
+        "--section",
+        choices=("checklist", "next-steps", "all"),
+        default="all",
+        help="Choose which recap section to display.",
+    )
+    return parser
+
+
+def _render(section: str) -> str:
+    if section == "checklist":
+        lines = ["Day 37 Recap Checklist:", *_format_checklist(get_recap_checklist())]
+    elif section == "next-steps":
+        lines = [
+            "Recommended Next Steps:",
+            *_format_next_steps(get_next_steps()),
+        ]
+    else:
+        lines = [
+            "Day 37 Recap Checklist:",
+            *_format_checklist(get_recap_checklist()),
+            "",
+            "Recommended Next Steps:",
+            *_format_next_steps(get_next_steps()),
+        ]
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Entry point for the command line interface."""
+
+    parser = build_parser()
+    args: Namespace = parser.parse_args(list(argv) if argv is not None else None)
+    print(_render(args.section))
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -1,65 +1,76 @@
 # Coding for MBA
 
-## Overview
+A 50-day applied Python and analytics curriculum designed for business
+professionals. Each `Day_XX_*` directory contains a self-contained lesson that
+walks through practical data skills, from programming fundamentals to
+introductory machine learning.
 
-Coding for MBA is a curated set of fifty daily lessons that blend Python,
-analytics, and introductory machine learning skills for business-minded
-learners. Each `Day_XX_*` directory contains self-contained scripts or
-notebooks that build progressively toward data fluency.
-
-## Environment Setup
-
-Use the following steps to create a local development environment:
+## 🚀 Quick start
 
 ```bash
 git clone https://github.com/your-username/Coding-For-MBA.git
 cd Coding-For-MBA
 python -m venv .venv
-source .venv/bin/activate  # On Windows use `.venv\Scripts\activate`
+source .venv/bin/activate  # On Windows use `.venv\\Scripts\\activate`
 pip install -r requirements.txt
 ```
 
-### Optional database extras
-
-Some lessons showcase connectors that live in optional packages:
+Optional extras for database-focused lessons:
 
 - MySQL: `pip install mysql-connector-python`
 - PostgreSQL: `pip install psycopg2-binary`
 - MongoDB: `pip install pymongo`
 
-Installing these extras is only necessary if you want to run the examples
-against live services; the test suite uses mocks and runs without them.
+## 📚 Navigating the lessons
 
-## Lesson scripts
-
-- [Day 31 – Relational Databases](Day_31_Databases/databases.py): builds and
-  queries a SQLite database, mirroring production-ready analysis workflows.
-- [Day 32 – Other Databases](Day_32_Other_Databases/other_databases.py):
-  demonstrates dependency-injected connection patterns for SQL and MongoDB
-  clients so that data access logic remains testable.
-
-Run a lesson directly with `python <path-to-script>`. For example, Day 31 can
-be executed via:
+Lessons are organised chronologically. Jump to any topic by running the
+corresponding script:
 
 ```bash
 python Day_31_Databases/databases.py
+python Day_34_Building_an_API/api_server.py
 ```
 
-## Running Pytest
+## 🧾 Day 37 recap CLI
 
-Automated tests cover key helpers from the curriculum. Execute the entire test
-suite with:
+Day 37 wraps up the journey with a recap script that generates reusable
+artifacts:
+
+- `get_recap_checklist()` summarises the core program outcomes.
+- `get_next_steps()` recommends actions to continue your learning.
+- The command-line interface renders either section or both.
+
+Run the recap from the project root:
+
+```bash
+python -m Day_37_Conclusion.conclusion
+# or specify a section
+python -m Day_37_Conclusion.conclusion --section next-steps
+```
+
+## ✅ Testing the curriculum
+
+Automated tests live under `tests/` and cover representative helpers from the
+lessons, including the Day 37 recap.
 
 ```bash
 pytest
 ```
 
-To focus on specific lessons:
+Run a single test module with:
 
 ```bash
-pytest tests/test_day_31.py
-pytest tests/test_day_32.py
+pytest tests/test_day_37.py
 ```
 
-The Day 32 tests rely solely on the dependency-injected stubs so they can run
-without provisioning database services.
+## 🗺️ Repository overview
+
+- `Day_01_Introduction` through `Day_50_MLOps`: daily lesson content.
+- `Day_37_Conclusion/conclusion.py`: recap data structures and CLI entry point.
+- `tests/`: unit tests for selected lessons.
+
+## 🙌 Contributing
+
+Have ideas to expand the business analytics focus? Open an issue or submit a
+pull request—we welcome community contributions that keep the curriculum
+practical and accessible.

--- a/tests/test_day_37.py
+++ b/tests/test_day_37.py
@@ -1,0 +1,67 @@
+"""Tests for the Day 37 recap helpers."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Day_37_Conclusion.conclusion import (  # noqa: E402
+    get_next_steps,
+    get_recap_checklist,
+    main,
+)
+
+
+def test_get_recap_checklist_returns_expected_items():
+    expected = [
+        "Review the Python foundations covered across the 50-day journey.",
+        "Revisit data analytics workflows, from cleaning through visualization.",
+        "Connect the dots between statistical thinking and business strategy.",
+        "Reflect on automation opportunities identified during the lessons.",
+    ]
+    checklist = get_recap_checklist()
+
+    assert isinstance(checklist, list)
+    assert checklist == expected
+
+
+def test_get_next_steps_returns_expected_actions():
+    expected = [
+        {
+            "title": "Build a portfolio project",
+            "description": (
+                "Apply the analytics-to-insights pipeline on a business dataset "
+                "and document the impact for stakeholders."
+            ),
+        },
+        {
+            "title": "Deepen machine learning skills",
+            "description": (
+                "Experiment with supervised and unsupervised models using the "
+                "frameworks introduced in later lessons."
+            ),
+        },
+        {
+            "title": "Share knowledge with peers",
+            "description": (
+                "Host a lunch-and-learn or internal workshop to reinforce your "
+                "understanding and surface collaboration ideas."
+            ),
+        },
+    ]
+    next_steps = get_next_steps()
+
+    assert isinstance(next_steps, list)
+    assert next_steps == expected
+
+
+def test_main_outputs_requested_section(capsys):
+    main(["--section", "checklist"])
+    captured = capsys.readouterr()
+    assert "Day 37 Recap Checklist:" in captured.out
+    assert "Recommended Next Steps" not in captured.out
+
+    main(["--section", "next-steps"])
+    captured = capsys.readouterr()
+    assert "Recommended Next Steps:" in captured.out
+    assert "Day 37 Recap Checklist" not in captured.out


### PR DESCRIPTION
## Summary
- add a Day 37 conclusion module that exposes recap data structures and a CLI renderer
- create unit tests that verify the recap checklist, next steps, and CLI output
- refresh the README to follow the updated template and document the recap script and tests

## Testing
- pytest tests/test_day_37.py

------
https://chatgpt.com/codex/tasks/task_b_68da80b44064832db040b793032d849b