### PR TITLE
Add MkDocs edit URI

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Coding for MBA
 site_url: https://saint2706.github.io/Coding-For-MBA/
 repo_url: https://github.com/saint2706/Coding-For-MBA
+edit_uri: edit/main/docs/
 theme:
   name: material
   features:


### PR DESCRIPTION
## Summary
- configure MkDocs to use the repository edit URI so "Edit this page" buttons point to GitHub
- built the site to confirm the configuration and verified the generated index page links to the correct edit URL

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_b_6900b0861b40832496b86cc312b10adf