### PR TITLE
Refactor Day 49 NLP utilities and add tests

### DIFF
--- a/Day_49_NLP/README.md
+++ b/Day_49_NLP/README.md
@@ -1,41 +1,35 @@
 # Day 49: Natural Language Processing (NLP)
 
-Welcome to Day 49! Today, we focus on **Natural Language Processing (NLP)**, a field of AI that enables computers to understand, interpret, and generate human language. We will cover some fundamental concepts and techniques for turning text into numerical data that machine learning models can process.
+## Overview
 
-## Key Concepts
+Day 49 introduces the classic feature-extraction techniques that turn raw
+text into numeric matrices. Bag-of-words counts and TF-IDF scores are the
+foundations for many traditional NLP pipelines and remain useful for quick
+baselines or lightweight models.
 
-### What is NLP?
-NLP is all about the interaction between computers and human language. It involves tasks like sentiment analysis (which we saw with RNNs), language translation, text summarization, and question answering. A key challenge in NLP is converting unstructured text data into a structured numerical format.
+## What's in this folder?
 
-### 1. Text Preprocessing
-Before feeding text to a model, it needs to be cleaned and standardized. Common steps include:
--   **Tokenization:** Breaking down text into individual words or subwords (tokens).
--   **Lowercasing:** Converting all text to lowercase.
--   **Stop Word Removal:** Removing common words (like "the", "is", "a") that don't carry much meaning.
--   **Stemming/Lemmatization:** Reducing words to their root form (e.g., "running" -> "run").
+* `solutions.py` – exposes `build_count_matrix` and `build_tfidf_matrix`
+  helper functions plus a small demo script that prints both
+  representations for a sample corpus.
 
-### 2. Text Vectorization
-This is the process of converting text tokens into numerical vectors.
+## Running the lesson script
 
--   **Bag-of-Words (BoW):** Represents text by the frequency of words it contains. It ignores grammar and word order.
-    -   **CountVectorizer:** A simple BoW approach that counts the occurrences of each word.
+Ensure the lesson dependencies are installed (in particular
+`scikit-learn`, `pandas`, and `numpy`). Then execute the walkthrough:
 
--   **TF-IDF (Term Frequency-Inverse Document Frequency):** An improvement over BoW. It weighs words not only by their frequency in a document but also by how rare they are across all documents in the corpus. This gives higher importance to words that are more specific to a document.
-    -   **Term Frequency (TF):** `(Number of times term appears in a document) / (Total number of terms in the document)`
-    -   **Inverse Document Frequency (IDF):** `log(Total number of documents / Number of documents with term)`
-    -   **TF-IDF Score:** `TF * IDF`
+```bash
+python Day_49_NLP/solutions.py
+```
 
--   **Word Embeddings (like Word2Vec, GloVe):** Dense vector representations of words where similar words have similar vector representations. We saw this in action with the `Embedding` layer in the previous lesson. These are powerful because they capture semantic relationships between words.
+## Running the tests
 
----
+The automated checks validate the helper functions against a miniature
+corpus. Run them with:
 
-## Practice Exercise
+```bash
+pytest tests/test_day_49.py
+```
 
--   The `solutions.py` file demonstrates how to use `scikit-learn` to perform basic text vectorization.
--   The code covers:
-    1.  Creating a small corpus of text documents.
-    2.  Using `CountVectorizer` to create a Bag-of-Words representation of the text.
-    3.  Using `TfidfVectorizer` to create a TF-IDF representation.
-    4.  Showing the resulting document-term matrices and feature names (the vocabulary).
-
-Review the code to understand these fundamental techniques for converting text into a machine-readable format.
+All tests expect to be run from the repository root so that imports
+resolve correctly.

--- a/Day_49_NLP/solutions.py
+++ b/Day_49_NLP/solutions.py
@@ -1,64 +1,58 @@
+"""Utility functions and a demo for bag-of-words and TF-IDF vectorization."""
+
 import pandas as pd
 from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
 
-# --- NLP Text Vectorization Example ---
 
-# 1. Sample Corpus
-# A corpus is a collection of text documents.
-corpus = [
-    "The quick brown fox jumped over the lazy dog.",
-    "The dog was not lazy.",
-    "The fox is quick."
-]
+def build_count_matrix(corpus):
+    """Return a document-term matrix of raw counts for the given corpus."""
 
-print("--- NLP Vectorization Demo ---")
-print("Sample Corpus:")
-for doc in corpus:
-    print(f"- '{doc}'")
-print("-" * 30)
+    vectorizer = CountVectorizer()
+    matrix = vectorizer.fit_transform(corpus)
+    return pd.DataFrame(matrix.toarray(), columns=vectorizer.get_feature_names_out())
 
 
-# --- Method 1: Bag-of-Words with CountVectorizer ---
-print("\n--- 1. Bag-of-Words (CountVectorizer) ---")
-# Create an instance of CountVectorizer
-# It automatically handles tokenization and lowercasing.
-count_vectorizer = CountVectorizer()
+def build_tfidf_matrix(corpus):
+    """Return a document-term matrix of TF-IDF scores for the given corpus."""
 
-# Fit the vectorizer to the corpus and transform the corpus into a document-term matrix
-X_count = count_vectorizer.fit_transform(corpus)
-
-# The vocabulary (the set of unique words)
-print("Vocabulary (Feature Names):")
-print(count_vectorizer.get_feature_names_out())
-
-# The resulting document-term matrix (in a dense format for readability)
-# Each row is a document, each column is a word in the vocabulary.
-# The values are the word counts.
-df_count = pd.DataFrame(X_count.toarray(), columns=count_vectorizer.get_feature_names_out())
-print("\nDocument-Term Matrix (Counts):")
-print(df_count)
-print("This matrix shows the count of each word in each document.")
-print("-" * 30)
+    vectorizer = TfidfVectorizer()
+    matrix = vectorizer.fit_transform(corpus)
+    return pd.DataFrame(matrix.toarray(), columns=vectorizer.get_feature_names_out())
 
 
-# --- Method 2: TF-IDF with TfidfVectorizer ---
-print("\n--- 2. TF-IDF (TfidfVectorizer) ---")
-# Create an instance of TfidfVectorizer
-# It also handles tokenization and lowercasing.
-tfidf_vectorizer = TfidfVectorizer()
+def demo():
+    """Print a walkthrough of bag-of-words and TF-IDF representations."""
 
-# Fit and transform the corpus
-X_tfidf = tfidf_vectorizer.fit_transform(corpus)
+    corpus = [
+        "The quick brown fox jumped over the lazy dog.",
+        "The dog was not lazy.",
+        "The fox is quick."
+    ]
 
-# The vocabulary is the same as before
-print("Vocabulary (Feature Names):")
-print(tfidf_vectorizer.get_feature_names_out())
+    print("--- NLP Vectorization Demo ---")
+    print("Sample Corpus:")
+    for doc in corpus:
+        print(f"- '{doc}'")
+    print("-" * 30)
 
-# The resulting TF-IDF matrix
-# The values are the TF-IDF scores, not raw counts.
-# Notice how common words like 'the' have lower scores than more specific words.
-df_tfidf = pd.DataFrame(X_tfidf.toarray(), columns=tfidf_vectorizer.get_feature_names_out())
-print("\nTF-IDF Matrix:")
-print(df_tfidf.round(2)) # Round for better readability
-print("This matrix shows the TF-IDF score for each word, highlighting important words.")
-print("-" * 30)
+    print("\n--- 1. Bag-of-Words (CountVectorizer) ---")
+    df_count = build_count_matrix(corpus)
+    print("Vocabulary (Feature Names):")
+    print(df_count.columns.to_list())
+    print("\nDocument-Term Matrix (Counts):")
+    print(df_count)
+    print("This matrix shows the count of each word in each document.")
+    print("-" * 30)
+
+    print("\n--- 2. TF-IDF (TfidfVectorizer) ---")
+    df_tfidf = build_tfidf_matrix(corpus)
+    print("Vocabulary (Feature Names):")
+    print(df_tfidf.columns.to_list())
+    print("\nTF-IDF Matrix:")
+    print(df_tfidf.round(2))
+    print("This matrix shows the TF-IDF score for each word, highlighting important words.")
+    print("-" * 30)
+
+
+if __name__ == "__main__":
+    demo()

--- a/tests/test_day_49.py
+++ b/tests/test_day_49.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Day_49_NLP.solutions import build_count_matrix, build_tfidf_matrix
+
+
+def test_build_count_matrix_vocab_and_counts():
+    corpus = [
+        "Apple banana apple",
+        "Banana carrot"
+    ]
+
+    df = build_count_matrix(corpus)
+
+    assert list(df.columns) == ["apple", "banana", "carrot"]
+    assert df.shape == (2, 3)
+
+    expected = np.array(
+        [
+            [2, 1, 0],
+            [0, 1, 1]
+        ]
+    )
+    np.testing.assert_array_equal(df.to_numpy(), expected)
+
+
+def test_build_tfidf_matrix_vocab_shape_and_values():
+    corpus = [
+        "Cat sat",
+        "Cat sat sat"
+    ]
+
+    df = build_tfidf_matrix(corpus)
+
+    assert list(df.columns) == ["cat", "sat"]
+    assert df.shape == (2, 2)
+
+    expected = np.array(
+        [
+            [0.70710678, 0.70710678],
+            [0.4472136, 0.89442719]
+        ]
+    )
+    np.testing.assert_allclose(df.to_numpy(), expected, rtol=1e-5, atol=1e-8)


### PR DESCRIPTION
## Summary
- refactor the Day 49 NLP lesson into reusable helpers for bag-of-words and TF-IDF matrices
- refresh the lesson README with quick-start instructions for the script and tests
- add automated coverage that verifies the vocabulary and matrix outputs for both vectorizers

## Testing
- pytest tests/test_day_49.py

------
https://chatgpt.com/codex/tasks/task_b_68da80baec0c832d96486eb435f53f58