### PR TITLE
Emphasize seven-phase roadmap on docs landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,13 +35,24 @@ ______________________________________________________________________
 
 ## What you get
 
-- Structured journey across five phases that balance technical execution with business storytelling.
+- Seven-phase journey that connects Python foundations, machine learning, and SQL mastery to business storytelling.
 - Repeatable lesson pattern with Python scripts, notebooks, and solution walk-throughs.
 - Tooling for local development, CI, and documentation so you can learn by doing.
+
+| Phase | Days | Focus |
+| --- | --- | --- |
+| [Phase 1 – Python Foundations](phases/phase1.md) | 01-20 | Automate workflows with core Python skills. |
+| [Phase 2 – Data Analytics & Workflows](phases/phase2.md) | 21-39 | Build analysis-ready datasets with Pandas, APIs, and visualization. |
+| [Phase 3 – Machine Learning Foundations](phases/phase3.md) | 40-54 | Apply supervised, unsupervised, and neural techniques to business problems. |
+| [Phase 4 – Advanced ML & MLOps](phases/phase4.md) | 55-67 | Operationalize models with transformers, deployment, and monitoring. |
+| [Phase 5 – Business Intelligence](phases/phase5.md) | 68-84 | Design BI programs, stakeholder journeys, and enablement playbooks. |
+| [Phase 6 – BI Advanced & Capstone](phases/phase6.md) | 85-90 | Deliver cloud BI solutions, governance, and a culminating capstone. |
+| [Phase 7 – SQL & Database Mastery](phases/phase7.md) | 91-108 | Master enterprise SQL, database design, and performance tuning. |
 
 ## Explore next
 
 - 📘 [Browse all lessons](lessons/_index.md)
 - 🚀 [Set up your environment](get-started.md)
 - 🧭 [Review the phase roadmap](phases/overview.md)
+- 🗂️ [Use the phase navigation tabs to choose your path](phases/overview.md#phase-navigation)
 - 🏁 [Dive into the Business Intelligence sprint](phases/phase5.md)


### PR DESCRIPTION
## Summary
- highlight the full seven-phase journey in the landing page feature list
- add a condensed phase table that mirrors the overview data with direct links to each phase
- surface a dedicated link to the phase navigation tabs for quick access

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6900e1f310788330a0fa1e7a0ade32af