### PR TITLE
Refactor Day 44-45 lessons into reusable utilities and add tests

### DIFF
--- a/Day_44_Unsupervised_Learning/README.md
+++ b/Day_44_Unsupervised_Learning/README.md
@@ -1,48 +1,52 @@
 # Day 44: Unsupervised Learning
 
-Welcome to Day 44! Today, we shift our focus to **Unsupervised Learning**, where we work with unlabeled data to discover hidden patterns and structures. We'll explore two fundamental techniques: **K-Means Clustering** for grouping data and **Principal Component Analysis (PCA)** for dimensionality reduction.
+## Overview
 
-> **Prerequisites:** Install scikit-learn with `pip install scikit-learn` to experiment with the clustering and PCA demos. Need a `pip` refresher? Revisit the Day 20 Python Package Manager lesson.
+Day 44 introduces two foundational unsupervised learning workflows:
 
-## Key Concepts
+- **K-Means clustering** groups unlabeled observations into clusters using
+  distance to learned centroids.
+- **Principal Component Analysis (PCA)** compresses high-dimensional data
+  into a smaller number of orthogonal components for easier visualization
+  and downstream modeling.
 
-### What is Unsupervised Learning?
-In unsupervised learning, the algorithm is given a dataset without explicit labels and must find patterns or relationships on its own. The goal is not to predict an output but to understand the data's underlying structure.
+Install scikit-learn before running the examples:
 
-### 1. K-Means Clustering
-K-Means is an algorithm that groups a dataset into a pre-specified number of clusters (`k`). It aims to partition the data points into `k` clusters in which each data point belongs to the cluster with the nearest mean (cluster centroid).
+```bash
+pip install scikit-learn
+```
 
-- **How it works:**
-  1.  **Initialize:** Randomly select `k` initial centroids from the data.
-  2.  **Assign:** Assign each data point to the closest centroid.
-  3.  **Update:** Recalculate the centroids as the mean of all data points assigned to that cluster.
-  4.  **Repeat:** Repeat the assignment and update steps until the centroids no longer change significantly.
-- **Use Case:** Customer segmentation, document clustering, image compression.
+## What's inside
 
-### 2. Principal Component Analysis (PCA)
-PCA is a dimensionality reduction technique used to reduce the number of features in a dataset while preserving as much of the original information (variance) as possible.
+- `solutions.py` – reusable functions for generating blob data, fitting
+  K-Means, and projecting datasets with PCA. Executing the file still
+  creates the original visualisations.
+- `README.md` – lesson summary (this document).
 
-- **How it works:**
-  - PCA identifies new, uncorrelated variables called **principal components**. These components are linear combinations of the original features.
-  - The first principal component accounts for the largest possible variance in the data, the second component accounts for the second largest, and so on.
-  - By keeping only the first few principal components, we can reduce the dimensionality of the data with minimal loss of information.
-- **Use Case:** Speeding up model training, data visualization (by reducing data to 2D or 3D).
+## Running the lesson script
 
----
+Execute the scripted walkthrough, which will save clustering and PCA plots
+to the project directory:
 
-## Practice Exercises
+```bash
+python Day_44_Unsupervised_Learning/solutions.py
+```
 
-1.  **Conceptual Questions:**
-    *   What is the primary goal of clustering?
-    *   How do you choose the value of `k` in K-Means? (Hint: Research the "Elbow Method").
-    *   What is the main benefit of using PCA?
+## Running the tests
 
-2.  **Code Implementation:**
-    *   The `solutions.py` file demonstrates how to implement both K-Means and PCA using `scikit-learn`.
-    *   The code covers:
-        1.  Generating synthetic data suitable for clustering.
-        2.  Applying K-Means to find clusters in the data.
-        3.  Loading the Iris dataset and applying PCA to reduce its dimensionality from 4 to 2.
-        4.  Visualizing the results of both algorithms.
+Automated tests validate the reusable helpers. Run just the Day 44 checks
+with:
 
-Review the code to understand these powerful unsupervised techniques.
+```bash
+pytest tests/test_day_44.py
+```
+
+To execute the entire suite, simply call `pytest` from the repository
+root.
+
+## Further exploration
+
+- Experiment with different numbers of clusters in `fit_kmeans` to observe
+  how centroids move.
+- Try increasing the number of PCA components and inspect the cumulative
+  explained variance to decide how many dimensions to keep.

--- a/Day_44_Unsupervised_Learning/solutions.py
+++ b/Day_44_Unsupervised_Learning/solutions.py
@@ -1,73 +1,123 @@
+"""Reusable utilities for Day 44 unsupervised learning demos."""
+
+from typing import Tuple
+
 import matplotlib.pyplot as plt
-from sklearn.datasets import make_blobs, load_iris
-from sklearn.preprocessing import StandardScaler
+import numpy as np
 from sklearn.cluster import KMeans
+from sklearn.datasets import load_iris, make_blobs
 from sklearn.decomposition import PCA
-
-# --- Part 1: K-Means Clustering ---
-print("--- K-Means Clustering Example ---")
-
-# 1. Generate synthetic data
-# We create 300 data points grouped into 4 distinct clusters.
-X_blobs, y_blobs = make_blobs(n_samples=300, centers=4, cluster_std=0.7, random_state=42)
-
-# 2. Apply K-Means
-# We specify k=4, since we know there are 4 clusters.
-kmeans = KMeans(n_clusters=4, random_state=42, n_init=10) # n_init=10 to avoid bad initializations
-kmeans.fit(X_blobs)
-y_kmeans = kmeans.predict(X_blobs)
-centroids = kmeans.cluster_centers_
-
-print("K-Means applied to synthetic data with 4 clusters.")
-
-# 3. Visualize the results
-plt.figure(figsize=(10, 6))
-plt.scatter(X_blobs[:, 0], X_blobs[:, 1], c=y_kmeans, s=50, cmap='viridis', label='Data Points')
-plt.scatter(centroids[:, 0], centroids[:, 1], c='red', s=200, alpha=0.75, marker='X', label='Centroids')
-plt.title('K-Means Clustering')
-plt.xlabel('Feature 1')
-plt.ylabel('Feature 2')
-plt.legend()
-plt.grid(True)
-plt.savefig('kmeans_clusters.png')
-print("Saved K-Means visualization to 'kmeans_clusters.png'")
-print("-" * 30)
+from sklearn.preprocessing import StandardScaler
 
 
-# --- Part 2: Principal Component Analysis (PCA) ---
-print("\n--- PCA Example ---")
+def generate_blobs(
+    n_samples: int = 300,
+    centers: int = 4,
+    cluster_std: float = 0.7,
+    random_state: int | None = 42,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Create a synthetic blob dataset for clustering demonstrations."""
 
-# 1. Load the Iris dataset
-iris = load_iris()
-X_iris, y_iris = iris.data, iris.target
+    return make_blobs(
+        n_samples=n_samples,
+        centers=centers,
+        cluster_std=cluster_std,
+        random_state=random_state,
+    )
 
-# 2. Standardize the data
-# PCA is affected by scale, so it's important to scale the features first.
-X_scaled = StandardScaler().fit_transform(X_iris)
-print("Iris dataset loaded and scaled.")
 
-# 3. Apply PCA
-# We want to reduce the 4 dimensions to 2 for visualization.
-pca = PCA(n_components=2)
-X_pca = pca.fit_transform(X_scaled)
+def fit_kmeans(
+    X: np.ndarray,
+    n_clusters: int = 4,
+    random_state: int | None = 42,
+    n_init: int = 10,
+) -> Tuple[KMeans, np.ndarray, np.ndarray]:
+    """Fit a K-Means model and return the estimator, labels, and cluster centers."""
 
-print(f"Original shape: {X_scaled.shape}")
-print(f"Shape after PCA: {X_pca.shape}")
+    model = KMeans(n_clusters=n_clusters, random_state=random_state, n_init=n_init)
+    labels = model.fit_predict(X)
+    return model, labels, model.cluster_centers_
 
-# Explained variance
-explained_variance = pca.explained_variance_ratio_
-print(f"Explained variance by component: {explained_variance}")
-print(f"Total variance explained by 2 components: {sum(explained_variance)*100:.2f}%")
-print("-" * 30)
 
-# 4. Visualize the PCA results
-plt.figure(figsize=(10, 6))
-scatter = plt.scatter(X_pca[:, 0], X_pca[:, 1], c=y_iris, cmap='viridis', edgecolor='k', s=60)
-plt.title('PCA of Iris Dataset')
-plt.xlabel('First Principal Component')
-plt.ylabel('Second Principal Component')
-plt.legend(handles=scatter.legend_elements()[0], labels=iris.target_names.tolist())
-plt.grid(True)
-plt.savefig('pca_iris.png')
-print("Saved PCA visualization to 'pca_iris.png'")
-print("-" * 30)
+def load_iris_data() -> Tuple[np.ndarray, np.ndarray, list[str]]:
+    """Load the Iris dataset along with target values and class labels."""
+
+    iris = load_iris()
+    return iris.data, iris.target, iris.target_names.tolist()
+
+
+def run_pca(
+    X: np.ndarray,
+    n_components: int = 2,
+) -> Tuple[np.ndarray, PCA, StandardScaler]:
+    """Scale the features, run PCA, and return the transformed data with models."""
+
+    scaler = StandardScaler()
+    X_scaled = scaler.fit_transform(X)
+    pca = PCA(n_components=n_components)
+    transformed = pca.fit_transform(X_scaled)
+    return transformed, pca, scaler
+
+
+def _plot_kmeans_results(X: np.ndarray, labels: np.ndarray, centers: np.ndarray) -> None:
+    plt.figure(figsize=(10, 6))
+    plt.scatter(X[:, 0], X[:, 1], c=labels, s=50, cmap="viridis", label="Data Points")
+    plt.scatter(
+        centers[:, 0],
+        centers[:, 1],
+        c="red",
+        s=200,
+        alpha=0.75,
+        marker="X",
+        label="Centroids",
+    )
+    plt.title("K-Means Clustering")
+    plt.xlabel("Feature 1")
+    plt.ylabel("Feature 2")
+    plt.legend()
+    plt.grid(True)
+    plt.savefig("kmeans_clusters.png")
+
+
+def _plot_pca_results(
+    transformed: np.ndarray, targets: np.ndarray, target_names: list[str]
+) -> None:
+    plt.figure(figsize=(10, 6))
+    scatter = plt.scatter(
+        transformed[:, 0],
+        transformed[:, 1],
+        c=targets,
+        cmap="viridis",
+        edgecolor="k",
+        s=60,
+    )
+    plt.title("PCA of Iris Dataset")
+    plt.xlabel("First Principal Component")
+    plt.ylabel("Second Principal Component")
+    plt.legend(handles=scatter.legend_elements()[0], labels=target_names)
+    plt.grid(True)
+    plt.savefig("pca_iris.png")
+
+
+if __name__ == "__main__":
+    print("--- K-Means Clustering Example ---")
+    blobs, _ = generate_blobs()
+    model, blob_labels, centers = fit_kmeans(blobs)
+    print("K-Means applied to synthetic data with 4 clusters.")
+    print(f"Cluster centers:\n{centers}")
+    _plot_kmeans_results(blobs, blob_labels, centers)
+    print("Saved K-Means visualization to 'kmeans_clusters.png'")
+    print("-" * 30)
+
+    print("\n--- PCA Example ---")
+    iris_features, iris_target, iris_names = load_iris_data()
+    transformed, pca_model, _ = run_pca(iris_features)
+    print(f"Original shape: {iris_features.shape}")
+    print(f"Shape after PCA: {transformed.shape}")
+    explained_variance = pca_model.explained_variance_ratio_
+    print(f"Explained variance by component: {explained_variance}")
+    total_variance = explained_variance.sum() * 100
+    print(f"Total variance explained by 2 components: {total_variance:.2f}%")
+    _plot_pca_results(transformed, iris_target, iris_names)
+    print("Saved PCA visualization to 'pca_iris.png'")
+    print("-" * 30)

--- a/Day_45_Feature_Engineering_and_Evaluation/README.md
+++ b/Day_45_Feature_Engineering_and_Evaluation/README.md
@@ -1,63 +1,53 @@
 # Day 45: Feature Engineering & Model Evaluation
 
-Welcome to Day 45! Today, we cover two critical aspects of the machine learning workflow: **Feature Engineering**, the art of creating better input features, and **Model Evaluation**, the science of assessing a model's performance beyond simple accuracy.
+## Overview
 
-> **Prerequisites:** Install scikit-learn with `pip install scikit-learn` so you can follow the preprocessing and evaluation walkthroughs. Need a reminder on managing packages? Revisit the Day 20 Python Package Manager lesson.
+Day 45 demonstrates how thoughtful preprocessing and rigorous evaluation
+combine to build trustworthy models:
 
-## 1. Feature Engineering
+- **Feature engineering pipelines** clean, scale, and encode raw columns so
+  downstream estimators receive consistent numeric inputs.
+- **Evaluation workflows** compare predictions against held-out data using
+  confusion matrices and rich classification reports.
 
-Feature engineering is the process of using domain knowledge to create features that make machine learning algorithms work better. Good features can make the difference between a poor model and a highly accurate one.
+Install scikit-learn before exploring the examples:
 
-### Key Techniques
+```bash
+pip install scikit-learn
+```
 
--   **Feature Scaling:**
-    -   **Standardization:** Rescales features to have a mean of 0 and a standard deviation of 1. (Used in `StandardScaler`).
-    -   **Normalization:** Rescales features to a range of [0, 1]. (Used in `MinMaxScaler`).
-    -   **Why?** Essential for distance-based algorithms (like KNN, SVM) and gradient-based algorithms.
+## What's inside
 
--   **Encoding Categorical Variables:**
-    -   **One-Hot Encoding:** Creates a new binary column for each category. Best for nominal data (categories with no intrinsic order).
-    -   **Label Encoding:** Assigns a unique integer to each category. Suitable for ordinal data (categories with a clear order).
+- `solutions.py` – helper functions for assembling preprocessing pipelines,
+  transforming the toy dataset, training a logistic regression model, and
+  returning evaluation metrics.
+- `README.md` – lesson overview (this document).
 
--   **Handling Missing Values:**
-    -   **Imputation:** Filling in missing values (e.g., with the mean, median, or mode of the column).
+## Running the lesson script
 
-## 2. Advanced Model Evaluation
+Execute the end-to-end walkthrough, which prints processed feature arrays,
+confusion matrix details, and a classification report:
 
-While accuracy is a common metric, it can be misleading, especially for imbalanced datasets (where one class is much more frequent than others).
+```bash
+python Day_45_Feature_Engineering_and_Evaluation/solutions.py
+```
 
-### Key Metrics for Classification
+## Running the tests
 
--   **Confusion Matrix:** A table that summarizes the performance of a classification model.
+Run the dedicated Day 45 tests to validate the preprocessing and evaluation
+utilities:
 
-|                | Predicted: NO  | Predicted: YES |
-|----------------|----------------|----------------|
-| **Actual: NO** | True Negative  | False Positive |
-| **Actual: YES**| False Negative | True Positive  |
+```bash
+pytest tests/test_day_45.py
+```
 
--   **Precision:** Measures the accuracy of positive predictions.
-    -   `Precision = TP / (TP + FP)`
-    -   *Of all the times the model predicted YES, how many were actually YES?*
+To execute the entire project test suite, run `pytest` from the repository
+root.
 
--   **Recall (Sensitivity):** Measures the ability of the model to find all the positive samples.
-    -   `Recall = TP / (TP + FN)`
-    -   *Of all the actual YES instances, how many did the model correctly identify?*
+## Further exploration
 
--   **F1-Score:** The harmonic mean of precision and recall. It provides a single score that balances both concerns.
-    -   `F1-Score = 2 * (Precision * Recall) / (Precision + Recall)`
-
----
-
-## Practice Exercises
-
-1.  **Conceptual Questions:**
-    *   Why is feature scaling important? Name one algorithm that requires it and one that doesn't.
-    *   When would you use One-Hot Encoding versus Label Encoding?
-    *   Explain a scenario where high accuracy might be a misleading metric.
-
-2.  **Code Implementation:**
-    *   The `solutions.py` file demonstrates:
-        1.  A simple feature engineering pipeline including imputation, scaling, and one-hot encoding.
-        2.  How to calculate and interpret a confusion matrix, precision, recall, and F1-score using `scikit-learn`.
-
-Review the code to understand how to prepare data and properly evaluate a model.
+- Swap in additional categorical columns and confirm that the preprocessing
+  pipeline scales automatically.
+- Replace the logistic regression classifier in `build_model_pipeline` with
+  another estimator (e.g., RandomForestClassifier) and compare the resulting
+  confusion matrix.

--- a/Day_45_Feature_Engineering_and_Evaluation/solutions.py
+++ b/Day_45_Feature_Engineering_and_Evaluation/solutions.py
@@ -1,92 +1,153 @@
-import pandas as pd
+"""Composable feature engineering and evaluation utilities for Day 45."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Tuple
+
 import numpy as np
-from sklearn.model_selection import train_test_split
-from sklearn.impute import SimpleImputer
-from sklearn.preprocessing import StandardScaler, OneHotEncoder
+import pandas as pd
 from sklearn.compose import ColumnTransformer
-from sklearn.pipeline import Pipeline
+from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import confusion_matrix, classification_report
-
-# --- Part 1: Feature Engineering Pipeline ---
-print("--- Feature Engineering Example ---")
-
-# Create a sample dataset with missing values and categorical data
-data = {
-    'age': [25, 30, 35, 40, np.nan, 45, 50],
-    'salary': [50000, 60000, np.nan, 80000, 90000, 100000, 110000],
-    'city': ['New York', 'London', 'Paris', 'New York', 'London', 'Tokyo', 'Paris'],
-    'purchased': [0, 1, 0, 1, 1, 0, 1] # Target variable
-}
-df = pd.DataFrame(data)
-print("Original DataFrame:")
-print(df)
-print("-" * 30)
-
-# Separate features and target
-X = df.drop('purchased', axis=1)
-y = df['purchased']
-
-# Identify numeric and categorical features
-numeric_features = ['age', 'salary']
-categorical_features = ['city']
-
-# Create preprocessing pipelines for numeric and categorical data
-# For numeric data: impute missing values with the mean, then scale.
-numeric_transformer = Pipeline(steps=[
-    ('imputer', SimpleImputer(strategy='mean')),
-    ('scaler', StandardScaler())
-])
-
-# For categorical data: one-hot encode.
-categorical_transformer = Pipeline(steps=[
-    ('onehot', OneHotEncoder(handle_unknown='ignore'))
-])
-
-# Create a preprocessor object using ColumnTransformer to apply different transformations
-# to different columns.
-preprocessor = ColumnTransformer(
-    transformers=[
-        ('num', numeric_transformer, numeric_features),
-        ('cat', categorical_transformer, categorical_features)
-    ])
-
-# Apply the preprocessing pipeline
-X_processed = preprocessor.fit_transform(X)
-
-print("Shape of data after preprocessing:", X_processed.shape)
-print("Note: 'city' was expanded into 3 columns by OneHotEncoder.")
-print("Transformed data (first 3 rows):")
-print(X_processed[:3])
-print("-" * 30)
+from sklearn.metrics import classification_report, confusion_matrix
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
 
-# --- Part 2: Advanced Model Evaluation ---
-print("\n--- Model Evaluation Example ---")
+def create_sample_dataframe() -> pd.DataFrame:
+    """Return the toy purchase dataset used in the lesson."""
 
-# Split the processed data
-X_train, X_test, y_train, y_test = train_test_split(X_processed, y, test_size=0.3, random_state=42)
+    data = {
+        "age": [25, 30, 35, 40, np.nan, 45, 50],
+        "salary": [50000, 60000, np.nan, 80000, 90000, 100000, 110000],
+        "city": [
+            "New York",
+            "London",
+            "Paris",
+            "New York",
+            "London",
+            "Tokyo",
+            "Paris",
+        ],
+        "purchased": [0, 1, 0, 1, 1, 0, 1],
+    }
+    return pd.DataFrame(data)
 
-# Train a simple model
-model = LogisticRegression()
-model.fit(X_train, y_train)
 
-# Make predictions
-y_pred = model.predict(X_test)
+def build_preprocessing_pipeline(
+    numeric_features: Iterable[str] = ("age", "salary"),
+    categorical_features: Iterable[str] = ("city",),
+) -> ColumnTransformer:
+    """Create a ColumnTransformer that handles numeric and categorical columns."""
 
-# 1. Confusion Matrix
-cm = confusion_matrix(y_test, y_pred)
-print("Confusion Matrix:")
-print(cm)
-print("TN | FP")
-print("FN | TP")
-print(f"True Negatives (TN): {cm[0, 0]} | False Positives (FP): {cm[0, 1]}")
-print(f"False Negatives (FN): {cm[1, 0]} | True Positives (TP): {cm[1, 1]}")
-print("-" * 30)
+    numeric_transformer = Pipeline(
+        steps=[
+            ("imputer", SimpleImputer(strategy="mean")),
+            ("scaler", StandardScaler()),
+        ]
+    )
+    categorical_transformer = Pipeline(
+        steps=[
+            ("onehot", OneHotEncoder(handle_unknown="ignore")),
+        ]
+    )
 
-# 2. Classification Report (Precision, Recall, F1-Score)
-report = classification_report(y_test, y_pred, zero_division=0)
-print("Classification Report:")
-print(report)
-print("This report provides a breakdown of precision, recall, and f1-score for each class.")
-print("-" * 30)
+    return ColumnTransformer(
+        transformers=[
+            ("num", numeric_transformer, list(numeric_features)),
+            ("cat", categorical_transformer, list(categorical_features)),
+        ]
+    )
+
+
+def preprocess_dataframe(
+    df: pd.DataFrame,
+    preprocessor: ColumnTransformer | None = None,
+) -> Tuple[np.ndarray, pd.Series, ColumnTransformer]:
+    """Fit the preprocessing pipeline and return the transformed feature matrix."""
+
+    if "purchased" not in df.columns:
+        raise ValueError("Expected 'purchased' target column in the dataframe.")
+
+    X = df.drop("purchased", axis=1)
+    y = df["purchased"]
+    preprocessor = preprocessor or build_preprocessing_pipeline()
+    X_processed = preprocessor.fit_transform(X)
+    return X_processed, y, preprocessor
+
+
+def build_model_pipeline(preprocessor: ColumnTransformer) -> Pipeline:
+    """Combine preprocessing with a logistic regression classifier."""
+
+    return Pipeline(
+        steps=[
+            ("preprocess", preprocessor),
+            ("classifier", LogisticRegression()),
+        ]
+    )
+
+
+def evaluate_model(
+    df: pd.DataFrame,
+    test_size: float = 0.3,
+    random_state: int | None = 42,
+) -> Tuple[Pipeline, Dict[str, object]]:
+    """Train the pipeline and compute evaluation metrics on a test split."""
+
+    if "purchased" not in df.columns:
+        raise ValueError("Expected 'purchased' target column in the dataframe.")
+
+    X = df.drop("purchased", axis=1)
+    y = df["purchased"]
+    preprocessor = build_preprocessing_pipeline()
+    pipeline = build_model_pipeline(preprocessor)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=test_size, random_state=random_state
+    )
+    pipeline.fit(X_train, y_train)
+    y_pred = pipeline.predict(X_test)
+
+    metrics: Dict[str, object] = {
+        "confusion_matrix": confusion_matrix(y_test, y_pred),
+        "classification_report": classification_report(
+            y_test, y_pred, zero_division=0
+        ),
+    }
+    return pipeline, metrics
+
+
+if __name__ == "__main__":
+    print("--- Feature Engineering Example ---")
+    dataframe = create_sample_dataframe()
+    print("Original DataFrame:")
+    print(dataframe)
+    print("-" * 30)
+
+    processed, target, fitted_preprocessor = preprocess_dataframe(dataframe)
+    print("Shape of data after preprocessing:", processed.shape)
+    print("Note: 'city' was expanded into multiple columns by OneHotEncoder.")
+    print("Transformed data (first 3 rows):")
+    print(processed[:3])
+    print("-" * 30)
+
+    print("\n--- Model Evaluation Example ---")
+    model, metrics = evaluate_model(dataframe)
+    confusion = metrics["confusion_matrix"]
+    print("Confusion Matrix:")
+    print(confusion)
+    print("TN | FP")
+    print("FN | TP")
+    print(
+        f"True Negatives (TN): {confusion[0, 0]} | False Positives (FP): {confusion[0, 1]}"
+    )
+    print(
+        f"False Negatives (FN): {confusion[1, 0]} | True Positives (TP): {confusion[1, 1]}"
+    )
+    print("-" * 30)
+    print("Classification Report:")
+    print(metrics["classification_report"])
+    print(
+        "This report provides a breakdown of precision, recall, and f1-score for each class."
+    )
+    print("-" * 30)

--- a/tests/test_day_44.py
+++ b/tests/test_day_44.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Day_44_Unsupervised_Learning.solutions import (  # noqa: E402
+    fit_kmeans,
+    generate_blobs,
+    load_iris_data,
+    run_pca,
+)
+
+
+def test_generate_blobs_produces_expected_shapes():
+    X, y = generate_blobs(n_samples=120, centers=3, random_state=0)
+
+    assert X.shape == (120, 2)
+    assert y.shape == (120,)
+    assert len(np.unique(y)) == 3
+
+
+def test_fit_kmeans_returns_cluster_centers_with_expected_shape():
+    X, _ = generate_blobs(n_samples=150, centers=3, random_state=1)
+
+    _, labels, centers = fit_kmeans(X, n_clusters=3, random_state=1)
+
+    assert centers.shape == (3, X.shape[1])
+    assert len(np.unique(labels)) == 3
+
+
+def test_run_pca_returns_expected_variance():
+    features, _, _ = load_iris_data()
+
+    transformed, pca_model, scaler = run_pca(features, n_components=2)
+
+    assert transformed.shape == (features.shape[0], 2)
+    assert scaler.mean_.shape[0] == features.shape[1]
+    assert pytest.approx(pca_model.explained_variance_ratio_.sum(), abs=1e-3) == 0.958

--- a/tests/test_day_45.py
+++ b/tests/test_day_45.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Day_45_Feature_Engineering_and_Evaluation.solutions import (  # noqa: E402
+    create_sample_dataframe,
+    evaluate_model,
+    preprocess_dataframe,
+)
+
+
+def test_preprocess_dataframe_returns_expected_shape_and_features():
+    df = create_sample_dataframe()
+
+    processed, target, preprocessor = preprocess_dataframe(df)
+
+    assert processed.shape == (7, 6)
+    assert target.tolist() == [0, 1, 0, 1, 1, 0, 1]
+    expected_features = [
+        "num__age",
+        "num__salary",
+        "cat__city_London",
+        "cat__city_New York",
+        "cat__city_Paris",
+        "cat__city_Tokyo",
+    ]
+    assert preprocessor.get_feature_names_out().tolist() == expected_features
+
+
+def test_evaluate_model_returns_expected_confusion_matrix():
+    df = create_sample_dataframe()
+
+    pipeline, metrics = evaluate_model(df, test_size=0.3, random_state=42)
+
+    assert "preprocess" in pipeline.named_steps
+    np.testing.assert_array_equal(metrics["confusion_matrix"], np.array([[1, 1], [0, 1]]))
+    assert "precision" in metrics["classification_report"].lower()


### PR DESCRIPTION
## Summary
- refactor the Day 44 unsupervised learning lesson into reusable helpers for blob generation, K-Means clustering, and PCA while preserving the example script behaviour
- split the Day 45 feature engineering walkthrough into composable preprocessing/evaluation pipelines that expose transformed arrays and metrics
- align both READMEs with the standard structure and add focused pytest coverage for the new utilities

## Testing
- pytest tests/test_day_44.py tests/test_day_45.py

------
https://chatgpt.com/codex/tasks/task_b_68da80baf3c0832d883734653b16067d