### PR TITLE
Load interactive widget assets globally

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,13 @@ plugins:
   - redirects
   - minify:
       minify_html: true
+extra_css:
+  - stylesheets/extra.css
+  - stylesheets/interactive-widgets.css
+extra_javascript:
+  - https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js
+  - javascripts/pyodide-console.js
+  - javascripts/progress-tracker.js
 markdown_extensions:
   - admonition
   - footnotes


### PR DESCRIPTION
## Summary
- add the shared extra and interactive widget stylesheets to the MkDocs configuration
- load the Pyodide runtime and site-wide widget helper scripts via `extra_javascript`

## Testing
- mkdocs serve -v

------
https://chatgpt.com/codex/tasks/task_b_6900af24c0708324955a24e7d6e1fc43