### PR TITLE
Fix ML curriculum internal lesson links

### DIFF
--- a/docs/ml_curriculum.md
+++ b/docs/ml_curriculum.md
@@ -14,24 +14,24 @@ This roadmap outlines a phased journey from classic machine learning foundations
 
 | Day | Lesson | Key takeaway |
 | --- | ------ | ------------ |
-| Day 40 | [Introduction to Machine Learning](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_40_Intro_to_ML/README.md) | Frame ML problems, manage the train/validate/test split, and measure performance with cross-validation. |
-| Day 41 | [Supervised Learning – Regression](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_41_Supervised_Learning_Regression/README.md) | Fit linear models, tune regularisation, and interpret coefficients for business insights. |
-| Day 42 | [Supervised Learning – Classification Part 1](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_42_Supervised_Learning_Classification_Part_1/README.md) | Compare logistic regression and decision trees while diagnosing accuracy, precision, and recall. |
-| Day 43 | [Supervised Learning – Classification Part 2](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_43_Supervised_Learning_Classification_Part_2/README.md) | Ensemble methods, ROC curves, and thresholding strategy selection. |
-| Day 44 | [Unsupervised Learning](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_44_Unsupervised_Learning/README.md) | Cluster customer segments and reduce dimensionality with PCA. |
-| Day 45 | [Feature Engineering & Evaluation](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_45_Feature_Engineering_and_Evaluation/README.md) | Build repeatable feature pipelines and validate models with more nuanced metrics. |
-| Day 46 | [Intro to Neural Networks](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_46_Intro_to_Neural_Networks/README.md) | Understand perceptrons, activation functions, and gradient descent. |
-| Day 47 | [Convolutional Neural Networks](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_47_Convolutional_Neural_Networks/README.md) | Apply convolutional filters for image classification. |
-| Day 48 | [Recurrent Neural Networks](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_48_Recurrent_Neural_Networks/README.md) | Model sequential data with RNNs, LSTMs, and GRUs. |
-| Day 49 | [Natural Language Processing](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_49_NLP/README.md) | Build text classification pipelines with tokenisation and embeddings. |
-| Day 50 | [MLOps](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_50_MLOps/README.md) | Package, persist, and monitor models for reliable deployment. |
-| Day 51 | [Regularised Models](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_51_Regularized_Models/README.md) | Contrast ridge, lasso, elastic net, and Poisson GLMs while measuring coefficient shrinkage. |
-| Day 52 | [Ensemble Methods](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_52_Ensemble_Methods/README.md) | Blend bagging, boosting, and stacking ensembles with calibrated probability estimates. |
-| Day 53 | [Model Tuning & Feature Selection](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_53_Model_Tuning_and_Feature_Selection/README.md) | Optimise hyperparameters with grid/Bayesian search and validate feature subsets via permutation importance and RFE. |
-| Day 54 | [Probabilistic Modeling](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_54_Probabilistic_Modeling/README.md) | Master Gaussian mixtures, Bayesian classifiers, EM, and HMM log-likelihoods to reason about uncertainty. |
-| Day 55 | [Advanced Unsupervised Learning](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_55_Advanced_Unsupervised_Learning/README.md) | Deploy DBSCAN, hierarchical clustering, t-SNE/UMAP-style embeddings, and autoencoder-driven anomaly detection. |
-| Day 56 | [Time Series & Forecasting](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_56_Time_Series_and_Forecasting/README.md) | Forecast seasonal demand with ARIMA/SARIMAX, Holt-Winters, and Prophet-style decompositions plus robust evaluation. |
-| Day 57 | [Recommender Systems](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_57_Recommender_Systems/README.md) | Build collaborative filtering and matrix factorisation recommenders with implicit-feedback aware ranking metrics. |
+| Day 40 | [Introduction to Machine Learning](lessons/day-40-intro-to-ml.md) | Frame ML problems, manage the train/validate/test split, and measure performance with cross-validation. |
+| Day 41 | [Supervised Learning – Regression](lessons/day-41-supervised-learning-regression.md) | Fit linear models, tune regularisation, and interpret coefficients for business insights. |
+| Day 42 | [Supervised Learning – Classification Part 1](lessons/day-42-supervised-learning-classification-part-1.md) | Compare logistic regression and decision trees while diagnosing accuracy, precision, and recall. |
+| Day 43 | [Supervised Learning – Classification Part 2](lessons/day-43-supervised-learning-classification-part-2.md) | Ensemble methods, ROC curves, and thresholding strategy selection. |
+| Day 44 | [Unsupervised Learning](lessons/day-44-unsupervised-learning.md) | Cluster customer segments and reduce dimensionality with PCA. |
+| Day 45 | [Feature Engineering & Evaluation](lessons/day-45-feature-engineering-and-evaluation.md) | Build repeatable feature pipelines and validate models with more nuanced metrics. |
+| Day 46 | [Intro to Neural Networks](lessons/day-46-intro-to-neural-networks.md) | Understand perceptrons, activation functions, and gradient descent. |
+| Day 47 | [Convolutional Neural Networks](lessons/day-47-convolutional-neural-networks.md) | Apply convolutional filters for image classification. |
+| Day 48 | [Recurrent Neural Networks](lessons/day-48-recurrent-neural-networks.md) | Model sequential data with RNNs, LSTMs, and GRUs. |
+| Day 49 | [Natural Language Processing](lessons/day-49-nlp.md) | Build text classification pipelines with tokenisation and embeddings. |
+| Day 50 | [MLOps](lessons/day-50-mlops.md) | Package, persist, and monitor models for reliable deployment. |
+| Day 51 | [Regularised Models](lessons/day-51-regularized-models.md) | Contrast ridge, lasso, elastic net, and Poisson GLMs while measuring coefficient shrinkage. |
+| Day 52 | [Ensemble Methods](lessons/day-52-ensemble-methods.md) | Blend bagging, boosting, and stacking ensembles with calibrated probability estimates. |
+| Day 53 | [Model Tuning & Feature Selection](lessons/day-53-model-tuning-and-feature-selection.md) | Optimise hyperparameters with grid/Bayesian search and validate feature subsets via permutation importance and RFE. |
+| Day 54 | [Probabilistic Modeling](lessons/day-54-probabilistic-modeling.md) | Master Gaussian mixtures, Bayesian classifiers, EM, and HMM log-likelihoods to reason about uncertainty. |
+| Day 55 | [Advanced Unsupervised Learning](lessons/day-55-advanced-unsupervised-learning.md) | Deploy DBSCAN, hierarchical clustering, t-SNE/UMAP-style embeddings, and autoencoder-driven anomaly detection. |
+| Day 56 | [Time Series & Forecasting](lessons/day-56-time-series-and-forecasting.md) | Forecast seasonal demand with ARIMA/SARIMAX, Holt-Winters, and Prophet-style decompositions plus robust evaluation. |
+| Day 57 | [Recommender Systems](lessons/day-57-recommender-systems.md) | Build collaborative filtering and matrix factorisation recommenders with implicit-feedback aware ranking metrics. |
 
 ### Recommended next steps after Phase 1
 
@@ -45,10 +45,10 @@ Deep learning expands the model families available in Phase 1. Focus on building
 
 | Day | Lesson | Key takeaway |
 | --- | ------ | ------------ |
-| Day 58 | [Transformers and Attention](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_58_Transformers_and_Attention/README.md) | Assemble encoder–decoder stacks, fine-tune pretrained checkpoints, and interpret attention heatmaps with deterministic demos. |
-| Day 59 | [Generative Models](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_59_Generative_Models/README.md) | Compare autoencoders, VAEs, GANs, and diffusion denoisers while monitoring reconstruction loss curves on synthetic data. |
-| Day 60 | [Graph and Geometric Learning](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_60_Graph_and_Geometric_Learning/README.md) | Prototype GraphSAGE and GAT-style message passing networks for toy node classification tasks with interpretable attention scores. |
-| Day 61 | [Reinforcement and Offline Learning](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_61_Reinforcement_and_Offline_Learning/README.md) | Explore policy/value methods, contextual bandits, and offline evaluation baselines that converge to reproducible reward thresholds. |
+| Day 58 | [Transformers and Attention](lessons/day-58-transformers-and-attention.md) | Assemble encoder–decoder stacks, fine-tune pretrained checkpoints, and interpret attention heatmaps with deterministic demos. |
+| Day 59 | [Generative Models](lessons/day-59-generative-models.md) | Compare autoencoders, VAEs, GANs, and diffusion denoisers while monitoring reconstruction loss curves on synthetic data. |
+| Day 60 | [Graph and Geometric Learning](lessons/day-60-graph-and-geometric-learning.md) | Prototype GraphSAGE and GAT-style message passing networks for toy node classification tasks with interpretable attention scores. |
+| Day 61 | [Reinforcement and Offline Learning](lessons/day-61-reinforcement-and-offline-learning.md) | Explore policy/value methods, contextual bandits, and offline evaluation baselines that converge to reproducible reward thresholds. |
 
 - Refresh Python packages for GPU acceleration (PyTorch or TensorFlow) and practice training models on cloud notebooks.
 - Study convolutional network variants (ResNet, EfficientNet) and fine-tune pretrained models for domain-specific images.
@@ -70,9 +70,9 @@ Turn prototypes into production systems by investing in reliable infrastructure 
 
 | Day | Lesson | Key takeaway |
 | --- | ------ | ------------ |
-| Day 65 | [MLOps Pipelines and CI/CD](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_65_MLOps_Pipelines_and_CI/README.md) | Orchestrate feature stores, registries, and GitHub Actions workflows with DAG-style automation. |
-| Day 66 | [Model Deployment and Serving](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_66_Model_Deployment_and_Serving/README.md) | Compare REST, gRPC, batch, streaming, and edge serving patterns with load-tested adapters. |
-| Day 67 | [Model Monitoring and Reliability](https://github.com/saint2706/Coding-For-MBA/blob/main/Day_67_Model_Monitoring_and_Reliability/README.md) | Detect data drift, evaluate canaries, and export observability metrics for retraining triggers. |
+| Day 65 | [MLOps Pipelines and CI/CD](lessons/day-65-mlops-pipelines-and-ci.md) | Orchestrate feature stores, registries, and GitHub Actions workflows with DAG-style automation. |
+| Day 66 | [Model Deployment and Serving](lessons/day-66-model-deployment-and-serving.md) | Compare REST, gRPC, batch, streaming, and edge serving patterns with load-tested adapters. |
+| Day 67 | [Model Monitoring and Reliability](lessons/day-67-model-monitoring-and-reliability.md) | Detect data drift, evaluate canaries, and export observability metrics for retraining triggers. |
 
 - Industrialise feature pipelines with tools like Feature Store platforms or workflow orchestrators (Airflow, Prefect).
 - Automate training and evaluation with CI/CD pipelines, integrating unit tests, data quality checks, and model validation gates.


### PR DESCRIPTION
## Summary
- update the machine learning curriculum roadmap to link to on-site lesson pages instead of GitHub READMEs so navigation stays within the docs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e8ca2f182c83278900204e1f5b0e23