### PR TITLE
Add community discussions playbook and contributor onboarding docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing to Coding for MBA
+
+Thank you for your interest in shaping the Coding for MBA curriculum! This guide is written for external contributors who want to improve lessons, documentation, tooling, or community resources.
+
+- 🧭 [Ways to contribute](#ways-to-contribute)
+- 🛠️ [Development environment](#development-environment)
+- 🔄 [Contribution workflow](#contribution-workflow)
+- ✅ [Quality checklist](#quality-checklist)
+- 💬 [Community and support](#community-and-support)
+
+## Ways to Contribute
+
+We welcome contributions that help business-focused learners succeed:
+
+| Area | Examples |
+| ---- | -------- |
+| **Curriculum & Content** | Clarify lesson explanations, fix typos, expand business scenarios, add exercises or solution walkthroughs. |
+| **Code Enhancements** | Improve sample scripts, add tests, refactor utilities, or expand data-loading helpers. |
+| **Documentation** | Update guides in `docs/`, add troubleshooting steps, or improve onboarding materials. |
+| **Community** | Share learning tips, provide feedback, or propose roadmap ideas in GitHub Discussions. |
+
+If you have a new idea, open a [GitHub Discussion](https://github.com/saint2706/Coding-For-MBA/discussions) in the **Feedback & Ideas** category to align on direction before building.
+
+## Development Environment
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/saint2706/Coding-For-MBA.git
+   cd Coding-For-MBA
+   ```
+2. **Create a virtual environment** (Python 3.12+ recommended)
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\Scripts\activate
+   ```
+3. **Install dependencies**
+   ```bash
+   pip install -r requirements.txt
+   pip install -r requirements-dev.txt  # for linting and tests
+   ```
+4. **Optional extras**: Use `make format`, `make lint`, and `mkdocs serve` to work with formatting and documentation locally.
+
+## Contribution Workflow
+
+1. **Discuss** – Search existing [issues](https://github.com/saint2706/Coding-For-MBA/issues) and [discussions](https://github.com/saint2706/Coding-For-MBA/discussions). Open a new thread or issue if needed to gather context.
+2. **Fork & branch** – Fork the repository and create a feature branch (`git checkout -b feature/your-feature`).
+3. **Make focused changes** – Follow the project structure; update or add tests and documentation that reflect the change.
+4. **Run checks locally**
+   ```bash
+   make format  # optional but recommended
+   make lint
+   pytest
+   ```
+5. **Commit with context** – Write clear commit messages summarizing the change and reference related issues.
+6. **Submit a pull request** – Provide:
+   - A concise summary of changes
+   - Testing evidence (commands run)
+   - Screenshots or recordings if you modified visual output
+   - Links to related discussions or issues
+7. **Collaborate on review** – Be ready to answer questions, iterate on feedback, and keep discussions respectful. Once approved, maintainers will merge your pull request.
+
+## Quality Checklist
+
+Before requesting a review, ensure you have:
+
+- [ ] Added or updated automated tests when touching executable code.
+- [ ] Confirmed `pytest` passes locally (or explained why it fails).
+- [ ] Run `make lint` to satisfy formatting and linting standards.
+- [ ] Updated relevant documentation (`README`, lesson guides, or MkDocs pages).
+- [ ] Verified links and relative paths for any new Markdown content.
+- [ ] Included attribution for external datasets or resources where required.
+
+## Community and Support
+
+- **GitHub Discussions:** Join the learner community, ask for feedback, and help triage questions in the [Help Desk](https://github.com/saint2706/Coding-For-MBA/discussions/categories/help-desk) and **Show and Tell** categories.
+- **Issues:** Use GitHub issues for actionable tasks or bug reports once requirements are clear.
+- **Code of Conduct:** Practice empathy and inclusivity. Be constructive, stay on topic, and respect privacy when sharing business data examples.
+
+Need help getting started? Open a [Discussion](https://github.com/saint2706/Coding-For-MBA/discussions/new) and a maintainer or community host will respond.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ pip install mysql-connector-python psycopg2-binary pymongo
 
 The documentation includes interactive examples, detailed explanations, and downloadable materials for each lesson.
 
+## 🗣️ Community & Support
+
+- **[Join GitHub Discussions →](https://github.com/saint2706/Coding-For-MBA/discussions)** – Connect with peers, ask questions in the Help Desk, and showcase wins in Show and Tell.
+- **[GitHub Discussions Playbook](docs/community/github-discussions.md)** – Learn how we organize categories, moderate conversations, and track learner engagement.
+- **[Contribution Guidelines](CONTRIBUTING.md)** – Follow the external contributor workflow for proposing changes and submitting pull requests.
+
 ## 🗺️ Curriculum Overview
 
 The curriculum is organized into four progressive phases over 67 days:

--- a/docs/community/github-discussions.md
+++ b/docs/community/github-discussions.md
@@ -1,0 +1,77 @@
+# GitHub Discussions Playbook
+
+Create a welcoming learner hub by enabling GitHub Discussions on the repository and giving learners a clear sense of how to participate.
+
+## 1. Enable and Configure Discussions
+
+1. Navigate to **Settings → General → Discussions** in the GitHub repository.
+2. Check **Enable discussions** and select the template **Q&A** to seed the space with best-practice categories.
+3. Add the following custom categories to align with the cohort experience:
+   - **Announcements** *(Category type: Announcement)* – official updates, milestone releases, and cohort kickoff posts.
+   - **Help Desk** *(Category type: Q&A)* – learner questions about lessons, tooling, or troubleshooting.
+   - **Show and Tell** *(Category type: Open ended)* – space to share mini-projects, wins, and reflections.
+   - **Study Groups** *(Category type: Open ended)* – coordinate peer-led sessions, accountability partners, or office hours.
+   - **Feedback & Ideas** *(Category type: Idea)* – collect feature requests, lesson improvements, and documentation suggestions.
+4. Seed each category with a pinned starter topic to model tone and expectations (examples below).
+5. Update the repository description or README badge row with a **Discussions** link for fast access.
+
+## 2. Launch Announcement Template
+
+Use this message (adapted to your voice) as the kickoff post in the **Announcements** category:
+
+> 👋 Welcome to the Coding for MBA learner community! This space is your hub for asking questions, celebrating wins, and shaping the roadmap. Introduce yourself in the "Welcome thread," drop questions in **Help Desk**, and let us know what you're building in **Show and Tell**. We're excited to learn with you!
+
+Encourage learners to subscribe to the announcement thread to receive important notifications.
+
+## 3. Community Guidelines Snapshot
+
+Share the following principles in a pinned topic within **Announcements** or link to the `CONTRIBUTING.md` file:
+
+- **Be specific:** Give context, include lesson numbers, and describe expected vs. actual behavior.
+- **Practice kindness:** Assume positive intent, celebrate diverse backgrounds, and offer constructive feedback.
+- **Close the loop:** Mark questions as answered by selecting the accepted response so future learners benefit.
+- **Keep it organized:** Use tags (e.g., `lesson-21`, `mlops`, `beginner-help`) to help others discover discussions.
+- **Respect privacy:** Share only anonymized business data or synthetic datasets when discussing projects.
+
+## 4. Moderation & Roles
+
+| Role | Responsibilities | Suggested Owners |
+| ---- | ---------------- | ---------------- |
+| **Community Host** | Welcome newcomers, post weekly roundups, curate unanswered questions. | Curriculum maintainers |
+| **Subject-Matter Guides** | Provide verified answers for specific curriculum phases (e.g., Data Foundations, ML Ops). | Volunteer alumni or TAs |
+| **Automation Bot (optional)** | Remind learners about open questions, tag threads without activity, and prompt feedback. | GitHub Action or Probot app |
+
+Set a moderation rhythm:
+
+- Review new discussions 2–3 times per week.
+- Acknowledge new posts within 24 hours, even if only to say "Thanks, we'll take a look."
+- Archive or convert off-topic threads into issues if they represent bugs or feature requests.
+
+## 5. Engagement Rituals
+
+- **Weekly check-in:** Post a Monday thread asking "What are you focusing on this week?"
+- **Demo Friday:** Invite learners to share projects, dashboards, or analysis wins.
+- **Curriculum office hours:** Host a live session once per month and summarize takeaways in Discussions.
+- **Monthly retrospective:** Collect "Start/Stop/Continue" feedback in the **Feedback & Ideas** category.
+
+## 6. Metrics to Monitor
+
+Track community health indicators directly from GitHub Insights or manual exports:
+
+- New members posting or commenting per week.
+- Ratio of answered vs. unanswered questions in **Help Desk**.
+- Time-to-first-response for support questions.
+- Popular topics or tags driving engagement.
+- Suggestions converted into accepted GitHub issues or pull requests.
+
+## 7. Suggested Starter Topics
+
+Use these ideas to seed each category:
+
+- **Announcements:** "Welcome to the Coding for MBA Learner Community" *(pinned)*
+- **Help Desk:** "How to request feedback on your Day 30 web scraping project"
+- **Show and Tell:** "Share your business insight dashboards"
+- **Study Groups:** "Forming accountability squads for Phase 2"
+- **Feedback & Ideas:** "What's one improvement that would level up this curriculum?"
+
+Maintaining an intentional Discussions space turns passive learners into an active alumni network. Celebrate wins, keep the cadence predictable, and continually point new learners to the community hub.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,9 @@ nav:
   - ML Theory & Mathematics: theory.md
   - Dependency Review: dependency-review.md
   - Repository Roadmap: roadmap.md
+  - Community Hub:
+      - GitHub Discussions Playbook: community/github-discussions.md
+      - Contributor Handbook: contributing.md
   - Automation Commands: agents.md
   - License: LICENSE.md
   - Lessons:


### PR DESCRIPTION
## Summary
- add a GitHub Discussions playbook that outlines categories, moderation, and engagement rituals
- introduce a top-level CONTRIBUTING guide for external collaborators and link it across the site
- surface community resources in the README and MkDocs navigation for easier discovery

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f0c081ee2483309f876e8ab6a07a56