### PR TITLE
Fix lessons export link

### DIFF
--- a/docs/lessons/index.md
+++ b/docs/lessons/index.md
@@ -13,7 +13,7 @@ Use the theme toggle in the header to switch between the light and dark palettes
 
 - **Machine Learning Curriculum** – Phased roadmap that explains how the Day 40–67 sequence ladders into an end-to-end ML capability.
 - **Lessons** – Direct access to every `Day_*` lesson README, enhanced with quick links to the supporting notebooks and scripts.
-- **Accessible lesson exports** – Screen-reader-ready HTML and Markdown versions of every notebook live under [`docs/lessons/`](./lessons/) for offline or assistive-technology-first study.
+- **Accessible lesson exports** – Screen-reader-ready HTML and Markdown versions of every notebook live under [`docs/lessons/`](/lessons/) for offline or assistive-technology-first study.
 
 ## Lessons
 


### PR DESCRIPTION
## Summary
- update the lessons export link to target the generated /lessons/ directory so users avoid a 404

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_b_68ee5618c6d88323ab275fe9d214ee8a