### PR TITLE
chore(ci): update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v3
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: "3.12"
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Summary
- bump the workflow's actions/checkout action to v4
- upgrade actions/setup-python to v5 and standardize on Python 3.12

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68da91de86b4832db8923b9f6a83e820