### PR TITLE
Avoid mutating DataFrame titles during filtering

### DIFF
--- a/Day_23_Pandas/pandas_from_csv.py
+++ b/Day_23_Pandas/pandas_from_csv.py
@@ -32,10 +32,11 @@ def filter_by_title(df: pd.DataFrame, keyword: str) -> pd.DataFrame:
     if df is None or "title" not in df.columns:
         return pd.DataFrame()  # Return empty DataFrame if input is invalid
 
-    # Ensure title column is string type to use .str accessor
-    df["title"] = df["title"].astype(str)
+    # Ensure title column is string type to use .str accessor without mutating the original DataFrame
+    title_series = df["title"].astype(str)
+    mask = title_series.str.contains(keyword, case=False, na=False)
 
-    return df.loc[df["title"].str.contains(keyword, case=False, na=False)]
+    return df.loc[mask]
 
 
 def main():

--- a/tests/test_day_23.py
+++ b/tests/test_day_23.py
@@ -78,3 +78,12 @@ def test_filter_by_title_invalid_df():
     empty_df_no_title = filter_by_title(df_no_title, "Python")
     assert isinstance(empty_df_no_title, pd.DataFrame)
     assert empty_df_no_title.empty
+
+
+def test_filter_by_title_preserves_original_dtype(sample_dataframe):
+    """Ensures the helper does not mutate the original DataFrame's dtypes."""
+    original_dtype = sample_dataframe["title"].dtype
+
+    _ = filter_by_title(sample_dataframe, "Python")
+
+    assert sample_dataframe["title"].dtype == original_dtype


### PR DESCRIPTION
## Summary
- avoid mutating the original DataFrame when casting the title column in `filter_by_title`
- add a regression test ensuring the helper keeps the source DataFrame's dtypes intact

## Testing
- pytest --override-ini addopts= tests/test_day_23.py

------
https://chatgpt.com/codex/tasks/task_e_68f0ddf4b0fc8330b9ba5f26acfae005