### PR TITLE
Handle cursors without result sets in execute_sql_query

### DIFF
--- a/Day_32_Other_Databases/other_databases.py
+++ b/Day_32_Other_Databases/other_databases.py
@@ -58,7 +58,10 @@ def execute_sql_query(
         else:
             cursor.execute(query, parameters)
 
-        results = cursor.fetchall()
+        results: Sequence[Any] = []
+        description = getattr(cursor, "description", None)
+        if description:
+            results = cursor.fetchall()
 
         if commit and hasattr(connection, "commit"):
             connection.commit()

--- a/tests/test_day_32.py
+++ b/tests/test_day_32.py
@@ -56,6 +56,26 @@ def test_execute_sql_query_commits_when_requested():
     connection.commit.assert_called_once()
 
 
+def test_execute_sql_query_skips_fetch_when_no_result_set_but_commits():
+    credentials = {"host": "localhost"}
+    connection = mock.Mock()
+    cursor = connection.cursor.return_value
+    cursor.description = None
+    cursor.fetchall.side_effect = RuntimeError("fetchall should not be called")
+    client_factory = mock.Mock(return_value=connection)
+
+    rows = execute_sql_query(
+        client_factory,
+        "UPDATE sales SET revenue = revenue + 100",
+        credentials=credentials,
+        commit=True,
+    )
+
+    assert rows == []
+    cursor.fetchall.assert_not_called()
+    connection.commit.assert_called_once()
+
+
 def test_upsert_sales_forecast_executes_all_rows_and_commits():
     credentials = {"host": "db.internal"}
     connection = mock.Mock()


### PR DESCRIPTION
## Summary
- avoid calling `fetchall` when the cursor does not expose a result set
- ensure DML executions still commit and return an empty sequence
- add regression coverage for commit-only executions without result sets

## Testing
- pytest tests/test_day_32.py -o addopts=""


------
https://chatgpt.com/codex/tasks/task_b_68df9df2d6fc833187a0bebb01b17a0a