### PR TITLE
Potential fix for code scanning alert no. 68: Flask app is run in debug mode

### DIFF
--- a/Day_50_MLOps/bonus_flask_api.py
+++ b/Day_50_MLOps/bonus_flask_api.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     
     # Skip running the server in test/automated environments
     if os.environ.get("FLASK_RUN_TEST_MODE") != "1":
-        app.run(debug=True)
+        app.run(debug=False)
     else:
         print("Flask app created successfully (test mode - not starting server)")
         print("Model loaded:" if model is not None else "Model not loaded")


### PR DESCRIPTION
Potential fix for [https://github.com/saint2706/Coding-For-MBA/security/code-scanning/68](https://github.com/saint2706/Coding-For-MBA/security/code-scanning/68)

To fix this problem, the Flask server should not be started with `debug=True`. The best way is to set `debug=False`, or omit the `debug` parameter entirely (the default is `False`).  
If you still want auto-reloading and debugging for local development, rely on an environment variable for explicit control, e.g. `FLASK_DEBUG=1`. Ideally, the code should detect a development/debug environment explicitly before enabling `debug=True`. For the provided code, set `debug=False` unconditionally (since the current use-case does not read a standard debug environment variable), ensuring the server never starts with the Werkzeug debugger enabled.

**What to change:**
- In Day_50_MLOps/bonus_flask_api.py, update line 91 to use `app.run(debug=False)` or simply `app.run()` (since debug defaults to False).
- No new imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
