### PR TITLE
Add Day 84 career development capstone scaffolding

### DIFF
--- a/Day_84_BI_Career_Development_and_Capstone/README.md
+++ b/Day_84_BI_Career_Development_and_Capstone/README.md
@@ -1,0 +1,62 @@
+# Day 84 – BI Career Development and Capstone
+
+> This lesson closes Phase 5 by converting the roadmap insights into a polished career
+narrative. Pair it with [Day 83 – BI Career Assets](../Day_83_BI_Career_Assets/README.md)
+and the planning prompts in [Day 84 – BI Roadmapping](../Day_84_BI_Roadmapping/README.md).
+
+## Why it matters
+
+A strong capstone bridges your project experience with employer expectations. Using the
+roadmap ensures that the assets you build speak the language of BI hiring managers and
+stakeholders.
+
+## Capstone workflow
+
+1. **Frame the business objective** – state the business question, success metrics, and
+   stakeholder audience that will anchor your presentation.
+2. **Design the solution storyline** – outline the analytics flow, highlight how each
+   roadmap title becomes a tangible artifact, and document the collaboration or research
+   you will showcase.
+3. **Deliver and rehearse** – package the assets, rehearse the pitch, and prepare
+   follow-up material such as interview responses or stakeholder FAQs.
+
+## Career assets checklist
+
+Use these roadmap-aligned prompts to plan the artifacts that demonstrate your value.
+
+- [ ] Building Your Portfolio – curate 2–3 projects that reflect the BI stack you want to
+      be hired for and verify the links work end to end.
+- [ ] Portfolio presentation – craft a live walkthrough or video demo that emphasizes the
+      business outcomes, not just the dashboards.
+- [ ] Open-Source Projects – contribute a small feature or documentation update to a BI
+      tool and capture screenshots or pull requests.
+- [ ] BI Competitions – summarize results, lessons learned, and ranking; link to
+      notebooks or dashboards.
+- [ ] BI Communities – list the meetups, Slack groups, or forums where you discuss trends
+      and what you have learned.
+- [ ] Conferences & Webinars – log the events you attend, the insights gained, and how
+      they influence your projects.
+- [ ] Networking – schedule outreach conversations with analysts or hiring managers and
+      document the advice you receive.
+- [ ] Professional Development – document the courses, workshops, or mentoring sessions
+      that sharpened your BI skills.
+- [ ] Certifications – track progress toward credentials, exam dates, and renewal plans.
+
+## Job readiness checklist
+
+Focus your interview preparation with these roadmap tasks.
+
+- [ ] Resume optimization – align bullets with BI metrics, tools, and quantified outcomes.
+- [ ] Interview preparation – rehearse portfolio walkthroughs, stakeholder stories, and
+      challenge questions that link to the capstone.
+- [ ] Salary negotiation strategies – research compensation benchmarks, benefits, and
+      cost-of-living adjustments.
+- [ ] Job Preparation – outline your 30/60/90-day plan, onboarding priorities, and key
+      relationships to build once you land the role.
+
+## Next steps
+
+- Run `python Day_84_BI_Career_Development_and_Capstone/lesson.py` to print the capstone
+  phases and generate checklist templates.
+- Export the JSON checklist to your project management tool and update it as you complete
+  each roadmap milestone.

--- a/Day_84_BI_Career_Development_and_Capstone/__init__.py
+++ b/Day_84_BI_Career_Development_and_Capstone/__init__.py
@@ -1,0 +1,19 @@
+"""Day 84 – BI Career Development and Capstone helpers."""
+
+from .solutions import (
+    CAREER_ASSET_TITLES,
+    JOB_READINESS_TITLES,
+    ChecklistItem,
+    generate_checklists,
+    load_career_topics,
+    serialize_checklists,
+)
+
+__all__ = [
+    "CAREER_ASSET_TITLES",
+    "JOB_READINESS_TITLES",
+    "ChecklistItem",
+    "generate_checklists",
+    "load_career_topics",
+    "serialize_checklists",
+]

--- a/Day_84_BI_Career_Development_and_Capstone/lesson.py
+++ b/Day_84_BI_Career_Development_and_Capstone/lesson.py
@@ -1,0 +1,73 @@
+# %%
+"""Day 84 – BI Career Development and Capstone classroom script."""
+
+# %%
+from __future__ import annotations
+
+from textwrap import indent
+
+from Day_84_BI_Career_Development_and_Capstone import generate_checklists, serialize_checklists
+
+# %%
+CAPSTONE_PHASES: list[tuple[str, str]] = [
+    (
+        "Phase 1 – Frame the business objective",
+        (
+            "Summarize the business question, BI success metrics, and stakeholders. "
+            "Anchor your narrative in the developer-roadmap nodes you plan to demonstrate."
+        ),
+    ),
+    (
+        "Phase 2 – Design the solution storyline",
+        (
+            "Sketch a walkthrough that highlights your analytics workflow, decision checkpoints, "
+            "and how you will showcase portfolio artifacts such as dashboards or notebooks."
+        ),
+    ),
+    (
+        "Phase 3 – Deliverables and rehearsal",
+        (
+            "Map roadmap titles to concrete deliverables, rehearse the presentation, and prepare "
+            "supporting assets for interviews or stakeholder reviews."
+        ),
+    ),
+]
+
+# %%
+CHECKLISTS = generate_checklists()
+
+
+# %%
+def outline_capstone(phases: list[tuple[str, str]] = CAPSTONE_PHASES) -> None:
+    """Print the recommended capstone phases and guidance."""
+
+    print("\nDay 84 capstone planning guide\n")
+    for phase, description in phases:
+        print(f"{phase}\n{indent(description, '  ')}\n")
+
+
+# %%
+def display_checklists(checklists = CHECKLISTS) -> None:
+    """Print actionable checklists for learners."""
+
+    print("Roadmap-aligned checklists\n")
+    for group, items in checklists.items():
+        print(f"## {group}")
+        for item in items:
+            print(f"- [ ] {item.title}")
+        print()
+
+
+# %%
+def main() -> None:
+    """Guide the learner through the Day 84 facilitation."""
+
+    outline_capstone()
+    display_checklists()
+    print("Serialized checklist template (copy into your notes tool):\n")
+    print(serialize_checklists(CHECKLISTS))
+
+
+# %%
+if __name__ == "__main__":
+    main()

--- a/Day_84_BI_Career_Development_and_Capstone/solutions.py
+++ b/Day_84_BI_Career_Development_and_Capstone/solutions.py
@@ -1,0 +1,108 @@
+"""Utilities for Day 84 – BI Career Development and Capstone."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, MutableMapping
+
+from mypackage.bi_curriculum import BiTopic, group_topics_by_titles
+
+CAREER_ASSET_TITLES: list[str] = [
+    "Building Your Portfolio",
+    "Portfolio presentation",
+    "Open-Source Projects",
+    "BI Competitions",
+    "BI Communities",
+    "Conferences & Webinars",
+    "Networking",
+    "Professional Development",
+    "Certifications",
+]
+
+JOB_READINESS_TITLES: list[str] = [
+    "Resume optimization",
+    "Interview preparation",
+    "Salary negotiation strategies",
+    "Job Preparation",
+]
+
+ROADMAP_GROUPS: Mapping[str, list[str]] = {
+    "Career assets": CAREER_ASSET_TITLES,
+    "Job readiness": JOB_READINESS_TITLES,
+}
+
+
+@dataclass(slots=True)
+class ChecklistItem:
+    """A simple representation of a learner checklist item."""
+
+    title: str
+    status: str = "Not started"
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a serializable representation of the checklist item."""
+
+        return {"title": self.title, "status": self.status, "notes": self.notes}
+
+
+def load_career_topics(*, groups: Mapping[str, Iterable[str]] = ROADMAP_GROUPS) -> dict[str, list[BiTopic]]:
+    """Return the roadmap topics grouped for the capstone."""
+
+    return group_topics_by_titles(groups)
+
+
+def _build_checklist(topics: Iterable[BiTopic]) -> list[ChecklistItem]:
+    """Create checklist items from BI topics."""
+
+    return [ChecklistItem(title=topic.title) for topic in topics]
+
+
+def generate_checklists(
+    *, groups: Mapping[str, Iterable[str]] = ROADMAP_GROUPS
+) -> dict[str, list[ChecklistItem]]:
+    """Return checklist templates for career assets and job readiness."""
+
+    grouped_topics = load_career_topics(groups=groups)
+    return {group: _build_checklist(topics) for group, topics in grouped_topics.items()}
+
+
+def _checklists_to_serializable(
+    checklists: Mapping[str, Iterable[ChecklistItem]]
+) -> dict[str, list[dict[str, str]]]:
+    """Convert checklist dataclasses into JSON serializable dictionaries."""
+
+    payload: MutableMapping[str, list[dict[str, str]]] = {}
+    for group, items in checklists.items():
+        payload[group] = [item.to_dict() for item in items]
+    return dict(payload)
+
+
+def serialize_checklists(
+    checklists: Mapping[str, Iterable[ChecklistItem]] | None = None,
+    *,
+    groups: Mapping[str, Iterable[str]] = ROADMAP_GROUPS,
+    path: str | Path | None = None,
+    indent: int = 2,
+) -> str:
+    """Return JSON for the grouped checklists and optionally persist it."""
+
+    resolved = checklists if checklists is not None else generate_checklists(groups=groups)
+    serializable = _checklists_to_serializable(resolved)
+    json_text = json.dumps(serializable, indent=indent)
+    if path is not None:
+        destination = Path(path)
+        destination.write_text(json_text, encoding="utf-8")
+    return json_text
+
+
+__all__ = [
+    "CAREER_ASSET_TITLES",
+    "JOB_READINESS_TITLES",
+    "ChecklistItem",
+    "generate_checklists",
+    "load_career_topics",
+    "serialize_checklists",
+]

--- a/tests/test_day_84.py
+++ b/tests/test_day_84.py
@@ -1,0 +1,61 @@
+"""Tests for the Day 84 BI Career Development and Capstone utilities."""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Day_84_BI_Career_Development_and_Capstone import (
+    CAREER_ASSET_TITLES,
+    JOB_READINESS_TITLES,
+    ChecklistItem,
+    generate_checklists,
+    load_career_topics,
+    serialize_checklists,
+)
+
+EXPECTED_GROUPS = {"Career assets", "Job readiness"}
+
+
+def test_load_career_topics_matches_roadmap_titles() -> None:
+    grouped = load_career_topics()
+    assert set(grouped) == EXPECTED_GROUPS
+    assert {topic.title for topic in grouped["Career assets"]} == set(CAREER_ASSET_TITLES)
+    assert {topic.title for topic in grouped["Job readiness"]} == set(JOB_READINESS_TITLES)
+
+
+def test_generate_checklists_contains_all_titles() -> None:
+    checklists = generate_checklists()
+    assert set(checklists) == EXPECTED_GROUPS
+    career_items = checklists["Career assets"]
+    readiness_items = checklists["Job readiness"]
+
+    assert all(isinstance(item, ChecklistItem) for item in career_items)
+    assert all(isinstance(item, ChecklistItem) for item in readiness_items)
+
+    assert {item.title for item in career_items} == set(CAREER_ASSET_TITLES)
+    assert {item.title for item in readiness_items} == set(JOB_READINESS_TITLES)
+
+
+
+def test_serialize_checklists_round_trip(tmp_path: Path) -> None:
+    checklists = generate_checklists()
+    destination = tmp_path / "career_checklists.json"
+    json_text = serialize_checklists(checklists, path=destination)
+
+    payload = json.loads(json_text)
+    assert set(payload) == EXPECTED_GROUPS
+
+    assert [entry["title"] for entry in payload["Career assets"]] == CAREER_ASSET_TITLES
+    assert [entry["title"] for entry in payload["Job readiness"]] == JOB_READINESS_TITLES
+
+    saved = json.loads(destination.read_text(encoding="utf-8"))
+    assert saved == payload
+
+    for group_entries in payload.values():
+        for entry in group_entries:
+            assert set(entry) == {"title", "status", "notes"}
+            assert entry["status"] == "Not started"
+            assert entry["notes"] == ""


### PR DESCRIPTION
## Summary
- add the Day 84 BI Career Development and Capstone lesson scaffolding with roadmap-aligned checklists
- implement reusable checklist utilities for grouping topics and exporting JSON templates
- document the capstone workflow and provide coverage with targeted unit tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68f0d8c9c0488330a14db7660c1e9102