### PR TITLE
Improve Day 24 missing data guard

### DIFF
--- a/Day_24_Pandas_Advanced/README.md
+++ b/Day_24_Pandas_Advanced/README.md
@@ -48,6 +48,8 @@ The script for this lesson, `pandas_adv.py`, has been refactored to place each a
    ```bash
    python Day_24_Pandas_Advanced/pandas_adv.py
    ```
+   If the CSV file is missing, the refactored `handle_missing_data()` helper now raises
+   a clear `ValueError` explaining how to restore the dataset before continuing.
 1. **Run the Tests:** The tests use a sample DataFrame created in memory, so they don't depend on the external CSV file.
    ```bash
    pytest tests/test_day_24.py

--- a/Day_24_Pandas_Advanced/pandas_adv.py
+++ b/Day_24_Pandas_Advanced/pandas_adv.py
@@ -63,9 +63,15 @@ def filter_by_product_and_region(
 
 
 def handle_missing_data(
-    df: pd.DataFrame, strategy: str = "drop", fill_value=None
+    df: Optional[pd.DataFrame], strategy: str = "drop", fill_value=None
 ) -> pd.DataFrame:
     """Handles missing data by either dropping rows or filling with a value."""
+    if df is None or df.empty:
+        raise ValueError(
+            "No sales data is available. Ensure the CSV exists and contains rows before"
+            " calling handle_missing_data."
+        )
+
     df_copy = df.copy()
     if strategy == "drop":
         return df_copy.dropna()

--- a/Day_24_Pandas_Advanced/profile_pandas_adv.py
+++ b/Day_24_Pandas_Advanced/profile_pandas_adv.py
@@ -41,8 +41,11 @@ def build_pipeline(
 
     def pipeline() -> None:
         df = load_sales_data(str(data_path))
-        if df is None:
-            raise FileNotFoundError(f"CSV not found at {data_path}")
+        if df is None or df.empty:
+            raise ValueError(
+                f"Sales data could not be loaded from {data_path}. Ensure the CSV exists"
+                " and contains data."
+            )
 
         filter_by_high_revenue(df, threshold)
         filter_by_product_and_region(df, product, region)

--- a/tests/test_day_24.py
+++ b/tests/test_day_24.py
@@ -79,6 +79,13 @@ def test_handle_missing_data_fill(sample_dataframe):
     assert df_filled.loc[0, "Revenue"] == 60000
 
 
+def test_handle_missing_data_missing_frame():
+    """Passing None should raise a descriptive error instead of crashing."""
+
+    with pytest.raises(ValueError, match="No sales data is available"):
+        handle_missing_data(None, strategy="drop")
+
+
 def test_build_revenue_by_region_bar_chart_returns_sorted_bars(sample_dataframe):
     df = sample_dataframe.copy()
     df.loc[3, "Revenue"] = 4000


### PR DESCRIPTION
## Summary
- raise a descriptive ValueError when `handle_missing_data` receives a missing or empty frame
- update the profiling pipeline and lesson docs to surface the friendly error when the CSV is absent
- add a regression test covering the None-input error path

## Testing
- pytest tests/test_day_24.py

------
https://chatgpt.com/codex/tasks/task_b_68e672ee5ddc83269d40672f73fbdec2