### PR TITLE
Add pytest-cov dependency for coverage configuration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ ipykernel==7.0.1
 lexical-diversity
 mysql-connector-python==9.4.0
 pymongo==4.15.3
+pytest-cov==5.0.0


### PR DESCRIPTION
## Summary
- add pytest-cov to the default requirements so the coverage addopts in pytest.ini are always satisfied

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68f880dbee2c833095ff67d6baddd6a3