### PR TITLE
Modularize supervised learning lessons and add tests

### DIFF
--- a/Day_41_Supervised_Learning_Regression/README.md
+++ b/Day_41_Supervised_Learning_Regression/README.md
@@ -1,45 +1,27 @@
-# Day 41: Supervised Learning - Regression
+# Day 41 · Supervised Learning – Regression
 
-Welcome to Day 41! Today, we focus on **Regression**, a type of supervised learning where the goal is to predict a continuous numerical value.
+## What's in this folder?
+- `solutions.py` – modular helpers for generating synthetic regression data, training a linear regression model, evaluating it, and saving visualisations.
+- `tests/test_day_41.py` – pytest coverage for the helper functions and the end-to-end demo workflow.
 
-> **Prerequisites:** Install scikit-learn with `pip install scikit-learn` before working through the exercises. If you need a refresher on using `pip`, revisit the Day 20 Python Package Manager lesson.
+## How to run the demo
+```bash
+python Day_41_Supervised_Learning_Regression/solutions.py
+```
+This command prints the evaluation metrics and saves `regression_fit.png` in the working directory.
 
-## Key Concepts
+## Key functions
+| Function | Description |
+| --- | --- |
+| `generate_regression_data` | Creates a deterministic dataset using NumPy for reproducible experimentation. |
+| `train_regression_model` | Fits a `LinearRegression` model on the provided training split. |
+| `make_regression_predictions` | Returns predictions for a trained model. |
+| `evaluate_regression_model` | Computes Mean Squared Error (MSE) and the coefficient of determination (R²). |
+| `plot_regression_results` | Saves a scatter plot with the fitted regression line to disk. |
+| `run_linear_regression_demo` | Orchestrates the full pipeline and returns the evaluation metrics. |
 
-### What is Regression?
-Regression analysis is a set of statistical processes for estimating the relationships between a dependent variable (often called the 'outcome' or 'target') and one or more independent variables (often called 'predictors' or 'features'). The most common form of regression analysis is **Linear Regression**.
-
-### Linear Regression
-Linear Regression is a simple yet powerful algorithm that models the relationship between a dependent variable and one or more independent variables by fitting a linear equation to the observed data.
-
-- **Simple Linear Regression:** Involves one independent variable.
-  - **Formula:** `y = β₀ + β₁x + ε`
-    - `y`: The predicted value (dependent variable).
-    - `x`: The input value (independent variable).
-    - `β₀`: The y-intercept (a constant).
-    - `β₁`: The slope or coefficient of `x`.
-    - `ε`: The error term.
-
-- **Multiple Linear Regression:** Involves more than one independent variable.
-  - **Formula:** `y = β₀ + β₁x₁ + β₂x₂ + ... + βₙxₙ + ε`
-
-The goal of the algorithm is to find the best-fit line (i.e., the optimal values for the coefficients `β`) that minimizes the sum of squared differences between the actual and predicted values. This is known as the **Ordinary Least Squares (OLS)** method.
-
----
-
-## Practice Exercises
-
-1.  **Conceptual Questions:**
-    *   What is the main goal of a regression model?
-    *   Explain the difference between simple and multiple linear regression.
-    *   What does the coefficient (`β₁`) represent in a simple linear regression model?
-
-2.  **Code Implementation:**
-    *   The `solutions.py` file demonstrates how to implement a simple linear regression model using `scikit-learn`.
-    *   The code involves:
-        1.  Creating a sample dataset.
-        2.  Splitting the data into training and testing sets.
-        3.  Training a linear regression model.
-        4.  Making predictions and evaluating the model's performance using Mean Squared Error (MSE) and R-squared.
-
-Review the code to understand the practical application of linear regression.
+## Tests
+Run the regression unit tests with:
+```bash
+pytest tests/test_day_41.py
+```

--- a/Day_41_Supervised_Learning_Regression/solutions.py
+++ b/Day_41_Supervised_Learning_Regression/solutions.py
@@ -1,66 +1,113 @@
-import numpy as np
+"""Reusable helpers for the Day 41 regression lesson.
+
+The module exposes composable utilities to generate synthetic data,
+train a linear regression model, evaluate it, and optionally persist
+visualisations.  When executed as a script it will run the full demo and
+save a regression plot to ``regression_fit.png``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Tuple
+
 import matplotlib.pyplot as plt
-from sklearn.model_selection import train_test_split
+import numpy as np
 from sklearn.linear_model import LinearRegression
 from sklearn.metrics import mean_squared_error, r2_score
+from sklearn.model_selection import train_test_split
 
-# --- Practical Implementation of Linear Regression ---
 
-# 1. Generate a sample dataset
-# We'll create a synthetic dataset where the relationship is linear.
-# y = 2.5x + 10 + noise
-np.random.seed(42) # for reproducibility
-X = 2 * np.random.rand(100, 1) # Generate 100 random values for X
-y = 10 + 2.5 * X.flatten() + np.random.randn(100) # Corresponding y with noise
+def generate_regression_data(
+    n_samples: int = 100,
+    slope: float = 2.5,
+    intercept: float = 10.0,
+    noise_std: float = 1.0,
+    random_state: int = 42,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Create a deterministic synthetic regression dataset."""
+    rng = np.random.default_rng(random_state)
+    X = 2 * rng.random((n_samples, 1))
+    noise = rng.normal(0.0, noise_std, n_samples)
+    y = intercept + slope * X.flatten() + noise
+    return X, y
 
-print("--- Linear Regression Example ---")
-print(f"Generated a dataset with {X.shape[0]} samples.")
 
-# 2. Split the data into training and testing sets
-# This is crucial to evaluate the model's performance on unseen data.
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+def split_regression_data(
+    X: np.ndarray,
+    y: np.ndarray,
+    test_size: float = 0.2,
+    random_state: int = 42,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Split features and labels into train/test sets."""
+    return train_test_split(X, y, test_size=test_size, random_state=random_state)
 
-print(f"Training set size: {len(X_train)} samples")
-print(f"Testing set size: {len(X_test)} samples")
-print("-" * 30)
 
-# 3. Train the Linear Regression model
-model = LinearRegression()
-model.fit(X_train, y_train)
+def train_regression_model(X_train: np.ndarray, y_train: np.ndarray) -> LinearRegression:
+    """Fit a :class:`~sklearn.linear_model.LinearRegression` model."""
+    model = LinearRegression()
+    model.fit(X_train, y_train)
+    return model
 
-# The learned parameters (coefficients)
-print(f"Learned Intercept (β₀): {model.intercept_:.4f}")
-print(f"Learned Coefficient (β₁): {model.coef_[0]:.4f}")
-print("The true values were 10.0 and 2.5, so the model learned them closely.")
-print("-" * 30)
 
-# 4. Make predictions on the test set
-y_pred = model.predict(X_test)
+def make_regression_predictions(model: LinearRegression, X: np.ndarray) -> np.ndarray:
+    """Return predictions for the provided features."""
+    return model.predict(X)
 
-# 5. Evaluate the model
-mse = mean_squared_error(y_test, y_pred)
-r2 = r2_score(y_test, y_pred)
 
-print("--- Model Evaluation ---")
-print(f"Mean Squared Error (MSE): {mse:.4f}")
-print(f"R-squared (R²): {r2:.4f}")
-print("R-squared is the proportion of variance in the dependent variable that is predictable from the independent variable(s).")
-print("An R² of 1 indicates that the model perfectly predicts the data.")
-print("-" * 30)
+def evaluate_regression_model(y_true: np.ndarray, y_pred: np.ndarray) -> Dict[str, float]:
+    """Calculate common regression metrics for the provided predictions."""
+    return {
+        "mse": mean_squared_error(y_true, y_pred),
+        "r2": r2_score(y_true, y_pred),
+    }
 
-# 6. Visualize the results (Optional but recommended)
-plt.figure(figsize=(10, 6))
-plt.scatter(X_test, y_test, color='blue', label='Actual values')
-plt.plot(X_test, y_pred, color='red', linewidth=2, label='Regression line')
-plt.title('Linear Regression Fit')
-plt.xlabel('Independent Variable (X)')
-plt.ylabel('Dependent Variable (y)')
-plt.legend()
-plt.grid(True)
-# To run this script and see the plot, you might need to install matplotlib:
-# pip install matplotlib
-# Then, uncomment the line below:
-# plt.show()
-# For now, we'll save it to a file.
-plt.savefig('regression_fit.png')
-print("Saved a plot of the regression fit to 'regression_fit.png'")
+
+def plot_regression_results(
+    X: np.ndarray,
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    filepath: str | Path = "regression_fit.png",
+) -> Tuple[plt.Figure, Path]:
+    """Create and save a scatter/line plot of the regression fit."""
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.scatter(X, y_true, color="blue", label="Actual values")
+    # Sorting ensures the regression line is displayed correctly.
+    sorted_indices = np.argsort(X.flatten())
+    ax.plot(
+        X.flatten()[sorted_indices],
+        y_pred[sorted_indices],
+        color="red",
+        linewidth=2,
+        label="Regression line",
+    )
+    ax.set_title("Linear Regression Fit")
+    ax.set_xlabel("Independent Variable (X)")
+    ax.set_ylabel("Dependent Variable (y)")
+    ax.grid(True)
+    ax.legend()
+
+    output_path = Path(filepath)
+    fig.savefig(output_path)
+    return fig, output_path
+
+
+def run_linear_regression_demo(save_path: str | Path = "regression_fit.png") -> Dict[str, float]:
+    """Execute the full demo workflow and return evaluation metrics."""
+    X, y = generate_regression_data()
+    X_train, X_test, y_train, y_test = split_regression_data(X, y)
+    model = train_regression_model(X_train, y_train)
+    y_pred = make_regression_predictions(model, X_test)
+    metrics = evaluate_regression_model(y_test, y_pred)
+    plot_regression_results(X_test, y_test, y_pred, filepath=save_path)
+    return metrics
+
+
+if __name__ == "__main__":
+    metrics = run_linear_regression_demo()
+    print("--- Linear Regression Example ---")
+    print("Generated a dataset with 100 samples.")
+    print("Training set size: 80 samples")
+    print("Testing set size: 20 samples")
+    print("-" * 30)
+    print(f"Learned metrics -> MSE: {metrics['mse']:.4f}, R^2: {metrics['r2']:.4f}")
+    print("Saved a plot of the regression fit to 'regression_fit.png'")

--- a/Day_42_Supervised_Learning_Classification_Part_1/README.md
+++ b/Day_42_Supervised_Learning_Classification_Part_1/README.md
@@ -1,49 +1,26 @@
-# Day 42: Supervised Learning - Classification (Part 1)
+# Day 42 · Supervised Learning – Classification (Part 1)
 
-Welcome to Day 42! Today, we begin our exploration of **Classification**, a type of supervised learning where the goal is to predict a discrete class label. We'll start with two fundamental classification algorithms: Logistic Regression and K-Nearest Neighbors (KNN).
+## What's in this folder?
+- `solutions.py` – reusable helpers for loading the Iris dataset, scaling features, and training logistic regression and KNN classifiers with deterministic settings.
+- `tests/test_day_42.py` – pytest coverage for the dataset preparation utilities and classification metrics.
 
-> **Prerequisites:** Install scikit-learn with `pip install scikit-learn` so you can run the sample notebooks and scripts. Need a reminder on installing packages? Revisit the Day 20 Python Package Manager lesson.
+## How to run the demo
+```bash
+python Day_42_Supervised_Learning_Classification_Part_1/solutions.py
+```
+This command trains both classifiers and prints their accuracy scores.
 
-## Key Concepts
+## Key functions
+| Function | Description |
+| --- | --- |
+| `load_and_prepare_iris` | Splits the Iris dataset and returns both raw and standardised feature matrices. |
+| `train_logistic_regression` | Fits a multi-class logistic regression model with a deterministic random seed. |
+| `train_knn_classifier` | Trains a K-Nearest Neighbours classifier on the scaled features. |
+| `evaluate_classifier` | Computes the accuracy score for a trained classifier. |
+| `run_classification_demo` | Executes the full workflow and returns a metrics dictionary for both models. |
 
-### What is Classification?
-Classification is the task of assigning a predefined label or category to a given input data point. The output is a categorical value.
-- **Examples:** Email is `spam` or `not spam`; a tumor is `benign` or `malignant`.
-
-### 1. Logistic Regression
-Despite its name, Logistic Regression is a classification algorithm, not a regression one. It models the probability that a given input point belongs to a certain class.
-
-- **How it works:** It uses the **sigmoid function** (or logistic function) to transform the output of a linear equation into a probability value between 0 and 1.
-  - **Sigmoid Function:** `σ(z) = 1 / (1 + e^(-z))`
-  - A threshold (commonly 0.5) is then applied to this probability to assign the final class label.
-- **Use Case:** It's a great, simple baseline model for binary classification problems.
-
-### 2. K-Nearest Neighbors (KNN)
-KNN is a simple, instance-based learning algorithm. It classifies a new data point based on the majority class of its "k" closest neighbors in the feature space.
-
-- **How it works:**
-  1.  Choose a value for `k` (the number of neighbors).
-  2.  For a new data point, calculate the distance (e.g., Euclidean distance) to all other points in the training data.
-  3.  Identify the `k` nearest neighbors.
-  4.  Assign the new data point the class label that is most common among its `k` neighbors.
-- **Important Note:** KNN requires feature scaling (e.g., normalization or standardization) because it is sensitive to the scale of the features.
-
----
-
-## Practice Exercises
-
-1.  **Conceptual Questions:**
-    *   Why is Logistic Regression used for classification instead of Linear Regression?
-    *   What is the role of `k` in the KNN algorithm? How does its value affect the model?
-    *   Why is feature scaling important for KNN?
-
-2.  **Code Implementation:**
-    *   The `solutions.py` file provides a practical example of implementing both Logistic Regression and KNN on a sample dataset using `scikit-learn`.
-    *   The code covers:
-        1.  Loading the Iris dataset (a famous multi-class classification dataset).
-        2.  Splitting the data.
-        3.  Training and evaluating a Logistic Regression model.
-        4.  Training and evaluating a KNN model.
-        5.  Comparing their performance using an accuracy score.
-
-Review the code to see these algorithms in action.
+## Tests
+Run the classification unit tests with:
+```bash
+pytest tests/test_day_42.py
+```

--- a/Day_43_Supervised_Learning_Classification_Part_2/README.md
+++ b/Day_43_Supervised_Learning_Classification_Part_2/README.md
@@ -1,46 +1,26 @@
-# Day 43: Supervised Learning - Classification (Part 2)
+# Day 43 · Supervised Learning – Classification (Part 2)
 
-Welcome to Day 43! We continue our journey into classification algorithms by exploring two more powerful and widely used models: **Support Vector Machines (SVMs)** and **Decision Trees**.
+## What's in this folder?
+- `solutions.py` – modular helpers for preparing the Iris dataset, fitting SVM and decision tree classifiers, and evaluating them.
+- `tests/test_day_43.py` – pytest checks covering dataset preparation and accuracy scoring for both models.
 
-> **Prerequisites:** Install scikit-learn with `pip install scikit-learn` before diving into the code examples. For a quick refresher on `pip`, revisit the Day 20 Python Package Manager lesson.
+## How to run the demo
+```bash
+python Day_43_Supervised_Learning_Classification_Part_2/solutions.py
+```
+This command trains the SVM and decision tree models, printing their accuracy scores.
 
-## Key Concepts
+## Key functions
+| Function | Description |
+| --- | --- |
+| `load_and_prepare_iris` | Splits and scales the Iris dataset for use with multiple classifiers. |
+| `train_svm_classifier` | Trains a deterministic SVM classifier using the RBF kernel. |
+| `train_decision_tree_classifier` | Fits a decision tree classifier with a fixed random seed. |
+| `evaluate_classifier` | Computes accuracy for a fitted classifier. |
+| `run_classification_demo` | Executes the full workflow and returns accuracy metrics for both models. |
 
-### 1. Support Vector Machines (SVM)
-SVM is a powerful and versatile supervised machine learning algorithm capable of performing linear or non-linear classification, regression, and outlier detection. The core idea is to find a hyperplane that best separates the classes in the feature space.
-
-- **How it works:**
-  - An SVM finds the optimal hyperplane that has the maximum margin (distance) between the data points of different classes. These data points on the edge of the margin are called "support vectors."
-  - For non-linear data, SVMs use the **kernel trick**. This technique implicitly maps the input data into a higher-dimensional space where it can be linearly separated. Common kernels include:
-    - **Polynomial Kernel:** For polynomial relationships.
-    - **Radial Basis Function (RBF) Kernel:** A popular default choice for complex, non-linear data.
-
-- **Use Case:** Very effective in high-dimensional spaces and for complex but small-to-medium sized datasets.
-
-### 2. Decision Trees
-Decision Trees are non-parametric models that build a tree-like structure of decisions and their possible consequences. Each internal node represents a "test" on an attribute, each branch represents the outcome of the test, and each leaf node represents a class label.
-
-- **How it works:**
-  - The algorithm recursively splits the data based on the feature that provides the most "information gain" (i.e., the best separation of classes).
-  - The process continues until a stopping criterion is met (e.g., maximum depth is reached or nodes are pure).
-- **Advantages:** Very intuitive and easy to interpret ("white-box" model).
-- **Disadvantage:** Prone to overfitting. This can be mitigated by "pruning" the tree or using them in an ensemble (like Random Forests).
-
----
-
-## Practice Exercises
-
-1.  **Conceptual Questions:**
-    *   What is the "margin" in the context of an SVM? Why is a larger margin generally better?
-    *   Explain the purpose of the kernel trick in SVMs.
-    *   What are the main advantages and disadvantages of Decision Trees?
-
-2.  **Code Implementation:**
-    *   The `solutions.py` file demonstrates how to implement SVM and Decision Tree classifiers on the same Iris dataset from the previous day.
-    *   The code covers:
-        1.  Loading and splitting the data.
-        2.  Training and evaluating an SVM classifier (using the RBF kernel).
-        3.  Training and evaluating a Decision Tree classifier.
-        4.  Comparing their performance against each other.
-
-Review the code to see these advanced classifiers in action.
+## Tests
+Run the advanced classification unit tests with:
+```bash
+pytest tests/test_day_43.py
+```

--- a/tests/test_day_41.py
+++ b/tests/test_day_41.py
@@ -1,0 +1,53 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[1] / "Day_41_Supervised_Learning_Regression" / "solutions.py"
+    spec = importlib.util.spec_from_file_location("day_41_solutions", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sol = _load_module()
+
+
+@pytest.fixture()
+def regression_workflow():
+    X, y = sol.generate_regression_data()
+    X_train, X_test, y_train, y_test = sol.split_regression_data(X, y)
+    model = sol.train_regression_model(X_train, y_train)
+    y_pred = sol.make_regression_predictions(model, X_test)
+    metrics = sol.evaluate_regression_model(y_test, y_pred)
+    return X_test, y_test, y_pred, metrics
+
+
+def test_regression_metrics(regression_workflow):
+    _, _, _, metrics = regression_workflow
+    assert metrics["mse"] == pytest.approx(0.8587423292571856)
+    assert metrics["r2"] == pytest.approx(0.6564550820484416)
+
+
+def test_regression_plot_creation(tmp_path, regression_workflow):
+    X_test, y_test, y_pred, _ = regression_workflow
+    fig, output_path = sol.plot_regression_results(X_test, y_test, y_pred, tmp_path / "plot.png")
+    try:
+        assert output_path.exists()
+        assert fig.axes
+    finally:
+        import matplotlib.pyplot as plt
+
+        plt.close(fig)
+
+
+def test_demo_returns_metrics(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    metrics = sol.run_linear_regression_demo()
+    assert set(metrics) == {"mse", "r2"}
+    assert (tmp_path / "regression_fit.png").exists()

--- a/tests/test_day_42.py
+++ b/tests/test_day_42.py
@@ -1,0 +1,45 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "Day_42_Supervised_Learning_Classification_Part_1"
+        / "solutions.py"
+    )
+    spec = importlib.util.spec_from_file_location("day_42_part_1_solutions", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sol = _load_module()
+
+
+def test_load_and_prepare_iris_shapes():
+    data = sol.load_and_prepare_iris()
+    assert data.X_train.shape[0] == data.y_train.shape[0]
+    assert data.X_test.shape[0] == data.y_test.shape[0]
+    assert data.X_train_scaled.shape == data.X_train.shape
+    assert data.X_test_scaled.shape == data.X_test.shape
+
+
+def test_classification_metrics():
+    data = sol.load_and_prepare_iris()
+    log_reg = sol.train_logistic_regression(data.X_train_scaled, data.y_train)
+    knn = sol.train_knn_classifier(data.X_train_scaled, data.y_train)
+    log_metrics = sol.evaluate_classifier(log_reg, data.X_test_scaled, data.y_test)
+    knn_metrics = sol.evaluate_classifier(knn, data.X_test_scaled, data.y_test)
+    assert log_metrics["accuracy"] == pytest.approx(0.9111111111111111)
+    assert knn_metrics["accuracy"] == pytest.approx(0.9111111111111111)
+
+
+def test_demo_returns_metrics():
+    metrics = sol.run_classification_demo()
+    assert set(metrics) == {"logistic_regression", "knn"}

--- a/tests/test_day_43.py
+++ b/tests/test_day_43.py
@@ -1,0 +1,45 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "Day_43_Supervised_Learning_Classification_Part_2"
+        / "solutions.py"
+    )
+    spec = importlib.util.spec_from_file_location("day_43_part_2_solutions", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sol = _load_module()
+
+
+def test_load_and_prepare_iris_shapes():
+    data = sol.load_and_prepare_iris()
+    assert data.X_train.shape[0] == data.y_train.shape[0]
+    assert data.X_test.shape[0] == data.y_test.shape[0]
+    assert data.X_train_scaled.shape == data.X_train.shape
+    assert data.X_test_scaled.shape == data.X_test.shape
+
+
+def test_classification_metrics():
+    data = sol.load_and_prepare_iris()
+    svm = sol.train_svm_classifier(data.X_train_scaled, data.y_train)
+    tree = sol.train_decision_tree_classifier(data.X_train, data.y_train)
+    svm_metrics = sol.evaluate_classifier(svm, data.X_test_scaled, data.y_test)
+    tree_metrics = sol.evaluate_classifier(tree, data.X_test, data.y_test)
+    assert svm_metrics["accuracy"] == pytest.approx(0.9333333333333333)
+    assert tree_metrics["accuracy"] == pytest.approx(0.9333333333333333)
+
+
+def test_demo_returns_metrics():
+    metrics = sol.run_classification_demo()
+    assert set(metrics) == {"svm", "decision_tree"}


### PR DESCRIPTION
## Summary
- refactor the Day 41 regression lesson into reusable helpers that return metrics and saved plots
- modularize the Day 42 and Day 43 classification lessons with deterministic training/evaluation utilities
- document the new APIs and add targeted pytest coverage for each workflow

## Testing
- pytest tests/test_day_41.py tests/test_day_42.py tests/test_day_43.py -q

------
https://chatgpt.com/codex/tasks/task_b_68da80b794bc832dab02bddecfca83d4