### PR TITLE
Normalize product/region filtering

### DIFF
--- a/Day_24_Pandas_Advanced/pandas_adv.py
+++ b/Day_24_Pandas_Advanced/pandas_adv.py
@@ -59,7 +59,20 @@ def filter_by_product_and_region(
     """Filters the DataFrame for a specific product and region."""
     if df is None or "Product" not in df.columns or "Region" not in df.columns:
         return pd.DataFrame()
-    return df[(df["Product"] == product) & (df["Region"] == region)]
+    product_normalized = product.strip().casefold()
+    region_normalized = region.strip().casefold()
+
+    normalized_product_series = (
+        df["Product"].astype("string").str.strip().str.casefold()
+    )
+    normalized_region_series = (
+        df["Region"].astype("string").str.strip().str.casefold()
+    )
+
+    mask = (normalized_product_series == product_normalized) & (
+        normalized_region_series == region_normalized
+    )
+    return df[mask]
 
 
 def handle_missing_data(

--- a/tests/test_day_24.py
+++ b/tests/test_day_24.py
@@ -62,6 +62,24 @@ def test_filter_by_product_and_region(sample_dataframe):
     assert filtered_df.iloc[1]["Date"] == "2023-01-02"
 
 
+def test_filter_by_product_and_region_normalizes_strings():
+    df = pd.DataFrame(
+        {
+            "Product": ["  Laptop", "Mouse", "laptop  "],
+            "Region": ["north ", "South", " NORTH"],
+            "Units Sold": [90, 150, 110],
+        }
+    )
+
+    filtered_df = filter_by_product_and_region(df, " Laptop  ", "  north")
+
+    assert filtered_df.index.tolist() == [0, 2]
+    assert filtered_df["Units Sold"].tolist() == [90, 110]
+    # Original DataFrame should remain unchanged
+    assert df["Product"].tolist() == ["  Laptop", "Mouse", "laptop  "]
+    assert df["Region"].tolist() == ["north ", "South", " NORTH"]
+
+
 def test_handle_missing_data_drop(sample_dataframe):
     """Tests handling missing data by dropping rows."""
     # Row 2 has a NaN value


### PR DESCRIPTION
## Summary
- normalize Day 24 filtering by trimming and casefolding product and region values without mutating the source data
- add a regression test covering mixed-case and space-padded product/region combinations

## Testing
- pytest tests/test_day_24.py

------
https://chatgpt.com/codex/tasks/task_b_68ee40d71bfc8323aa03203975352313