### PR TITLE
Add centralised lint automation and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
         pip install -r requirements-dev.txt
         pip install pytest
 
+    - name: Lint and format checks
+      run: make lint
+
     - name: Test with pytest
       run: |
         pytest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: lint format
+
+NB_FILES := $(shell git ls-files '*.ipynb')
+MD_FILES := $(shell git ls-files '*.md')
+
+lint:
+	ruff check .
+	ruff format --check .
+	@if [ -n "$(NB_FILES)" ]; then \
+		nbqa black --check $(NB_FILES); \
+		nbqa ruff $(NB_FILES); \
+	else \
+		echo "No notebooks found."; \
+	fi
+	@if [ -n "$(MD_FILES)" ]; then \
+		mdformat --check $(MD_FILES); \
+	else \
+		echo "No Markdown files found."; \
+	fi
+
+format:
+	ruff check --fix .
+	ruff format .
+	@if [ -n "$(NB_FILES)" ]; then \
+		nbqa black $(NB_FILES); \
+		nbqa ruff --fix $(NB_FILES); \
+	else \
+		echo "No notebooks found."; \
+	fi
+	@if [ -n "$(MD_FILES)" ]; then \
+		mdformat $(MD_FILES); \
+	else \
+		echo "No Markdown files found."; \
+	fi

--- a/README.md
+++ b/README.md
@@ -162,16 +162,18 @@ pytest
 ## 🧹 Code formatting
 
 The repository standardises formatting across Python modules, notebooks, and
-Markdown documents. After installing `requirements-dev.txt`, run the following
-commands from the project root before opening a pull request:
+Markdown documents. After installing `requirements-dev.txt`, run the unified
+command from the project root before opening a pull request:
 
 ```bash
-ruff check --fix .
-ruff format .
-nbqa black $(git ls-files '*.ipynb')
-nbqa ruff --fix $(git ls-files '*.ipynb')
-mdformat $(git ls-files '*.md')
+make format
 ```
+
+This wraps the standard sequence—`ruff check --fix`, `ruff format`, notebook
+formatting via `nbqa`, and `mdformat` for Markdown—so that Python modules,
+Jupyter notebooks, and documentation stay in sync with the shared
+configuration defined in `pyproject.toml`. To check formatting without making
+changes (the command used in CI), run `make lint` instead.
 
 ## 🔄 Dependency reviews
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 88
+target-version = ["py312"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+src = ["."]
+extend-exclude = ["data"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+ignore = []
+
+[tool.ruff.format]
+docstring-code-format = true
+line-ending = "lf"
+quote-style = "double"
+indent-style = "space"
+
+[tool.nbqa.addopts]
+black = ["--line-length=88"]
+ruff = ["--extend-select=I"]
+
+[tool.nbqa.exclude]
+black = "data"
+ruff = "data"
+
+[tool.mdformat]
+wrap = 88
+number = false


### PR DESCRIPTION
## Summary
- introduce a pyproject.toml to centralise Black, Ruff, nbQA, and mdformat configuration
- add Makefile lint/format targets that wrap Ruff, nbQA, and mdformat runs across the repo
- document the new workflow in the README and ensure CI runs the unified lint command before tests

## Testing
- make lint *(fails: existing notebooks, markdown, and Python files currently violate the new checks)*

------
https://chatgpt.com/codex/tasks/task_b_68e672f715fc8326b22e629ca60573b5