### PR TITLE
Use Python 3.11 for CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - name: Set up Python 3.13
+    - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
-        python-version: "3.13"
-        allow-prereleases: true
+        python-version: "3.11"
         cache: 'pip'
         cache-dependency-path: |
           requirements.txt

--- a/.github/workflows/deploy-certs.yml
+++ b/.github/workflows/deploy-certs.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.11'
 
     - name: Install system dependencies for WeasyPrint
       run: |

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.11'
 
     - name: Install dependencies
       run: |
@@ -89,7 +89,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.11'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,11 +24,10 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - name: Set up Python 3.13
+    - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
-        python-version: "3.13"
-        allow-prereleases: true
+        python-version: "3.11"
         cache: 'pip'
         cache-dependency-path: |
           requirements.txt

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -14,11 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Set up Python 3.13
+      - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
-          allow-prereleases: true
+          python-version: '3.11'
           cache: pip
 
       - name: Install benchmark dependencies


### PR DESCRIPTION
## Summary
- switch all GitHub Actions workflows from Python 3.13 prereleases to stable Python 3.11
- remove allow-prereleases flags while keeping existing pip cache dependency paths

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_6905bd7543dc8330a4b00c47af1a0a3c