### PR TITLE
Refactor deep learning lessons into modular workflows

### DIFF
--- a/Day_46_Intro_to_Neural_Networks/README.md
+++ b/Day_46_Intro_to_Neural_Networks/README.md
@@ -44,12 +44,16 @@ Building neural networks from scratch is complex. We use specialized libraries t
 
 ## Practice Exercise
 
--   The `solutions.py` file demonstrates how to build a simple neural network for a classification task using **TensorFlow with the Keras API**.
+-   The `solutions.py` module now exposes dedicated helper functions for each step of the workflow (data preparation, model construction, training, and evaluation). Import the pieces you need instead of running everything on import.
 -   The code covers:
     1.  Loading and preparing the Iris dataset.
     2.  Building a sequential model with dense (fully connected) layers.
     3.  Compiling the model (specifying the optimizer, loss function, and metrics).
     4.  Training the model.
-    5.  Evaluating its performance.
+    5.  Evaluating its performance and making predictions.
 
-Review the code to understand the basic workflow of building and training a neural network.
+### Running the example and tests
+
+-   Execute the full walkthrough from the command line with `python Day_46_Intro_to_Neural_Networks/solutions.py`. The script prints the data shapes, model summary, and evaluation metrics.
+-   Need a quick confidence check without the full 50-epoch run? The automated test performs a single, deterministic epoch: `pytest tests/test_day_46.py`.
+-   Training on GPU hardware is optional for this small dataset, but TensorFlow will automatically leverage your GPU if it's available and correctly configured.

--- a/Day_47_Convolutional_Neural_Networks/README.md
+++ b/Day_47_Convolutional_Neural_Networks/README.md
@@ -37,11 +37,15 @@ A common CNN architecture consists of a stack of `Conv2D` and `MaxPooling2D` lay
 
 ## Practice Exercise
 
--   The `solutions.py` file demonstrates how to build and train a simple CNN to classify handwritten digits from the famous **MNIST dataset**.
+-   The `solutions.py` module now exports granular helpers (`prepare_mnist_data`, `build_cnn_model`, `train_cnn_model`, etc.) so you can mix and match pieces in notebooks or tests without kicking off a full five-epoch training run on import.
 -   The code covers:
     1.  Loading and preprocessing the MNIST image data. (Images are normalized to be between 0 and 1).
     2.  Building a sequential CNN model with `Conv2D`, `MaxPooling2D`, `Flatten`, and `Dense` layers.
     3.  Compiling and training the CNN.
     4.  Evaluating its performance on the test set. A well-trained CNN can achieve very high accuracy on this task.
 
-Review the code to see how these specialized layers are combined to create a powerful image classifier.
+### Running the example and tests
+
+-   For the full demonstration run `python Day_47_Convolutional_Neural_Networks/solutions.py`. Expect a few epochs of training output plus the final metrics.
+-   To verify the pipeline quickly (and without downloading the entire MNIST dataset), use the short smoke test: `pytest tests/test_day_47.py`. The test swaps in a tiny synthetic dataset and trains for a single epoch.
+-   CNN training benefits from GPU acceleration. TensorFlow will automatically use your GPU if the drivers and CUDA/cuDNN stack are configured; otherwise the CPU-only run will simply take longer.

--- a/Day_48_Recurrent_Neural_Networks/README.md
+++ b/Day_48_Recurrent_Neural_Networks/README.md
@@ -35,8 +35,8 @@ To solve this problem, more sophisticated RNN variants were developed:
 
 ## Practice Exercise
 
--   The `solutions.py` file demonstrates how to build and train a simple RNN (using an LSTM layer) for **sentiment analysis** on the **IMDB movie review dataset**.
--   The goal is to classify a review as either `positive` or `negative`.
+-   The refactored `solutions.py` module exposes building blocks such as `prepare_imdb_data`, `build_rnn_model`, and `train_rnn_model`. Import what you need for notebooks or experiments; nothing trains automatically when the module is imported.
+-   The goal remains to classify IMDB reviews as `positive` or `negative`, and the workflow now mirrors the modular structure used for other deep-learning lessons.
 -   The code covers:
     1.  Loading and preprocessing the IMDB text data. (Reviews are pre-processed into sequences of integers).
     2.  Padding the sequences to ensure they all have the same length.
@@ -44,4 +44,8 @@ To solve this problem, more sophisticated RNN variants were developed:
     4.  Compiling and training the RNN.
     5.  Evaluating its performance on the test set.
 
-Review the code to see how RNNs can be used to understand and classify sequential text data.
+### Running the example and tests
+
+-   Launch the full script with `python Day_48_Recurrent_Neural_Networks/solutions.py` to download IMDB, train the LSTM, and print evaluation metrics.
+-   For a very fast check, use `pytest tests/test_day_48.py`. The test stubs out the dataset loader with a handful of synthetic sequences and runs a single epoch so it finishes quickly.
+-   LSTM models benefit significantly from GPU acceleration. If you have CUDA/cuDNN configured, TensorFlow will pick it up automatically; otherwise the CPU execution path will still work (just slower).

--- a/Day_48_Recurrent_Neural_Networks/solutions.py
+++ b/Day_48_Recurrent_Neural_Networks/solutions.py
@@ -1,81 +1,142 @@
+"""Utility functions for building and training a small LSTM on the IMDB dataset."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+import numpy as np
 import tensorflow as tf
-from tensorflow.keras import layers, models, datasets
+from tensorflow.keras import datasets, layers, models
 from tensorflow.keras.preprocessing.sequence import pad_sequences
 
-# --- Building an RNN for Sentiment Analysis ---
 
-print("--- RNN (LSTM) for IMDB Sentiment Classification ---")
+DEFAULT_SEED = 42
 
-# 1. Load and Preprocess the IMDB Dataset
-# The dataset contains 50,000 movie reviews from IMDB, labeled as positive (1) or negative (0).
-# We'll limit the vocabulary to the top 10,000 most frequent words.
-vocab_size = 10000
-(train_data, train_labels), (test_data, test_labels) = datasets.imdb.load_data(num_words=vocab_size)
 
-print(f"Number of training samples: {len(train_data)}")
-print(f"Number of test samples: {len(test_data)}")
+def set_global_seed(seed: int = DEFAULT_SEED) -> None:
+    """Synchronise NumPy and TensorFlow RNGs for deterministic runs."""
 
-# Each review is a sequence of word indices. Let's look at one.
-print(f"Example review (as word indices): {train_data[0][:15]}...")
+    np.random.seed(seed)
+    tf.keras.utils.set_random_seed(seed)
 
-# The reviews have different lengths. We need to pad them to a uniform length.
-# We'll set a max length of 256. Reviews longer than this will be truncated.
-max_length = 256
-train_data_padded = pad_sequences(train_data, maxlen=max_length, padding='post')
-test_data_padded = pad_sequences(test_data, maxlen=max_length, padding='post')
 
-print(f"Padded training data shape: {train_data_padded.shape}")
-print(f"Padded test data shape: {test_data_padded.shape}")
-print("-" * 30)
+def prepare_imdb_data(
+    *, vocab_size: int = 10_000, max_length: int = 256
+) -> Tuple[Tuple[np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray]]:
+    """Load the IMDB sentiment dataset and pad sequences to a uniform length."""
 
-# 2. Build the Recurrent Neural Network Model
-# We will use an LSTM layer.
-embedding_dim = 16
+    (train_data, train_labels), (test_data, test_labels) = datasets.imdb.load_data(
+        num_words=vocab_size
+    )
 
-model = models.Sequential([
-    # 1. Embedding Layer: Turns positive integers (word indices) into dense vectors of fixed size.
-    # This layer learns word embeddings from the data.
-    layers.Embedding(input_dim=vocab_size, output_dim=embedding_dim, input_length=max_length),
+    train_data_padded = pad_sequences(train_data, maxlen=max_length, padding="post")
+    test_data_padded = pad_sequences(test_data, maxlen=max_length, padding="post")
 
-    # 2. LSTM Layer: The core of our RNN. 64 units in the LSTM cell.
-    layers.LSTM(64),
+    return (train_data_padded, np.array(train_labels)), (
+        test_data_padded,
+        np.array(test_labels),
+    )
 
-    # 3. Dense Classifier Head
-    layers.Dense(64, activation='relu'),
-    # Output layer with 1 neuron and a sigmoid activation for binary classification.
-    layers.Dense(1, activation='sigmoid')
-])
 
-# 3. Compile the Model
-model.compile(
-    optimizer='adam',
-    loss='binary_crossentropy', # Loss function for binary classification
-    metrics=['accuracy']
-)
+def build_rnn_model(
+    *,
+    vocab_size: int = 10_000,
+    embedding_dim: int = 16,
+    max_length: int = 256,
+    lstm_units: int = 64,
+    dense_units: int = 64,
+) -> tf.keras.Model:
+    """Create an LSTM-based classifier mirroring the tutorial architecture."""
 
-# Print model summary
-print("Model Summary:")
-model.summary()
-print("-" * 30)
+    model = models.Sequential(
+        [
+            layers.Input(shape=(max_length,)),
+            layers.Embedding(input_dim=vocab_size, output_dim=embedding_dim),
+            layers.LSTM(lstm_units),
+            layers.Dense(dense_units, activation="relu"),
+            layers.Dense(1, activation="sigmoid"),
+        ]
+    )
 
-# 4. Train the Model
-print("Training the RNN (LSTM)...")
-history = model.fit(
-    train_data_padded,
-    train_labels,
-    epochs=5, # 5 epochs is sufficient for a good result
-    batch_size=128,
-    validation_split=0.2, # Use 20% of training data for validation
-    verbose=1
-)
-print("Model training complete.")
-print("-" * 30)
+    model.compile(optimizer="adam", loss="binary_crossentropy", metrics=["accuracy"])
+    return model
 
-# 5. Evaluate the Model
-print("Evaluating the model on the test set...")
-test_loss, test_acc = model.evaluate(test_data_padded, test_labels, verbose=2)
 
-print(f"\nTest Accuracy: {test_acc * 100:.2f}%")
-print(f"Test Loss: {test_loss:.4f}")
-print("RNNs with LSTM/GRU cells are very effective for sequence tasks like sentiment analysis.")
-print("-" * 30)
+def train_rnn_model(
+    model: tf.keras.Model,
+    train_data: np.ndarray,
+    train_labels: np.ndarray,
+    *,
+    epochs: int = 5,
+    batch_size: int = 128,
+    validation_split: float = 0.2,
+    verbose: int = 1,
+    shuffle: bool = True,
+) -> tf.keras.callbacks.History:
+    """Fit the RNN and return the training history."""
+
+    history = model.fit(
+        train_data,
+        train_labels,
+        epochs=epochs,
+        batch_size=batch_size,
+        validation_split=validation_split,
+        verbose=verbose,
+        shuffle=shuffle,
+    )
+    return history
+
+
+def evaluate_rnn_model(
+    model: tf.keras.Model,
+    test_data: np.ndarray,
+    test_labels: np.ndarray,
+    *,
+    verbose: int = 2,
+) -> Dict[str, float]:
+    """Evaluate the trained RNN on the held-out test data."""
+
+    return model.evaluate(test_data, test_labels, verbose=verbose, return_dict=True)
+
+
+def run_full_workflow(
+    *,
+    vocab_size: int = 10_000,
+    max_length: int = 256,
+    epochs: int = 5,
+    batch_size: int = 128,
+    verbose: int = 1,
+    seed: int = DEFAULT_SEED,
+) -> Tuple[tf.keras.callbacks.History, Dict[str, float], tf.keras.Model]:
+    """Train and evaluate the IMDB LSTM classifier end-to-end."""
+
+    set_global_seed(seed)
+    (train_data, train_labels), (test_data, test_labels) = prepare_imdb_data(
+        vocab_size=vocab_size, max_length=max_length
+    )
+    model = build_rnn_model(
+        vocab_size=vocab_size, embedding_dim=16, max_length=max_length
+    )
+    history = train_rnn_model(
+        model,
+        train_data,
+        train_labels,
+        epochs=epochs,
+        batch_size=batch_size,
+        validation_split=0.2,
+        verbose=verbose,
+    )
+    metrics = evaluate_rnn_model(model, test_data, test_labels, verbose=verbose)
+    return history, metrics, model
+
+
+if __name__ == "__main__":
+    history, metrics, model = run_full_workflow()
+
+    print("--- RNN (LSTM) for IMDB Sentiment Classification ---")
+    model.summary()
+    print("-" * 30)
+    print("Final training accuracy:", history.history["accuracy"][-1])
+    print("Test metrics:")
+    for name, value in metrics.items():
+        print(f"  {name}: {value:.4f}")

--- a/tests/test_day_46.py
+++ b/tests/test_day_46.py
@@ -1,0 +1,39 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+
+def _load_day46_module():
+    module_path = Path(__file__).resolve().parents[1] / "Day_46_Intro_to_Neural_Networks" / "solutions.py"
+    spec = importlib.util.spec_from_file_location("day46_solutions", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+day46 = _load_day46_module()
+
+
+def test_iris_training_single_epoch():
+    day46.set_global_seed(123)
+    data = day46.prepare_iris_data(random_state=123)
+
+    model = day46.build_iris_model(data.X_train.shape[1], data.y_train.shape[1])
+    history = day46.train_iris_model(
+        model,
+        data.X_train,
+        data.y_train,
+        epochs=1,
+        batch_size=16,
+        validation_split=0.2,
+        verbose=0,
+        shuffle=False,
+    )
+    metrics = day46.evaluate_iris_model(model, data.X_test, data.y_test, verbose=0)
+
+    assert history.params["epochs"] == 1
+    assert len(history.history["loss"]) == 1
+    assert set(metrics.keys()) == {"loss", "accuracy"}
+    assert 0.0 <= metrics["accuracy"] <= 1.0

--- a/tests/test_day_47.py
+++ b/tests/test_day_47.py
@@ -1,0 +1,54 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+import numpy as np
+
+
+def _load_day47_module():
+    module_path = Path(__file__).resolve().parents[1] / "Day_47_Convolutional_Neural_Networks" / "solutions.py"
+    spec = importlib.util.spec_from_file_location("day47_solutions", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+day47 = _load_day47_module()
+
+
+def _fake_mnist_load_data():
+    rng = np.random.default_rng(123)
+
+    def build_split(num_samples: int):
+        images = rng.random((num_samples, 28, 28), dtype=np.float32)
+        labels = rng.integers(0, 10, size=(num_samples,), dtype=np.int64)
+        return images, labels
+
+    train_split = build_split(24)
+    test_split = build_split(12)
+    return train_split, test_split
+
+
+def test_cnn_training_with_synthetic_data(monkeypatch):
+    day47.set_global_seed(7)
+    monkeypatch.setattr(day47.datasets.mnist, "load_data", _fake_mnist_load_data)
+
+    (train_images, train_labels), (test_images, test_labels) = day47.prepare_mnist_data()
+    model = day47.build_cnn_model(input_shape=train_images.shape[1:])
+    day47.compile_cnn_model(model)
+    history = day47.train_cnn_model(
+        model,
+        train_images,
+        train_labels,
+        epochs=1,
+        batch_size=6,
+        validation_data=(test_images, test_labels),
+        verbose=0,
+        shuffle=False,
+    )
+    metrics = day47.evaluate_cnn_model(model, test_images, test_labels, verbose=0)
+
+    assert len(history.history["loss"]) == 1
+    assert set(metrics.keys()) == {"loss", "accuracy"}

--- a/tests/test_day_48.py
+++ b/tests/test_day_48.py
@@ -1,0 +1,62 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+import numpy as np
+
+
+def _load_day48_module():
+    module_path = Path(__file__).resolve().parents[1] / "Day_48_Recurrent_Neural_Networks" / "solutions.py"
+    spec = importlib.util.spec_from_file_location("day48_solutions", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+day48 = _load_day48_module()
+
+
+def _fake_imdb_load_data(num_words=None):
+    rng = np.random.default_rng(321)
+
+    def build_split(num_samples: int):
+        lengths = rng.integers(5, 15, size=num_samples)
+        sequences = [rng.integers(1, 100, size=int(length)).tolist() for length in lengths]
+        labels = rng.integers(0, 2, size=num_samples, dtype=np.int64)
+        return sequences, labels
+
+    train_split = build_split(32)
+    test_split = build_split(16)
+    return train_split, test_split
+
+
+def test_rnn_training_with_stubbed_dataset(monkeypatch):
+    day48.set_global_seed(11)
+    monkeypatch.setattr(day48.datasets.imdb, "load_data", _fake_imdb_load_data)
+
+    (train_data, train_labels), (test_data, test_labels) = day48.prepare_imdb_data(
+        vocab_size=100, max_length=32
+    )
+    model = day48.build_rnn_model(
+        vocab_size=100,
+        embedding_dim=8,
+        max_length=32,
+        lstm_units=16,
+        dense_units=16,
+    )
+    history = day48.train_rnn_model(
+        model,
+        train_data,
+        train_labels,
+        epochs=1,
+        batch_size=8,
+        validation_split=0.2,
+        verbose=0,
+        shuffle=False,
+    )
+    metrics = day48.evaluate_rnn_model(model, test_data, test_labels, verbose=0)
+
+    assert len(history.history["loss"]) == 1
+    assert set(metrics.keys()) == {"loss", "accuracy"}


### PR DESCRIPTION
## Summary
- refactor the Day 46–48 solution scripts into reusable functions for data preparation, model construction, training, and evaluation
- add lightweight pytest smoke tests for each lesson that seed randomness and stub heavy datasets for quick execution
- update the lesson READMEs with the new modular workflow guidance, GPU notes, and instructions for running the tests

## Testing
- pytest tests/test_day_46.py tests/test_day_47.py tests/test_day_48.py -q


------
https://chatgpt.com/codex/tasks/task_b_68da80bbb86c832da84eacd3b191294a