### PR TITLE
Add shared profiling helpers and lesson benchmarks

### DIFF
--- a/Day_24_Pandas_Advanced/README.md
+++ b/Day_24_Pandas_Advanced/README.md
@@ -53,6 +53,17 @@ The script for this lesson, `pandas_adv.py`, has been refactored to place each a
     pytest tests/test_day_24.py
     ```
 
+## 🔬 Profiling the Workflow
+
+Curious about where Pandas spends its time? Launch the shared profiling helper to benchmark the lesson workflow:
+
+```bash
+python Day_24_Pandas_Advanced/profile_pandas_adv.py --mode cprofile
+python Day_24_Pandas_Advanced/profile_pandas_adv.py --mode timeit --repeat 5 --number 3
+```
+
+The first command prints a truncated `cProfile` report. In our baseline run the CSV load (`pandas.read_csv`) and the follow-up cleaning call (`handle_missing_data`) dominated the runtime, confirming that disk I/O and DataFrame materialisation are the hot spots.【732170†L1-L28】 The `timeit` helper highlights how quickly the full workflow executes once the operating system cache is warm—about 3 ms per iteration on average across five repeats.【af7429†L1-L7】 If you plan to reuse the dataset across multiple analyses, load the CSV once and reuse the DataFrame rather than calling `read_csv` inside a tight loop.
+
 ## 💻 Exercises: Day 24
 
 1.  **Load and Inspect:**

--- a/Day_24_Pandas_Advanced/profile_pandas_adv.py
+++ b/Day_24_Pandas_Advanced/profile_pandas_adv.py
@@ -1,0 +1,117 @@
+"""Command-line helpers for profiling the Pandas advanced lesson."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Callable
+
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from mypackage.profiling import print_report, profile_callable
+
+try:  # pragma: no cover - runtime guard for script execution
+    from .pandas_adv import (
+        filter_by_high_revenue,
+        filter_by_product_and_region,
+        handle_missing_data,
+        load_sales_data,
+    )
+except ImportError:  # pragma: no cover - allows ``python profile_pandas_adv.py``
+    CURRENT_DIR = Path(__file__).resolve().parent
+    if str(CURRENT_DIR) not in sys.path:
+        sys.path.append(str(CURRENT_DIR))
+    from pandas_adv import (  # type: ignore  # pylint: disable=import-error
+        filter_by_high_revenue,
+        filter_by_product_and_region,
+        handle_missing_data,
+        load_sales_data,
+    )
+
+
+def build_pipeline(
+    data_path: Path, threshold: float, product: str, region: str, missing_strategy: str
+) -> Callable[[], None]:
+    """Return a callable that executes the common lesson workflow."""
+
+    def pipeline() -> None:
+        df = load_sales_data(str(data_path))
+        if df is None:
+            raise FileNotFoundError(f"CSV not found at {data_path}")
+
+        filter_by_high_revenue(df, threshold)
+        filter_by_product_and_region(df, product, region)
+        handle_missing_data(df, strategy=missing_strategy)
+
+    return pipeline
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=("cprofile", "timeit"),
+        default="cprofile",
+        help="Profiling backend to use (default: cprofile)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=50_000,
+        help="Revenue threshold used in filter_by_high_revenue",
+    )
+    parser.add_argument(
+        "--product",
+        default="Laptop",
+        help="Product name used for filter_by_product_and_region",
+    )
+    parser.add_argument(
+        "--region",
+        default="North",
+        help="Region used for filter_by_product_and_region",
+    )
+    parser.add_argument(
+        "--missing-strategy",
+        choices=("drop", "fill"),
+        default="fill",
+        help="Strategy used when calling handle_missing_data",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=5,
+        help="Number of timing repeats when --mode=timeit",
+    )
+    parser.add_argument(
+        "--number",
+        type=int,
+        default=1,
+        help="Number of calls per repeat when --mode=timeit",
+    )
+    args = parser.parse_args()
+
+    data_path = Path(__file__).resolve().parent / "sales_data.csv"
+    pipeline = build_pipeline(
+        data_path=data_path,
+        threshold=args.threshold,
+        product=args.product,
+        region=args.region,
+        missing_strategy=args.missing_strategy,
+    )
+
+    profile_report, timing_report = profile_callable(
+        pipeline,
+        mode=args.mode,
+        repeat=args.repeat,
+        number=args.number,
+    )
+    print_report(profile_report=profile_report, timing_report=timing_report)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/Day_30_Web_Scraping/README.md
+++ b/Day_30_Web_Scraping/README.md
@@ -47,6 +47,17 @@ paragraphs = soup.find_all('p')
 first_paragraph_text = paragraphs[0].get_text()
 ```
 
+## 🔬 Profiling the Scraper
+
+Profiling helps you spot whether networking or HTML parsing is the bottleneck. Two helper commands wire into the shared profiler:
+
+```bash
+python Day_30_Web_Scraping/profile_web_scraping.py --mode cprofile
+python Day_30_Web_Scraping/profile_web_scraping.py --mode timeit --local-html Day_30_Web_Scraping/books_sample.html --repeat 5 --number 3
+```
+
+The `cProfile` output shows that almost all time is spent inside `requests.Session.get`—network I/O dominates the runtime, so batching requests or caching responses offers the biggest win.【ad83b3†L1-L29】 For deterministic timing, use the saved `books_sample.html` page (refresh it with `curl http://books.toscrape.com/ -o Day_30_Web_Scraping/books_sample.html`). Parsing that local file takes ~0.03 seconds per iteration across five repeats, letting you focus on BeautifulSoup performance without hitting the network.【de293a†L1-L7】 Reusing a single `requests.Session` and avoiding repeated downloads can dramatically cut the cost when scraping multiple pages.
+
 ## 💻 Exercises: Day 30
 
 For these exercises, we will scrape the website `http://books.toscrape.com/`, a site specifically designed for scraping practice.

--- a/Day_30_Web_Scraping/books_sample.html
+++ b/Day_30_Web_Scraping/books_sample.html
@@ -1,0 +1,2240 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]>      <html lang="en-us" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html lang="en-us" class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html lang="en-us" class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="en-us" class="no-js"> <!--<![endif]-->
+    <head>
+        <title>
+    All products | Books to Scrape - Sandbox
+</title>
+
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+        <meta name="created" content="24th Jun 2016 09:29" />
+        <meta name="description" content="" />
+        <meta name="viewport" content="width=device-width" />
+        <meta name="robots" content="NOARCHIVE,NOCACHE" />
+
+        <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
+        <!--[if lt IE 9]>
+        <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
+        <![endif]-->
+
+        
+            <link rel="shortcut icon" href="static/oscar/favicon.ico" />
+        
+
+        
+        
+    
+    
+        <link rel="stylesheet" type="text/css" href="static/oscar/css/styles.css" />
+    
+    <link rel="stylesheet" href="static/oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.css" />
+    <link rel="stylesheet" type="text/css" href="static/oscar/css/datetimepicker.css" />
+
+
+        
+        
+
+        
+
+        
+            
+            
+
+        
+    </head>
+
+    <body id="default" class="default">
+        
+        
+    
+    
+    <header class="header container-fluid">
+        <div class="page_inner">
+            <div class="row">
+                <div class="col-sm-8 h1"><a href="index.html">Books to Scrape</a><small> We love being scraped!</small>
+</div>
+
+                
+            </div>
+        </div>
+    </header>
+
+    
+    
+<div class="container-fluid page">
+    <div class="page_inner">
+        
+    <ul class="breadcrumb">
+        <li>
+            <a href="index.html">Home</a>
+        </li>
+        <li class="active">All products</li>
+    </ul>
+
+        <div class="row">
+
+            <aside class="sidebar col-sm-4 col-md-3">
+                
+                <div id="promotions_left">
+                    
+                </div>
+                
+    
+    
+        
+        <div class="side_categories">
+            <ul class="nav nav-list">
+                
+                    <li>
+                        <a href="catalogue/category/books_1/index.html">
+                            
+                                Books
+                            
+                        </a>
+
+                        <ul>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/travel_2/index.html">
+                            
+                                Travel
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/mystery_3/index.html">
+                            
+                                Mystery
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/historical-fiction_4/index.html">
+                            
+                                Historical Fiction
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/sequential-art_5/index.html">
+                            
+                                Sequential Art
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/classics_6/index.html">
+                            
+                                Classics
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/philosophy_7/index.html">
+                            
+                                Philosophy
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/romance_8/index.html">
+                            
+                                Romance
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/womens-fiction_9/index.html">
+                            
+                                Womens Fiction
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/fiction_10/index.html">
+                            
+                                Fiction
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/childrens_11/index.html">
+                            
+                                Childrens
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/religion_12/index.html">
+                            
+                                Religion
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/nonfiction_13/index.html">
+                            
+                                Nonfiction
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/music_14/index.html">
+                            
+                                Music
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/default_15/index.html">
+                            
+                                Default
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/science-fiction_16/index.html">
+                            
+                                Science Fiction
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/sports-and-games_17/index.html">
+                            
+                                Sports and Games
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/add-a-comment_18/index.html">
+                            
+                                Add a comment
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/fantasy_19/index.html">
+                            
+                                Fantasy
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/new-adult_20/index.html">
+                            
+                                New Adult
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/young-adult_21/index.html">
+                            
+                                Young Adult
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/science_22/index.html">
+                            
+                                Science
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/poetry_23/index.html">
+                            
+                                Poetry
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/paranormal_24/index.html">
+                            
+                                Paranormal
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/art_25/index.html">
+                            
+                                Art
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/psychology_26/index.html">
+                            
+                                Psychology
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/autobiography_27/index.html">
+                            
+                                Autobiography
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/parenting_28/index.html">
+                            
+                                Parenting
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/adult-fiction_29/index.html">
+                            
+                                Adult Fiction
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/humor_30/index.html">
+                            
+                                Humor
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/horror_31/index.html">
+                            
+                                Horror
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/history_32/index.html">
+                            
+                                History
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/food-and-drink_33/index.html">
+                            
+                                Food and Drink
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/christian-fiction_34/index.html">
+                            
+                                Christian Fiction
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/business_35/index.html">
+                            
+                                Business
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/biography_36/index.html">
+                            
+                                Biography
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/thriller_37/index.html">
+                            
+                                Thriller
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/contemporary_38/index.html">
+                            
+                                Contemporary
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/spirituality_39/index.html">
+                            
+                                Spirituality
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/academic_40/index.html">
+                            
+                                Academic
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/self-help_41/index.html">
+                            
+                                Self Help
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/historical_42/index.html">
+                            
+                                Historical
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/christian_43/index.html">
+                            
+                                Christian
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/suspense_44/index.html">
+                            
+                                Suspense
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/short-stories_45/index.html">
+                            
+                                Short Stories
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/novels_46/index.html">
+                            
+                                Novels
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/health_47/index.html">
+                            
+                                Health
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/politics_48/index.html">
+                            
+                                Politics
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/cultural_49/index.html">
+                            
+                                Cultural
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/erotica_50/index.html">
+                            
+                                Erotica
+                            
+                        </a>
+
+                        </li>
+                        
+                
+                    <li>
+                        <a href="catalogue/category/books/crime_51/index.html">
+                            
+                                Crime
+                            
+                        </a>
+
+                        </li>
+                        
+                            </ul></li>
+                        
+                
+            </ul>
+        </div>
+    
+    
+
+            </aside>
+
+            <div class="col-sm-8 col-md-9">
+                
+                <div class="page-header action">
+                    <h1>All products</h1>
+                </div>
+                
+
+                
+
+
+
+<div id="messages">
+
+</div>
+
+
+                <div id="promotions">
+                    
+                </div>
+
+                
+    <form method="get" class="form-horizontal">
+        
+        <div style="display:none">
+            
+            
+        </div>
+
+        
+            
+                
+                    <strong>1000</strong> results - showing <strong>1</strong> to <strong>20</strong>.
+                
+            
+            
+        
+    </form>
+    
+        <section>
+            <div class="alert alert-warning" role="alert"><strong>Warning!</strong> This is a demo website for web scraping purposes. Prices and ratings here were randomly assigned and have no real meaning.</div>
+
+            <div>
+                <ol class="row">
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/a-light-in-the-attic_1000/index.html"><img src="media/cache/2c/da/2cdad67c44b002e7ead0cc35693c0e8b.jpg" alt="A Light in the Attic" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating Three">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/a-light-in-the-attic_1000/index.html" title="A Light in the Attic">A Light in the ...</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£51.77</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/tipping-the-velvet_999/index.html"><img src="media/cache/26/0c/260c6ae16bce31c8f8c95daddd9f4a1c.jpg" alt="Tipping the Velvet" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating One">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/tipping-the-velvet_999/index.html" title="Tipping the Velvet">Tipping the Velvet</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£53.74</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/soumission_998/index.html"><img src="media/cache/3e/ef/3eef99c9d9adef34639f510662022830.jpg" alt="Soumission" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating One">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/soumission_998/index.html" title="Soumission">Soumission</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£50.10</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/sharp-objects_997/index.html"><img src="media/cache/32/51/3251cf3a3412f53f339e42cac2134093.jpg" alt="Sharp Objects" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating Four">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/sharp-objects_997/index.html" title="Sharp Objects">Sharp Objects</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£47.82</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/sapiens-a-brief-history-of-humankind_996/index.html"><img src="media/cache/be/a5/bea5697f2534a2f86a3ef27b5a8c12a6.jpg" alt="Sapiens: A Brief History of Humankind" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating Five">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/sapiens-a-brief-history-of-humankind_996/index.html" title="Sapiens: A Brief History of Humankind">Sapiens: A Brief History ...</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£54.23</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/the-requiem-red_995/index.html"><img src="media/cache/68/33/68339b4c9bc034267e1da611ab3b34f8.jpg" alt="The Requiem Red" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating One">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/the-requiem-red_995/index.html" title="The Requiem Red">The Requiem Red</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£22.65</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/the-dirty-little-secrets-of-getting-your-dream-job_994/index.html"><img src="media/cache/92/27/92274a95b7c251fea59a2b8a78275ab4.jpg" alt="The Dirty Little Secrets of Getting Your Dream Job" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating Four">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/the-dirty-little-secrets-of-getting-your-dream-job_994/index.html" title="The Dirty Little Secrets of Getting Your Dream Job">The Dirty Little Secrets ...</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£33.34</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/the-coming-woman-a-novel-based-on-the-life-of-the-infamous-feminist-victoria-woodhull_993/index.html"><img src="media/cache/3d/54/3d54940e57e662c4dd1f3ff00c78cc64.jpg" alt="The Coming Woman: A Novel Based on the Life of the Infamous Feminist, Victoria Woodhull" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating Three">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/the-coming-woman-a-novel-based-on-the-life-of-the-infamous-feminist-victoria-woodhull_993/index.html" title="The Coming Woman: A Novel Based on the Life of the Infamous Feminist, Victoria Woodhull">The Coming Woman: A ...</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£17.93</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/the-boys-in-the-boat-nine-americans-and-their-epic-quest-for-gold-at-the-1936-berlin-olympics_992/index.html"><img src="media/cache/66/88/66883b91f6804b2323c8369331cb7dd1.jpg" alt="The Boys in the Boat: Nine Americans and Their Epic Quest for Gold at the 1936 Berlin Olympics" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating Four">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/the-boys-in-the-boat-nine-americans-and-their-epic-quest-for-gold-at-the-1936-berlin-olympics_992/index.html" title="The Boys in the Boat: Nine Americans and Their Epic Quest for Gold at the 1936 Berlin Olympics">The Boys in the ...</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£22.60</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/the-black-maria_991/index.html"><img src="media/cache/58/46/5846057e28022268153beff6d352b06c.jpg" alt="The Black Maria" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating One">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/the-black-maria_991/index.html" title="The Black Maria">The Black Maria</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£52.15</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/starving-hearts-triangular-trade-trilogy-1_990/index.html"><img src="media/cache/be/f4/bef44da28c98f905a3ebec0b87be8530.jpg" alt="Starving Hearts (Triangular Trade Trilogy, #1)" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating Two">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/starving-hearts-triangular-trade-trilogy-1_990/index.html" title="Starving Hearts (Triangular Trade Trilogy, #1)">Starving Hearts (Triangular Trade ...</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£13.99</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/shakespeares-sonnets_989/index.html"><img src="media/cache/10/48/1048f63d3b5061cd2f424d20b3f9b666.jpg" alt="Shakespeare&#39;s Sonnets" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating Four">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/shakespeares-sonnets_989/index.html" title="Shakespeare&#39;s Sonnets">Shakespeare&#39;s Sonnets</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£20.66</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/set-me-free_988/index.html"><img src="media/cache/5b/88/5b88c52633f53cacf162c15f4f823153.jpg" alt="Set Me Free" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating Five">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/set-me-free_988/index.html" title="Set Me Free">Set Me Free</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£17.46</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/scott-pilgrims-precious-little-life-scott-pilgrim-1_987/index.html"><img src="media/cache/94/b1/94b1b8b244bce9677c2f29ccc890d4d2.jpg" alt="Scott Pilgrim&#39;s Precious Little Life (Scott Pilgrim #1)" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating Five">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/scott-pilgrims-precious-little-life-scott-pilgrim-1_987/index.html" title="Scott Pilgrim&#39;s Precious Little Life (Scott Pilgrim #1)">Scott Pilgrim&#39;s Precious Little ...</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£52.29</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/rip-it-up-and-start-again_986/index.html"><img src="media/cache/81/c4/81c4a973364e17d01f217e1188253d5e.jpg" alt="Rip it Up and Start Again" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating Five">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/rip-it-up-and-start-again_986/index.html" title="Rip it Up and Start Again">Rip it Up and ...</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£35.02</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/our-band-could-be-your-life-scenes-from-the-american-indie-underground-1981-1991_985/index.html"><img src="media/cache/54/60/54607fe8945897cdcced0044103b10b6.jpg" alt="Our Band Could Be Your Life: Scenes from the American Indie Underground, 1981-1991" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating Three">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/our-band-could-be-your-life-scenes-from-the-american-indie-underground-1981-1991_985/index.html" title="Our Band Could Be Your Life: Scenes from the American Indie Underground, 1981-1991">Our Band Could Be ...</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£57.25</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/olio_984/index.html"><img src="media/cache/55/33/553310a7162dfbc2c6d19a84da0df9e1.jpg" alt="Olio" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating One">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/olio_984/index.html" title="Olio">Olio</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£23.88</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/mesaerion-the-best-science-fiction-stories-1800-1849_983/index.html"><img src="media/cache/09/a3/09a3aef48557576e1a85ba7efea8ecb7.jpg" alt="Mesaerion: The Best Science Fiction Stories 1800-1849" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating One">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/mesaerion-the-best-science-fiction-stories-1800-1849_983/index.html" title="Mesaerion: The Best Science Fiction Stories 1800-1849">Mesaerion: The Best Science ...</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£37.59</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/libertarianism-for-beginners_982/index.html"><img src="media/cache/0b/bc/0bbcd0a6f4bcd81ccb1049a52736406e.jpg" alt="Libertarianism for Beginners" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating Two">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/libertarianism-for-beginners_982/index.html" title="Libertarianism for Beginners">Libertarianism for Beginners</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£51.33</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                        <li class="col-xs-6 col-sm-4 col-md-3 col-lg-3">
+
+
+
+
+
+
+    <article class="product_pod">
+        
+            <div class="image_container">
+                
+                    
+                    <a href="catalogue/its-only-the-himalayas_981/index.html"><img src="media/cache/27/a5/27a53d0bb95bdd88288eaf66c9230d7e.jpg" alt="It&#39;s Only the Himalayas" class="thumbnail"></a>
+                    
+                
+            </div>
+        
+
+        
+            
+                <p class="star-rating Two">
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                    <i class="icon-star"></i>
+                </p>
+            
+        
+
+        
+            <h3><a href="catalogue/its-only-the-himalayas_981/index.html" title="It&#39;s Only the Himalayas">It&#39;s Only the Himalayas</a></h3>
+        
+
+        
+            <div class="product_price">
+                
+
+
+
+
+
+
+    
+        <p class="price_color">£45.17</p>
+    
+
+<p class="instock availability">
+    <i class="icon-ok"></i>
+    
+        In stock
+    
+</p>
+
+                
+                    
+
+
+
+
+
+
+    
+    <form>
+        <button type="submit" class="btn btn-primary btn-block" data-loading-text="Adding...">Add to basket</button>
+    </form>
+
+
+                
+            </div>
+        
+    </article>
+
+</li>
+                    
+                </ol>
+                
+
+
+
+    <div>
+        <ul class="pager">
+            
+            <li class="current">
+            
+                Page 1 of 50
+            
+            </li>
+            
+                <li class="next"><a href="catalogue/page-2.html">next</a></li>
+            
+        </ul>
+    </div>
+
+
+            </div>
+        </section>
+    
+
+
+            </div>
+
+        </div><!-- /row -->
+    </div><!-- /page_inner -->
+</div><!-- /container-fluid -->
+
+
+    
+<footer class="footer container-fluid">
+    
+        
+    
+</footer>
+
+
+        
+        
+  
+            <!-- jQuery -->
+            <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+            <script>window.jQuery || document.write('<script src="static/oscar/js/jquery/jquery-1.9.1.min.js"><\/script>')</script>
+        
+  
+
+
+        
+        
+    
+        
+    <!-- Twitter Bootstrap -->
+    <script type="text/javascript" src="static/oscar/js/bootstrap3/bootstrap.min.js"></script>
+    <!-- Oscar -->
+    <script src="static/oscar/js/oscar/ui.js" type="text/javascript" charset="utf-8"></script>
+
+    <script src="static/oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.js" type="text/javascript" charset="utf-8"></script>
+    <script src="static/oscar/js/bootstrap-datetimepicker/locales/bootstrap-datetimepicker.all.js" type="text/javascript" charset="utf-8"></script>
+
+
+        
+        
+    
+
+    
+
+
+        
+        <script type="text/javascript">
+            $(function() {
+                
+    
+    
+    oscar.init();
+
+    oscar.search.init();
+
+            });
+        </script>
+
+        
+        <!-- Version: N/A -->
+        
+    </body>
+</html>

--- a/Day_30_Web_Scraping/profile_web_scraping.py
+++ b/Day_30_Web_Scraping/profile_web_scraping.py
@@ -1,0 +1,90 @@
+"""Profile the book scraping workflow used in the web scraping lesson."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Callable
+
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from mypackage.profiling import print_report, profile_callable
+
+try:  # pragma: no cover - runtime guard for direct execution
+    from .web_scraping import URL, process_book_data, scrape_books
+except ImportError:  # pragma: no cover - allows ``python profile_web_scraping.py``
+    CURRENT_DIR = Path(__file__).resolve().parent
+    if str(CURRENT_DIR) not in sys.path:
+        sys.path.append(str(CURRENT_DIR))
+    from web_scraping import URL, process_book_data, scrape_books  # type: ignore
+
+
+def build_pipeline(url: str, html_path: Path | None) -> Callable[[], None]:
+    """Return a callable that performs the scraping workflow."""
+
+    if html_path is not None:
+        html_bytes = html_path.read_bytes()
+
+        def pipeline() -> None:
+            process_book_data(html_bytes)
+
+    else:
+
+        def pipeline() -> None:
+            scrape_books(url)
+
+    return pipeline
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=("cprofile", "timeit"),
+        default="cprofile",
+        help="Profiling backend to use (default: cprofile)",
+    )
+    parser.add_argument(
+        "--url",
+        default=URL,
+        help="Target URL to scrape when not using --local-html",
+    )
+    parser.add_argument(
+        "--local-html",
+        type=Path,
+        help="Optional path to a saved HTML page for offline profiling",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=5,
+        help="Number of timing repeats when --mode=timeit",
+    )
+    parser.add_argument(
+        "--number",
+        type=int,
+        default=1,
+        help="Number of calls per repeat when --mode=timeit",
+    )
+    args = parser.parse_args()
+
+    if args.mode == "timeit" and args.local_html is None:
+        raise SystemExit("--mode=timeit requires --local-html to avoid repeated network calls")
+
+    pipeline = build_pipeline(url=args.url, html_path=args.local_html)
+    profile_report, timing_report = profile_callable(
+        pipeline,
+        mode=args.mode,
+        repeat=args.repeat,
+        number=args.number,
+    )
+    print_report(profile_report=profile_report, timing_report=timing_report)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/mypackage/profiling.py
+++ b/mypackage/profiling.py
@@ -1,0 +1,175 @@
+"""Utility helpers for profiling functions across the project.
+
+This module provides lightweight wrappers around :mod:`cProfile` and
+``timeit`` so that lesson scripts can share consistent profiling
+behaviour.  The helpers intentionally keep the public API small and
+return rich data structures that make it easy to surface results in
+command-line tools or tests.
+
+Example
+-------
+>>> from mypackage import profiling
+>>> def slow_function():
+...     return sum(range(1000))
+>>> report = profiling.profile_with_cprofile(slow_function)
+>>> "sum" in report.text
+True
+
+The :func:`profile_with_cprofile` helper returns a :class:`ProfileReport`
+dataclass which includes both the raw result of the profiled callable and
+the formatted text output from :mod:`pstats`.  :func:`time_callable`
+returns a :class:`TimingReport` with summary statistics that can be used
+for documentation or quick regressions checks.
+"""
+
+from __future__ import annotations
+
+import cProfile
+import io
+import statistics
+import timeit
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, Tuple
+
+import pstats
+
+
+CallableType = Callable[..., Any]
+
+
+@dataclass
+class ProfileReport:
+    """Container for the results of a :mod:`cProfile` run."""
+
+    result: Any
+    stats: pstats.Stats
+    text: str
+
+
+@dataclass
+class TimingReport:
+    """Summary statistics from a :func:`timeit.Timer.repeat` run."""
+
+    runs: Tuple[float, ...]
+    repeat: int
+    number: int
+    best: float
+    average: float
+
+    def format(self) -> str:
+        """Return a human readable representation of the timing runs."""
+
+        lines = [
+            "Timing summary (seconds)",
+            f"  repeats: {self.repeat}",
+            f"  per-run calls: {self.number}",
+            f"  best: {self.best:.6f}",
+            f"  average: {self.average:.6f}",
+            "  raw runs: " + ", ".join(f"{run:.6f}" for run in self.runs),
+        ]
+        return "\n".join(lines)
+
+
+def profile_with_cprofile(
+    func: CallableType,
+    *args: Any,
+    sort_by: str = "cumulative",
+    print_top: Optional[int] = 30,
+    **kwargs: Any,
+) -> ProfileReport:
+    """Profile ``func`` with :mod:`cProfile` and return a report.
+
+    Parameters
+    ----------
+    func:
+        The callable to profile.
+    *args, **kwargs:
+        Arguments forwarded to the callable.
+    sort_by:
+        Field name recognised by :meth:`pstats.Stats.sort_stats`.
+    print_top:
+        When provided, only the top ``n`` lines will be printed.  ``None``
+        disables trimming.
+    """
+
+    profiler = cProfile.Profile()
+    result = profiler.runcall(func, *args, **kwargs)
+
+    stream = io.StringIO()
+    stats = pstats.Stats(profiler, stream=stream).strip_dirs().sort_stats(sort_by)
+    if print_top is None:
+        stats.print_stats()
+    else:
+        stats.print_stats(print_top)
+    text = stream.getvalue()
+    return ProfileReport(result=result, stats=stats, text=text)
+
+
+def time_callable(
+    func: CallableType,
+    *args: Any,
+    number: int = 1,
+    repeat: int = 5,
+    **kwargs: Any,
+) -> TimingReport:
+    """Benchmark ``func`` using :func:`timeit.Timer.repeat`.
+
+    The callable will be executed ``repeat`` times with ``number``
+    invocations per timing run.  Results are returned as a
+    :class:`TimingReport` which exposes helpful summary statistics.
+    """
+
+    def _target() -> Any:
+        return func(*args, **kwargs)
+
+    timer = timeit.Timer(_target)
+    runs = tuple(timer.repeat(repeat=repeat, number=number))
+    best = min(runs) / number
+    average = statistics.fmean(runs) / number
+    return TimingReport(runs=runs, repeat=repeat, number=number, best=best, average=average)
+
+
+def profile_callable(
+    func: CallableType,
+    *args: Any,
+    mode: str = "cprofile",
+    number: int = 1,
+    repeat: int = 5,
+    **kwargs: Any,
+) -> Tuple[Optional[ProfileReport], Optional[TimingReport]]:
+    """Convenience helper that dispatches to profiling or timing tools.
+
+    Parameters
+    ----------
+    mode:
+        Either ``"cprofile"`` (default) or ``"timeit"``.  When
+        ``"cprofile"`` is used only the :class:`ProfileReport` is
+        populated; when ``"timeit"`` only the :class:`TimingReport` is
+        returned.
+    """
+
+    mode_normalised = mode.lower()
+    if mode_normalised == "cprofile":
+        return profile_with_cprofile(func, *args, **kwargs), None
+    if mode_normalised == "timeit":
+        return None, time_callable(func, *args, number=number, repeat=repeat, **kwargs)
+    raise ValueError("mode must be either 'cprofile' or 'timeit'")
+
+
+def print_report(
+    profile_report: Optional[ProfileReport] = None,
+    timing_report: Optional[TimingReport] = None,
+) -> None:
+    """Pretty-print any provided reports to ``stdout``.
+
+    The helper keeps CLI scripts tidy by centralising formatting logic in
+    one place.
+    """
+
+    if profile_report is not None:
+        print("\n=== cProfile report ===")
+        print(profile_report.text.rstrip())
+    if timing_report is not None:
+        print("\n=== timeit summary ===")
+        print(timing_report.format())
+


### PR DESCRIPTION
## Summary
- add a reusable `mypackage.profiling` helper that wraps cProfile and timeit
- add lesson-specific profiling entry points for the Day 24 and Day 30 workflows, including an offline HTML snapshot for scraping
- document the profiling commands, sample findings, and optimizations in each lesson README

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68da882fcc30832db9d4ecfbb216258d