### PR TITLE
Add downloadable cheat sheets for each curriculum phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ The curriculum is organized into four progressive phases over 67 days:
 
 📘 **[See full curriculum roadmap →](docs/ml_curriculum.md)**
 
+## 📄 Phase Cheat Sheets
+
+Need the essentials at a glance? Download quick-reference guides for each phase of the journey: **[Phase Cheat Sheets](docs/cheatsheets/index.md)**.
+
+Each cheat sheet highlights core outcomes, business wins, and refresh drills so you can reinforce skills between lessons or share them with your team.
+
 ## 💻 Working with Lessons
 
 Each `Day_XX_*` folder contains:

--- a/docs/cheatsheets/index.md
+++ b/docs/cheatsheets/index.md
@@ -1,0 +1,18 @@
+# Phase Cheat Sheets
+
+Stay focused on the most important deliverables in each phase of the Coding for MBA journey. These quick-reference guides summarise the core learning outcomes, business applications, and checkpoints for the 67-day roadmap.
+
+Each cheat sheet is optimised for on-the-go review. Use the download links to save an offline copy or attach them to internal enablement hubs.
+
+| Phase | Coverage | Cheat Sheet |
+|-------|----------|-------------|
+| Phase 1 | Days 01-20 – Python foundations & core programming habits | [:material-download: Download](phase-1-cheat-sheet.md) |
+| Phase 2 | Days 21-39 – Data workflows, analytics stack, APIs, and visual storytelling | [:material-download: Download](phase-2-cheat-sheet.md) |
+| Phase 3 | Days 40-54 – Machine learning fundamentals, deep learning, and model evaluation | [:material-download: Download](phase-3-cheat-sheet.md) |
+| Phase 4 | Days 55-67 – Advanced ML techniques, governance, and production MLOps | [:material-download: Download](phase-4-cheat-sheet.md) |
+
+> 💡 **Tip:** Right-click any download link and choose "Save link as…" to store the Markdown file locally or convert it to PDF in your favourite note-taking tool.
+
+---
+
+Need a guided overview first? Revisit the [curriculum roadmap](../ml_curriculum.md) for how the phases connect to business capabilities.

--- a/docs/cheatsheets/phase-1-cheat-sheet.md
+++ b/docs/cheatsheets/phase-1-cheat-sheet.md
@@ -1,0 +1,63 @@
+# Phase 1 Cheat Sheet — Python Foundations (Days 01-20)
+
+> Launchpad for business leaders becoming technical operators. Master the Python syntax, patterns, and habits you will reuse throughout the 67-day journey.
+
+## Core Outcomes
+
+- Speak Python fluently: variables, expressions, conditionals, loops, functions, and error handling.
+- Manipulate essential data structures (lists, tuples, sets, dictionaries) to model business scenarios.
+- Build reusable utilities with modules, packages, and object-oriented design fundamentals.
+- Read, write, and validate structured data from files to support reporting workflows.
+- Establish a professional tooling baseline with virtual environments and dependency management.
+
+## Quick Syntax Reference
+
+| Task | Pattern | Example |
+|------|---------|---------|
+| Format numbers & currency | f-strings | `f"Revenue: ${revenue:,.0f}"` |
+| List comprehension | `[transform(x) for x in items if predicate(x)]` | `[c.upper() for c in customers if c.active]` |
+| Dictionary lookup with defaults | `value = mapping.get(key, fallback)` | `region = sales_map.get("APAC", 0)` |
+| Safe file handling | `with open(path, "r", encoding="utf-8") as f:` | `with open("customers.csv") as f:` |
+| Custom error handling | `try/except/else/finally` | `except ValueError as exc:` |
+| Create reusable module | `if __name__ == "__main__":` | `if __name__ == "__main__": cli()` |
+
+### Data Structure Spotlight
+
+- **Lists:** ordered, mutable collections — ideal for transaction logs and ETL staging areas.
+- **Tuples:** ordered, immutable — perfect for fixed KPI bundles (e.g., `(revenue, margin, churn)`).
+- **Sets:** unique membership — detect duplicate customer IDs or SKU codes.
+- **Dictionaries:** key-value lookups — central to configuration, dimension tables, and JSON-style payloads.
+
+## Business Wins to Target
+
+- Automate weekly metrics: ingest CSV exports, calculate KPIs, and email a summary.
+- Prototype decision logic: use conditionals to encode approval rules or lead scoring thresholds.
+- Build a reusable workbook helper: script repetitive Excel cleanup tasks (renaming columns, filtering rows).
+- Create a lightweight CLI that answers a common business question (e.g., break-even analysis).
+
+## Confidence Checklist
+
+Tick these boxes before advancing to Phase 2:
+
+- [ ] Can refactor nested loops into functions with clear docstrings.
+- [ ] Comfortable debugging `Traceback` output and writing informative exceptions.
+- [ ] Can serialize Python objects to JSON and back without losing fidelity.
+- [ ] Have packaged at least one utility into a module that other teammates can import.
+- [ ] Able to explain when to choose a list vs. dictionary vs. set in under 30 seconds.
+
+## Tooling & Workflow Habits
+
+- Use `python -m venv .venv` and `pip install -r requirements.txt` for isolated environments.
+- Adopt `black` or `ruff format` to keep scripts readable as they grow.
+- Pair CLI scripts with argument parsing (`argparse`) to make them reusable across teams.
+- Keep a `tests/` scratchpad with simple asserts for critical business rules.
+
+## 30-Minute Refresh Sprint
+
+1. **Warm-up (10 min):** Rebuild a `Customer` class with dunder methods for sorting and representation.
+2. **Automation drill (10 min):** Write a function that reads `sales.csv`, filters for the current quarter, and outputs JSON to `stdout`.
+3. **Communication (10 min):** Draft a short Loom or memo explaining how loops and list comprehensions accelerate a manual workflow.
+
+---
+
+**Next stop:** Phase 2 adds professional data workflows. Bring your clean code habits and packaging discipline forward.

--- a/docs/cheatsheets/phase-2-cheat-sheet.md
+++ b/docs/cheatsheets/phase-2-cheat-sheet.md
@@ -1,0 +1,61 @@
+# Phase 2 Cheat Sheet — Data Workflows & Analytics Stack (Days 21-39)
+
+> Translate raw data into trustworthy insights. This phase turns you into the connective tissue between business stakeholders and technical data platforms.
+
+## Core Outcomes
+
+- Operate confidently inside virtual environments and manage dependencies across projects.
+- Analyse datasets with NumPy and Pandas, handling missing values, joins, reshaping, and aggregations.
+- Design data-cleaning pipelines that produce reproducible, well-documented transformations.
+- Produce compelling static and interactive visualisations for executive storytelling.
+- Connect to relational databases, NoSQL stores, and third-party APIs to automate ingestion.
+- Build and deploy lightweight Flask services to expose analytics logic to other teams.
+
+## Analytics Workflow Blueprint
+
+1. **Ingest** – `pandas.read_csv`, database connectors (`sqlite3`, `sqlalchemy`, `psycopg2`, `pymongo`), authenticated API calls with `requests`.
+2. **Clean** – handle nulls (`fillna`, `dropna`), enforce schema (`astype`, categorical types), deduplicate, standardise text.
+3. **Transform** – vectorised calculations, window functions (`rolling`, `expanding`), group-by aggregations, pivot/unpivot operations.
+4. **Visualise** – Matplotlib/Seaborn for executive slides; Plotly for interactive dashboards.
+5. **Operationalise** – package pipeline steps into reusable functions, schedule scripts, or expose via Flask endpoints.
+
+## Pandas Power Moves
+
+| Situation | Method | Snippet |
+|-----------|--------|---------|
+| Combine datasets | `merge` / `join` | `orders.merge(customers, on="customer_id", how="left")` |
+| Feature scaling | `assign` | `df.assign(conversion_rate=lambda d: d.deals / d.visits)` |
+| Data quality | boolean masks | `df[df.revenue.between(0, 1_000_000)]` |
+| Multi-level analysis | `groupby` + `agg` | `sales.groupby(["region","segment"]).agg(rev=("revenue","sum"))` |
+| Share insights | `to_excel`, `to_markdown`, `to_json` | `df.to_excel("kpi-report.xlsx", index=False)` |
+
+## Visual Storytelling Prompts
+
+- Pair a key metric with a cumulative trend (line + area) to highlight compounding growth.
+- Use small multiples to compare regional performance while keeping scales consistent.
+- Add callouts (annotations) that explain inflection points—executives remember stories, not charts.
+
+## Integration Checklist
+
+- [ ] Store secrets and API keys in `.env` files and load with `python-dotenv`.
+- [ ] Wrap database queries in context managers to close connections reliably.
+- [ ] Version datasets or transformations with timestamps/hashes for traceability.
+- [ ] Provide a single `make report` or `python run_pipeline.py` command for teammates.
+- [ ] Document assumptions and edge cases in README snippets or inline comments.
+
+## Business Wins to Target
+
+- Automated KPI dashboards combining CRM exports + finance data.
+- API monitor that pings SaaS usage stats and alerts Slack when thresholds are exceeded.
+- Flask microservice exposing an underwriting or pricing model for internal stakeholders.
+- Interactive Plotly app that lets leaders scenario-plan pipeline or budget inputs.
+
+## 30-Minute Refresh Sprint
+
+1. **Data pull (10 min):** Request an authenticated JSON payload, normalise into a DataFrame, and persist as Parquet.
+2. **Transformation (10 min):** Chain `assign`, `groupby`, and `pivot_table` to produce a board-level KPI table.
+3. **Communication (10 min):** Export a clean PNG visual with annotations and craft a brief executive takeaway.
+
+---
+
+**Next stop:** Phase 3 moves from analytics to machine learning. Bring your disciplined pipelines—they become the backbone of model development.

--- a/docs/cheatsheets/phase-3-cheat-sheet.md
+++ b/docs/cheatsheets/phase-3-cheat-sheet.md
@@ -1,0 +1,63 @@
+# Phase 3 Cheat Sheet — Machine Learning Foundations (Days 40-54)
+
+> Convert analytics assets into predictive engines. This phase covers the entire ML development loop, from math intuition to production-ready baselines.
+
+## Core Outcomes
+
+- Recall the math building blocks: linear algebra operations, calculus intuition, and optimisation basics.
+- Execute the supervised learning workflow end-to-end (train/validation/test splits, metrics, error analysis).
+- Compare regression vs. classification approaches and select the right algorithm for the business problem.
+- Engineer features, evaluate model drift, and document assumptions for stakeholders.
+- Understand neural network fundamentals (dense nets, CNNs, RNNs) and when deep learning adds leverage.
+- Build NLP-ready pipelines for tokenisation, embeddings, and text classification.
+
+## Standard ML Playbook
+
+1. **Frame the question** – Align on business impact, success metrics, and decision cadence.
+2. **Prepare the data** – Feature selection, scaling (`StandardScaler`, `MinMaxScaler`), encoding (`OneHotEncoder`, embeddings).
+3. **Split responsibly** – Use stratified splits when class imbalance exists. Preserve temporal order for time-aware problems.
+4. **Train baseline models** – Start with linear/logistic regression, decision trees, or gradient boosting as interpretable anchors.
+5. **Evaluate** – Track MAE/RMSE for regression; accuracy/precision/recall/F1/ROC-AUC for classification.
+6. **Stress-test** – Perform cross-validation, residual analysis, calibration checks, and fairness diagnostics.
+7. **Communicate** – Pair charts (lift curves, SHAP summaries) with a narrative focused on risk/ROI.
+
+## Metric Cliff Notes
+
+| Scenario | Metric(s) | Notes |
+|----------|-----------|-------|
+| Forecast continuous values | MAE, RMSE, MAPE | RMSE penalises large errors; MAPE communicates % miss.
+| Predict churn / conversion | Precision, recall, F1, ROC-AUC | Align threshold with business tolerance for false positives/negatives.
+| Rank leads or products | Average precision, nDCG | Evaluate ordering quality, not just classification.
+| Multi-class problems | Macro vs. weighted F1 | Macro = treat classes equally; weighted = respect class frequency.
+
+## Deep Learning Highlights
+
+- **Dense networks:** great for structured data once feature engineering is mature.
+- **CNNs:** pattern detection for images, spatial data, or even time series via sliding windows.
+- **RNNs/LSTMs/GRUs:** sequential decisioning, language modelling, demand forecasting.
+- **Training tips:** normalise inputs, monitor overfitting (dropout, early stopping), profile GPU vs. CPU trade-offs.
+
+## Experiment Tracking Checklist
+
+- [ ] Log dataset version, feature set, and preprocessing pipeline.
+- [ ] Record hyperparameters and random seeds for reproducibility.
+- [ ] Persist models with metadata (metrics, timestamp, Git commit) using `joblib`, `mlflow`, or similar.
+- [ ] Maintain a comparison table (spreadsheet or markdown) summarising candidate models.
+- [ ] Capture qualitative findings: failure modes, surprising segments, data quality risks.
+
+## Business Wins to Target
+
+- Customer churn predictor that surfaces at-risk accounts with explainable drivers.
+- Dynamic pricing or demand forecasting models with scenario planning dashboards.
+- NLP classifier that routes support tickets or surfaces voice-of-customer themes.
+- Computer vision proof-of-concept demonstrating automated quality checks.
+
+## 30-Minute Refresh Sprint
+
+1. **Baseline (10 min):** Load a prepared dataset, create train/test splits, and fit logistic regression.
+2. **Feature tweak (10 min):** Add a new engineered feature, retrain, and compare lift using a metric table.
+3. **Explain (10 min):** Generate SHAP or feature importance plots and draft a stakeholder-ready narrative.
+
+---
+
+**Next stop:** Phase 4 focuses on production realities—governance, monitoring, and scaling advanced model families.

--- a/docs/cheatsheets/phase-4-cheat-sheet.md
+++ b/docs/cheatsheets/phase-4-cheat-sheet.md
@@ -1,0 +1,55 @@
+# Phase 4 Cheat Sheet — Advanced ML & MLOps (Days 55-67)
+
+> Ship trustworthy, scalable AI systems. Phase 4 emphasises governance, automation, and emerging model families for strategic edge.
+
+## Core Outcomes
+
+- Deploy and monitor advanced models: transformers, generative AI, graph learning, reinforcement learning.
+- Manage experimentation pipelines, CI/CD automation, and reproducible training infrastructure.
+- Implement fairness, interpretability, and causal inference guardrails to satisfy executives and regulators.
+- Build production-grade serving layers (batch + real-time) with observability and rollback strategies.
+- Design monitoring plans that track model/data drift, performance decay, and ethical KPIs.
+
+## Production-Ready Lifecycle
+
+1. **Packaging** – Containerise models (`Dockerfile`, `requirements.txt`), freeze dependencies, capture artefacts.
+2. **Automation** – Use CI/CD (GitHub Actions, Airflow, Prefect) to orchestrate training, testing, and deployment.
+3. **Deployment** – Choose fit-for-purpose channels: REST APIs, streaming consumers, batch scoring jobs, or edge devices.
+4. **Governance** – Maintain model cards, data lineage, and approval checklists. Integrate fairness & bias audits.
+5. **Monitoring** – Track latency, throughput, accuracy, calibration, drift, and business KPIs. Trigger alerts and fallbacks.
+6. **Feedback loop** – Capture human-in-the-loop labels, log predictions, and continuously retrain when thresholds are breached.
+
+## Advanced Technique Highlights
+
+| Topic | Use Case | Key Moves |
+|-------|----------|-----------|
+| Transformers | Text summarisation, Q&A, document intelligence | Fine-tune with transfer learning; manage token budgets and hallucination risk. |
+| Generative Models | Marketing copy, scenario simulation, data augmentation | Guardrails: prompt templates, content filters, human review checkpoints. |
+| Graph Learning | Customer networks, supply chain risk, fraud rings | Build graph features (centrality, community), leverage GraphSAGE/GAT for inductive learning. |
+| Reinforcement Learning | Pricing strategies, operations optimisation | Define reward shaping with business KPIs; run offline evaluation before live testing. |
+| Causal Inference | Campaign uplift, treatment effect | Use uplift models, doubly robust estimators, or causal forests; validate assumptions (ignorability, overlap). |
+
+## Risk & Compliance Checklist
+
+- [ ] Maintain dataset documentation with provenance, consent, and refresh cadence.
+- [ ] Run fairness metrics (demographic parity, equal opportunity) and mitigation strategies when gaps appear.
+- [ ] Stress-test against adversarial or out-of-distribution samples; log anomalies.
+- [ ] Establish rollback plans and SLA thresholds for each deployment pathway.
+- [ ] Socialise a communication plan for incidents, including exec briefings and customer messaging.
+
+## Business Wins to Target
+
+- Automated marketing content assistant with human-in-the-loop approval queue.
+- Graph-based lead scoring that identifies relationship clusters sales can activate.
+- Real-time fraud or risk scoring pipeline with latency SLOs and adaptive retraining.
+- Causal uplift model that guides personalised promotions and measures incremental lift.
+
+## 30-Minute Refresh Sprint
+
+1. **Ops drill (10 min):** Sketch the CI/CD stages for retraining and deploying a recommendation model.
+2. **Monitoring (10 min):** Define metrics, alert thresholds, and dashboards for a production NLP service.
+3. **Ethics brief (10 min):** Summarise fairness risks, governance controls, and escalation paths for executives.
+
+---
+
+🎯 **Graduation checkpoint:** You now have the assets to steward ML products from prototype to long-term business impact.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,12 @@ theme:
 nav:
   - Home: index.md
   - Machine Learning Curriculum: ml_curriculum.md
+  - Phase Cheat Sheets:
+      - Overview: cheatsheets/index.md
+      - Phase 1 — Python Foundations: cheatsheets/phase-1-cheat-sheet.md
+      - Phase 2 — Data Workflows & Analytics Stack: cheatsheets/phase-2-cheat-sheet.md
+      - Phase 3 — Machine Learning Foundations: cheatsheets/phase-3-cheat-sheet.md
+      - Phase 4 — Advanced ML & MLOps: cheatsheets/phase-4-cheat-sheet.md
   - ML Theory & Mathematics: theory.md
   - Dependency Review: dependency-review.md
   - Repository Roadmap: roadmap.md


### PR DESCRIPTION
## Summary
- add a new cheat sheet hub with downloadable quick-reference guides for all four curriculum phases
- document the new resources in the README and surface them in the MkDocs navigation

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f0c2ad00d883308e29dc2d7063f073