### PR TITLE
Ensure Day 50 model saver creates directories

### DIFF
--- a/Day_50_MLOps/solutions.py
+++ b/Day_50_MLOps/solutions.py
@@ -79,7 +79,8 @@ def train_iris_model(
 def save_model(model: LogisticRegression, path: Path | str) -> Path:
     """Persist the trained model to disk and return the resolved path."""
 
-    path = Path(path)
+    path = Path(path).expanduser().resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
     joblib.dump(model, path)
     return path
 

--- a/tests/test_day_50.py
+++ b/tests/test_day_50.py
@@ -40,3 +40,14 @@ def test_model_round_trip(tmp_path: Path) -> None:
     )
     assert predicted_index == baseline_predictions[0]
     assert predicted_label == target_names[baseline_predictions[0]]
+
+
+def test_save_model_creates_nested_directory(tmp_path: Path) -> None:
+    model, *_ = train_iris_model(random_state=123, subset_size=60)
+
+    nested_path = tmp_path / "models" / "iris.joblib"
+    saved_path = save_model(model, nested_path)
+
+    assert saved_path == nested_path.resolve()
+    assert saved_path.exists()
+    assert saved_path.parent.is_dir()


### PR DESCRIPTION
## Summary
- resolve the destination path in `save_model` and create missing parent directories before persisting models
- add a regression test that saves to a nested folder to verify directory creation

## Testing
- pytest tests/test_day_50.py -q --no-cov

------
https://chatgpt.com/codex/tasks/task_b_68df9e071c888331abf5c7334178f10f