### PR TITLE
Add interactive Plotly visuals for Day 24 and Day 26 lessons

### DIFF
--- a/Day_24_Pandas_Advanced/README.md
+++ b/Day_24_Pandas_Advanced/README.md
@@ -53,6 +53,25 @@ The script for this lesson, `pandas_adv.py`, has been refactored to place each a
     pytest tests/test_day_24.py
     ```
 
+## ✨ Interactive Plotly Visualisations
+
+Plotly chart builders now sit alongside the existing data-wrangling helpers:
+
+* `build_revenue_by_region_bar_chart()` aggregates revenue totals for each region and renders an interactive bar chart.
+* `build_units_vs_price_scatter()` plots price sensitivity using `Units Sold` on the y-axis and encodes the point colour scale for quick outlier detection.
+
+To experiment locally:
+
+1. Install notebook dependencies if you have not done so already:
+   ```bash
+   pip install notebook plotly
+   ```
+2. Launch Jupyter from the project root and open the companion notebook:
+   ```bash
+   jupyter notebook Day_24_Pandas_Advanced/pandas_adv_interactive.ipynb
+   ```
+3. Run the cells to compare the quick Matplotlib baseline with the interactive Plotly versions. Hover, filter, and export the Plotly figures directly from the notebook toolbar.
+
 ## 🔬 Profiling the Workflow
 
 Curious about where Pandas spends its time? Launch the shared profiling helper to benchmark the lesson workflow:

--- a/Day_24_Pandas_Advanced/pandas_adv_interactive.ipynb
+++ b/Day_24_Pandas_Advanced/pandas_adv_interactive.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Day 24 · Static vs. Interactive Visuals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook complements the refactored `pandas_adv.py` module. It contrasts a quick Matplotlib chart with the new Plotly helpers so you can experiment with both static and interactive views of the same sales dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "\n",
+    "from Day_24_Pandas_Advanced.pandas_adv import (\n",
+    "    build_revenue_by_region_bar_chart,\n",
+    "    build_units_vs_price_scatter,\n",
+    "    load_sales_data,\n",
+    ")\n",
+    "\n",
+    "DATA_PATH = Path('sales_data.csv')\n",
+    "df = load_sales_data(str(DATA_PATH))\n",
+    "if df is None:\n",
+    "    df = pd.read_csv(DATA_PATH)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Static baseline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.style.use('ggplot')\n",
+    "regional_revenue = df.groupby('Region')['Revenue'].sum().sort_values(ascending=False)\n",
+    "ax = regional_revenue.plot(kind='bar', figsize=(8, 4), title='Revenue by Region (Static)')\n",
+    "ax.set_ylabel('Total revenue')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interactive upgrades"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = build_revenue_by_region_bar_chart(df)\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scatter = build_units_vs_price_scatter(df)\n",
+    "scatter"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Day_26_Statistics/README.md
+++ b/Day_26_Statistics/README.md
@@ -25,6 +25,10 @@ computation from presentation.
      sales fields.
    * `run_ab_test()` wraps SciPy's independent t-test and reports whether the
      difference is statistically significant.
+   * `build_revenue_distribution_chart()` visualises the revenue histogram as an
+     interactive Plotly figure.
+   * `build_correlation_heatmap()` turns the correlation matrix into an
+     interactive heatmap with hover labels and colourbar explanations.
 2. **Run the Script:** From the project root, execute the module to see the
    printed analysis that the helpers power.
    ```bash
@@ -35,6 +39,23 @@ computation from presentation.
    ```bash
    pytest tests/test_day_26.py
    ```
+
+## 🧪 Explore the Interactive Notebooks
+
+Static Matplotlib previews are great for reports, but sometimes you need to
+hover over exact values or export a filtered view. Open the companion notebook
+to try the Plotly charts side by side with their static counterparts:
+
+1. Install notebook dependencies if you skipped them earlier:
+   ```bash
+   pip install notebook plotly
+   ```
+2. Launch Jupyter and open the walkthrough:
+   ```bash
+   jupyter notebook Day_26_Statistics/statistics_interactive.ipynb
+   ```
+3. Execute the notebook cells to compare the summary statistics, static plots,
+   and the new interactive revenue distribution and correlation heatmap.
 
 🎉 **Great job!** With these reusable statistics utilities you can move from
 simple summaries to rigorous, testable insights in your analyses.

--- a/Day_26_Statistics/statistics_interactive.ipynb
+++ b/Day_26_Statistics/statistics_interactive.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Day 26 \u00b7 Statistics with Interactive Visuals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Revisit the statistics helpers from `stats.py` and compare their numerical summaries with new Plotly-powered visualisations. The same dataset used earlier in the course is repurposed here to keep the story consistent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "\n",
+    "from Day_26_Statistics.stats import (\n",
+    "    build_correlation_heatmap,\n",
+    "    build_revenue_distribution_chart,\n",
+    "    compute_correlations,\n",
+    "    load_sales_data,\n",
+    ")\n",
+    "\n",
+    "DATA_PATH = Path('..') / 'Day_24_Pandas_Advanced' / 'sales_data.csv'\n",
+    "df = load_sales_data(DATA_PATH)\n",
+    "if df.empty:\n",
+    "    df = pd.read_csv(DATA_PATH)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Static checks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(8, 4))\n",
+    "plt.hist(df['Revenue'], bins=15, color='#636EFA', alpha=0.7)\n",
+    "plt.title('Revenue Distribution (Static Histogram)')\n",
+    "plt.xlabel('Revenue')\n",
+    "plt.ylabel('Frequency')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "correlations = compute_correlations(df)\n",
+    "fig, ax = plt.subplots(figsize=(6, 4))\n",
+    "im = ax.imshow(correlations, cmap='Blues', vmin=-1, vmax=1)\n",
+    "ax.set_xticks(range(len(correlations.columns)))\n",
+    "ax.set_xticklabels(correlations.columns, rotation=45, ha='right')\n",
+    "ax.set_yticks(range(len(correlations.index)))\n",
+    "ax.set_yticklabels(correlations.index)\n",
+    "ax.set_title('Correlation Heatmap (Static)')\n",
+    "fig.colorbar(im, ax=ax, label='Correlation')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interactive counterparts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interactive_hist = build_revenue_distribution_chart(df)\n",
+    "interactive_hist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interactive_heatmap = build_correlation_heatmap(df)\n",
+    "interactive_heatmap"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_day_24.py
+++ b/tests/test_day_24.py
@@ -8,6 +8,8 @@ import numpy as np
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from Day_24_Pandas_Advanced.pandas_adv import (
+    build_revenue_by_region_bar_chart,
+    build_units_vs_price_scatter,
     select_by_label,
     select_by_position,
     filter_by_high_revenue,
@@ -22,7 +24,9 @@ def sample_dataframe():
         'Date': ['2023-01-01', '2023-01-01', '2023-01-02', '2023-01-03'],
         'Region': ['North', 'South', 'North', 'South'],
         'Product': ['Laptop', 'Mouse', 'Laptop', 'Keyboard'],
-        'Revenue': [60000, 1000, np.nan, 3000]
+        'Units Sold': [90, 150, 110, 75],
+        'Price': [1200, 8, 950, 40],
+        'Revenue': [60000, 1200, np.nan, 3000]
     }
     return pd.DataFrame(data)
 
@@ -66,3 +70,28 @@ def test_handle_missing_data_fill(sample_dataframe):
     assert df_filled.loc[2, 'Revenue'] == pytest.approx(21333.33, rel=1e-2)
     # Check that other values are unchanged
     assert df_filled.loc[0, 'Revenue'] == 60000
+
+
+def test_build_revenue_by_region_bar_chart_returns_sorted_bars(sample_dataframe):
+    df = sample_dataframe.copy()
+    df.loc[3, "Revenue"] = 4000
+
+    figure = build_revenue_by_region_bar_chart(df)
+
+    assert figure.data[0].type == "bar"
+    assert list(figure.data[0].x) == ["North", "South"]
+    assert list(figure.data[0].y) == [60000, 5200]
+
+
+def test_build_units_vs_price_scatter_uses_required_columns(sample_dataframe):
+    df = sample_dataframe.copy()
+    df.loc[2, "Units Sold"] = 125
+    df.loc[2, "Price"] = 150
+
+    figure = build_units_vs_price_scatter(df)
+    scatter = figure.data[0]
+
+    assert scatter.type == "scatter"
+    assert scatter.mode == "markers"
+    assert list(scatter.x) == df["Price"].tolist()
+    assert list(scatter.y) == df["Units Sold"].tolist()

--- a/tests/test_day_26.py
+++ b/tests/test_day_26.py
@@ -9,6 +9,8 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from Day_26_Statistics.stats import (  # noqa: E402
+    build_correlation_heatmap,
+    build_revenue_distribution_chart,
     compute_correlations,
     load_sales_data,
     run_ab_test,
@@ -71,3 +73,34 @@ def test_run_ab_test_returns_ttest_metrics():
     assert results["p_value"] == pytest.approx(0.0006575, rel=1e-4)
     assert results["is_significant"] is True
     assert results["alpha"] == 0.05
+
+
+def test_build_revenue_distribution_chart_returns_histogram():
+    df = pd.DataFrame({"Revenue": [100.0, 150.0, 200.0, 200.0]})
+
+    figure = build_revenue_distribution_chart(df)
+
+    assert figure.data, "Expected histogram trace to be present"
+    histogram = figure.data[0]
+    assert histogram.type == "histogram"
+    assert list(histogram.x) == df["Revenue"].tolist()
+
+
+def test_build_correlation_heatmap_uses_compute_correlations():
+    df = pd.DataFrame(
+        {
+            "Units Sold": [10, 20, 30, 40],
+            "Price": [5.0, 6.0, 7.0, 8.0],
+            "Revenue": [50.0, 120.0, 210.0, 320.0],
+        }
+    )
+
+    figure = build_correlation_heatmap(df)
+    heatmap = figure.data[0]
+
+    correlations = compute_correlations(df)
+
+    assert heatmap.type == "heatmap"
+    assert list(heatmap.x) == list(correlations.columns)
+    assert list(heatmap.y) == list(correlations.index)
+    np.testing.assert_allclose(heatmap.z, correlations.values)


### PR DESCRIPTION
## Summary
- add Plotly figure builders to the advanced pandas and statistics helper modules
- document the new interactive charts and how to run them locally in the Day 24 and Day 26 READMEs
- provide companion notebooks that juxtapose static plots with the Plotly figures and extend the test suites

## Testing
- pytest tests/test_day_24.py tests/test_day_26.py

------
https://chatgpt.com/codex/tasks/task_b_68da8a25f88c832db2986ed52c39fcf9