### PR TITLE
Refactor Day 36 case study helpers and add tests

### DIFF
--- a/Day_36_Case_Study/README.md
+++ b/Day_36_Case_Study/README.md
@@ -1,52 +1,43 @@
-# 📘 Day 36: Capstone Case Study - Tying It All Together
+# 📊 Day 36 – Capstone Case Study
 
-Congratulations on making it to Day 36 of the 50-day Python for Business Analytics journey! You've explored foundational Python, powerful data tools, and even built lightweight applications. Now it's time to combine everything you've learned—from data cleaning and manipulation with Pandas to statistical analysis and visualization—to solve a realistic business problem from start to finish.
+## Overview
 
-## The Business Problem
+Day 36 ties together the full analytics workflow. You will load the
+`case_study_sales.csv` dataset, clean it, surface core revenue insights, and
+present a concise set of recommendations. The helpers in this folder mirror the
+solution structure so that you can focus on translating business questions into
+Python code.
 
-You are a business analyst at a mid-sized e-commerce company. The Head of Sales wants to understand the performance of different products, regions, customer segments, and sales channels for the last several months. They have provided you with a dataset of sales transactions (now including `Customer Segment`, `Sales Channel`, and a pre-calculated `Revenue` column) and have asked you to answer the following key questions:
+## Files
 
-1. Which were the top 5 products by total revenue?
-2. Which sales region generated the most revenue?
-3. Which customer segments and sales channels are driving the most revenue?
-4. Is there a correlation between the price of a product and the number of units sold?
-5. How did revenue trend over the recent months?
-6. What are your key recommendations based on this analysis?
+| File | Description |
+| --- | --- |
+| [`case_study.py`](case_study.py) | Student-facing template containing callable helpers and a minimal `main()` driver you can customize. |
+| [`case_study_sales.csv`](case_study_sales.csv) | Sales dataset that powers the analysis. |
+| [`solutions.py`](solutions.py) | Fully worked reference solution with detailed walkthrough code. |
 
-## Your Task: The Analysis Workflow
+## Suggested Workflow
 
-Your task is to perform a complete analysis by following the standard data analysis workflow. The `case_study_sales.csv` file is provided for this exercise.
+1. Use `load_case_study_data()` to import the CSV with parsed dates.
+2. Call `clean_case_study_data()` to enforce schema expectations and rebuild the
+   `Revenue` column when necessary.
+3. Explore metrics via `summarize_case_study()` or write your own aggregations
+   and visualizations.
+4. Capture narrative takeaways for the Head of Sales along with supporting
+   charts or tables.
 
-### Step 1: Load and Inspect the Data
+Running the script directly executes the helper pipeline and prints the top-line
+revenue summaries:
 
-* Load the `case_study_sales.csv` into a Pandas DataFrame.
-* Use `.head()`, `.info()`, and `.isnull().sum()` to get a first look at the data and identify any immediate issues (like missing values or unexpected data types).
+```bash
+python Day_36_Case_Study/case_study.py
+```
 
-### Step 2: Clean the Data
+## Tests
 
-* Handle any missing values. For this dataset, you can drop rows with missing data.
-* Ensure all columns have the correct data type (e.g., 'Date' should be datetime, 'Price' should be a float, and `Revenue` should be numeric).
+Automated tests validate the helpers against the bundled dataset. From the
+repository root run:
 
-### Step 3: Exploratory Data Analysis (EDA) & Answering Key Questions
-
-* **Top Products:** Group the data by 'Product' and calculate the sum of 'Revenue' for each. Sort the results to find the top 5.
-* **Top Region:** Group the data by 'Region' and calculate the sum of 'Revenue' for each.
-* **Customer Segments & Channels:** Group the data by `Customer Segment` and `Sales Channel` to understand which audiences and distribution paths drive revenue.
-* **Correlation:** Calculate the correlation between the 'Price' and 'Units Sold' columns.
-* **Time-Series Analysis:** Resample or group the data by month using the `Date` column and calculate the sum of 'Revenue' to see the trend over time.
-
-### Step 4: Visualize Your Findings
-
-* Create a **bar chart** showing the top 5 products by revenue.
-* Create a **pie chart** or **bar chart** showing the revenue contribution of each region.
-* Create a **bar chart** highlighting revenue by customer segment or sales channel.
-* Create a **line chart** showing the monthly revenue trend over the covered period.
-
-### Step 5: Write Your Summary
-
-* Based on your analysis and visualizations, write a brief, non-technical summary of your findings.
-* What are 1-2 actionable recommendations you would give to the Head of Sales? (e.g., "Focus marketing efforts on our top products," or "Investigate why the West region is underperforming.")
-
-A complete, end-to-end solution is provided in the `solutions.py` file for this lesson. Try to complete the case study on your own first!
-
-🎉 **Incredible Achievement!** Completing a case study like this means you have a solid, practical foundation in data analysis. You can now take a raw dataset, clean it, analyze it, visualize it, and extract actionable business insights. This milestone sets you up perfectly for Day 37, where we'll reflect on the full 50-day program and map out your next steps.
+```bash
+pytest tests/test_day_36.py
+```

--- a/Day_36_Case_Study/case_study.py
+++ b/Day_36_Case_Study/case_study.py
@@ -1,24 +1,101 @@
-"""
-Day 36: Capstone Case Study
+"""Utility helpers for the Day 36 capstone case study."""
 
-This is the main script file for the Day 36 case study.
-Students should write their code here to solve the business problem.
+from __future__ import annotations
 
-The steps are:
-1. Load the data from 'case_study_sales.csv'.
-2. Clean the data.
-3. Perform exploratory data analysis (EDA).
-4. Create visualizations.
-5. Summarize findings.
-
-A complete solution can be found in the 'solutions.py' file.
-"""
+from pathlib import Path
+from typing import Any, Dict
 
 import pandas as pd
-import seaborn as sns
-import matplotlib.pyplot as plt
 
-print("Day 25 Case Study - Main Script")
-print("Follow the steps in the README.md to complete your analysis.")
+DATA_PATH = Path(__file__).with_name("case_study_sales.csv")
 
-# You can start your code here...
+
+def load_case_study_data(path: str | Path = DATA_PATH) -> pd.DataFrame:
+    """Return the raw sales data as a :class:`~pandas.DataFrame`.
+
+    Parameters
+    ----------
+    path:
+        Location of the ``case_study_sales.csv`` file. Defaults to the copy that
+        ships with the repository.
+    """
+
+    return pd.read_csv(path, parse_dates=["Date"])
+
+
+def clean_case_study_data(data: pd.DataFrame) -> pd.DataFrame:
+    """Clean the raw case-study data for downstream analysis.
+
+    The helper performs a light-touch cleanup that mirrors the steps students
+    complete in the lesson notebook:
+
+    * ensure the ``Date`` column uses ``datetime64`` values,
+    * coerce numeric fields to numbers while dropping unparseable records,
+    * calculate ``Revenue`` from ``Price`` and ``Units Sold`` when it is
+      missing.
+    """
+
+    cleaned = data.copy()
+
+    cleaned["Date"] = pd.to_datetime(cleaned["Date"], errors="coerce")
+
+    numeric_columns = ["Price", "Units Sold"]
+    has_revenue = "Revenue" in cleaned.columns
+    if has_revenue:
+        numeric_columns.append("Revenue")
+
+    for column in numeric_columns:
+        cleaned[column] = pd.to_numeric(cleaned[column], errors="coerce")
+
+    cleaned = cleaned.dropna(subset=["Date", "Price", "Units Sold"])
+
+    if not has_revenue:
+        cleaned["Revenue"] = cleaned["Price"] * cleaned["Units Sold"]
+    else:
+        missing_revenue = cleaned["Revenue"].isna()
+        if missing_revenue.any():
+            cleaned.loc[missing_revenue, "Revenue"] = (
+                cleaned.loc[missing_revenue, "Price"]
+                * cleaned.loc[missing_revenue, "Units Sold"]
+            )
+
+    cleaned["Units Sold"] = cleaned["Units Sold"].round().astype("Int64")
+    cleaned["Revenue"] = cleaned["Revenue"].astype(float)
+
+    return cleaned.reset_index(drop=True)
+
+
+def summarize_case_study(data: pd.DataFrame, *, top_n: int = 5) -> Dict[str, Any]:
+    """Generate headline metrics for the capstone analysis."""
+
+    if data.empty:
+        raise ValueError("Cannot summarize an empty DataFrame.")
+
+    summary: Dict[str, Any] = {
+        "top_products": data.groupby("Product")["Revenue"].sum().sort_values(ascending=False).head(top_n),
+        "region_revenue": data.groupby("Region")["Revenue"].sum().sort_values(ascending=False),
+        "segment_revenue": data.groupby("Customer Segment")["Revenue"].sum().sort_values(ascending=False),
+        "channel_revenue": data.groupby("Sales Channel")["Revenue"].sum().sort_values(ascending=False),
+        "price_units_correlation": data[["Price", "Units Sold"]].corr().loc["Price", "Units Sold"],
+        "monthly_revenue": data.set_index("Date")["Revenue"].resample("M").sum(),
+    }
+
+    return summary
+
+
+def main() -> None:
+    """Run a minimal command-line summary for the case study."""
+
+    raw = load_case_study_data()
+    cleaned = clean_case_study_data(raw)
+    summary = summarize_case_study(cleaned)
+
+    print("Top products by revenue:")
+    print(summary["top_products"])
+    print("\nRevenue by region:")
+    print(summary["region_revenue"])
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_day_36.py
+++ b/tests/test_day_36.py
@@ -1,0 +1,54 @@
+"""Tests for the Day 36 case study helpers."""
+
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Day_36_Case_Study.case_study import (  # noqa: E402
+    clean_case_study_data,
+    load_case_study_data,
+    summarize_case_study,
+)
+
+
+def _load_cleaned_frame() -> pd.DataFrame:
+    raw = load_case_study_data()
+    return clean_case_study_data(raw)
+
+
+def test_clean_case_study_data_types():
+    cleaned = _load_cleaned_frame()
+
+    assert pd.api.types.is_datetime64_ns_dtype(cleaned["Date"])
+    assert pd.api.types.is_float_dtype(cleaned["Price"])
+    assert pd.api.types.is_integer_dtype(cleaned["Units Sold"])
+    assert pd.api.types.is_float_dtype(cleaned["Revenue"])
+
+
+def test_summarize_case_study_outputs():
+    cleaned = _load_cleaned_frame()
+    summary = summarize_case_study(cleaned)
+
+    expected_top_products = [
+        "Laptop",
+        "Smartphone",
+        "Tablet",
+        "Gaming Console",
+        "Monitor",
+    ]
+
+    assert summary["top_products"].index.tolist() == expected_top_products
+    assert summary["top_products"].iloc[0] == pytest.approx(158_830.0)
+
+    assert summary["region_revenue"].idxmax() == "North"
+    assert summary["region_revenue"].loc["North"] == pytest.approx(98_100.0)
+
+    assert summary["price_units_correlation"] == pytest.approx(-0.6828263212)
+
+    monthly_revenue = summary["monthly_revenue"]
+    january = pd.Timestamp("2024-01-31")
+    assert monthly_revenue.loc[january] == pytest.approx(33_500.0)


### PR DESCRIPTION
## Summary
- replace the Day 36 case study script with reusable helpers and a thin CLI entry point
- rewrite the lesson README to describe the helper workflow and link to the template and solution
- add pytest coverage that validates data cleaning types and summary metrics against the bundled dataset

## Testing
- pytest tests/test_day_36.py

------
https://chatgpt.com/codex/tasks/task_b_68da80ac6680832d874f11e58a01d68d