### PR TITLE
Improve CI caching and lint automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,9 @@ jobs:
         python-version: "3.13"
         allow-prereleases: true
         cache: 'pip'
-
-    - name: Cache pip dependencies
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+        cache-dependency-path: |
+          requirements.txt
+          requirements-dev.txt
 
     - name: Install dependencies
       run: |
@@ -54,8 +49,8 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
 
-    - name: Lint and format checks
-      run: make format
+    - name: Run linters
+      run: make lint
 
     - name: Test with pytest
-      run: pytest
+      run: pytest -q

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,11 +30,14 @@ jobs:
         python-version: "3.13"
         allow-prereleases: true
         cache: 'pip'
+        cache-dependency-path: |
+          requirements.txt
+          requirements-dev.txt
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
 
-    - name: Run formatting
-      run: make format
+    - name: Run lint checks
+      run: make lint

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ test:
 
 lint:
 	ruff check .
-	mdformat . --wrap 100
-	pre-commit run --all-files
+	mdformat --wrap 100 --check .
+	pre-commit run --all-files --show-diff-on-failure --color=always
 
 format:
 	ruff format .


### PR DESCRIPTION
## Summary
- rely on setup-python caching with declared dependency files and remove redundant cache step
- run lint checks in CI and lint workflows instead of formatting the repository
- make the Makefile lint target check markdown formatting and show diffs from pre-commit

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68f87e867fe483309a076c62801dd708