### PR TITLE
Add Binder configuration and notebook smoke test

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,0 +1,5 @@
+-r ../requirements.txt
+mysql-connector-python
+psycopg2-binary
+pymongo
+jupyterlab

--- a/.binder/start
+++ b/.binder/start
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REPO_ROOT="${REPO_DIR:-$PWD}"
+cd "$REPO_ROOT"
+exec jupyter lab \
+  --ip=0.0.0.0 \
+  --port=8888 \
+  --no-browser \
+  --NotebookApp.default_url=/lab \
+  --ServerApp.allow_remote_access=True

--- a/Day_31_Databases/databases_smoke_test.ipynb
+++ b/Day_31_Databases/databases_smoke_test.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0a50b3a1",
+   "metadata": {},
+   "source": [
+    "# Day 31 – Databases\n",
+    "\n",
+    "This notebook mirrors the Day 31 SQLite demo and is used for smoke testing the hosted Binder environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd70fd83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, pathlib\n",
+    "repo_root = pathlib.Path.cwd().resolve()\n",
+    "while repo_root != repo_root.parent:\n",
+    "    if (repo_root / 'requirements.txt').exists():\n",
+    "        break\n",
+    "    repo_root = repo_root.parent\n",
+    "else:\n",
+    "    raise RuntimeError('Could not locate repository root')\n",
+    "if str(repo_root) not in sys.path:\n",
+    "    sys.path.insert(0, str(repo_root))\n",
+    "print(f'Notebook sys.path primed with {repo_root}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38cb5325",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from Day_31_Databases import databases\n",
+    "database_path = \"company_data_smoke.db\"\n",
+    "print(database_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af2b4b46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "databases.initialize_employee_db(database_path)\n",
+    "print(\"Employees table created with sample records.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d369cc9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "databases.fetch_department_salaries(database_path, \"Sales\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "255a2c61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "engineering_df = databases.fetch_department_dataframe(database_path, \"Engineering\")\n",
+    "engineering_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a9b80e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "databases.cleanup_employee_db(database_path)\n",
+    "print(f\"Removed {database_path}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ modern ML operations and monitoring.
 
 ## 🚀 Quick start
 
+[![Launch a ready-to-run Binder workspace](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/saint2706/Coding-For-MBA/HEAD?urlpath=lab)
+
+> 💡 **Recommended for learners without install privileges:** The Binder badge launches a hosted JupyterLab session rooted at this repository with all core requirements and database extras pre-installed. You can open any `Day_*` notebook immediately and start executing cells without configuring your local machine.
+
 ```bash
 git clone https://github.com/saint2706/Coding-For-MBA.git
 cd Coding-For-MBA


### PR DESCRIPTION
## Summary
- add a Binder configuration that installs the core requirements plus database extras and launches JupyterLab from the project root
- document the hosted Binder launch badge in the README so learners without local installs can start quickly
- add a Day 31 SQLite smoke-test notebook that exercises the curriculum utilities in the hosted environment

## Testing
- `jupyter nbconvert --to notebook --execute Day_31_Databases/databases_smoke_test.ipynb --output /tmp/databases_smoke_test-executed.ipynb`


------
https://chatgpt.com/codex/tasks/task_b_68e67321c1f48326898cea53072cbb41