### PR TITLE
Add accessible exports for lessons

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ Navigate to a `Day_*` directory and select the relevant `.ipynb` file—for
 instance, `Day_31_Databases/databases.ipynb` walks through the SQLite example
 in an interactive notebook environment.
 
+## ♿ Accessible lesson exports
+
+Run `python tools/convert_lessons_to_notebooks.py` to regenerate the notebooks
+alongside screen-reader-friendly HTML and Markdown exports. The static
+artifacts are written to `docs/lessons/Day_*/*.html` and
+`docs/lessons/Day_*/*.md`, complete with skip-navigation links, a structured
+heading hierarchy, and placeholder alt text for every figure. These exports are
+perfect for learners who prefer assistive technology or need an offline copy of
+the curriculum.
+
 ## 🤝 Contributing to the docs
 
 1. Install the documentation dependencies with `pip install -r docs/requirements.txt` and `bundle install --gemfile docs/Gemfile`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ Use the navigation menu to explore the machine learning roadmap or drill into th
 
 - **Machine Learning Curriculum** – Phased roadmap that explains how the Day 40–67 sequence ladders into an end-to-end ML capability.
 - **Lessons** – Direct access to every `Day_*` lesson README, enhanced with quick links to the supporting notebooks and scripts.
+- **Accessible lesson exports** – Screen-reader-ready HTML and Markdown versions of every notebook live under [`docs/lessons/`](./lessons/) for offline or assistive-technology-first study.
 
 ## Contributing updates
 

--- a/tools/templates/accessible_html/index.html.j2
+++ b/tools/templates/accessible_html/index.html.j2
@@ -1,0 +1,10 @@
+{% extends 'lab/index.html.j2' %}
+
+{% block html_head %}
+    {{ super() }}
+    <meta name="description" content="Accessible export of lesson notebook for screen readers."/>
+{% endblock html_head %}
+
+{% block body %}
+    {{ super() }}
+{% endblock body %}


### PR DESCRIPTION
## Summary
- extend the lesson conversion utility to build Markdown and accessible HTML exports alongside each notebook, including automated WCAG checks
- add a nbconvert template directory so the exporter can inject screen reader specific metadata
- document where learners can download the accessible lesson bundle in the repository README and published docs landing page

## Testing
- python - <<'PY'
from pathlib import Path
from tools.convert_lessons_to_notebooks import convert_file, export_static_content
root = Path('.').resolve()
nb = convert_file(root / 'Day_01_Introduction' / 'helloworld.py')
export_static_content(nb, root / 'docs' / 'lessons', Path('tools/templates'))
PY

------
https://chatgpt.com/codex/tasks/task_b_68e67f9b26748326b1238e779dd9cced