### PR TITLE
Improve resilience across GitHub workflows

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -3,6 +3,9 @@ name: Core CI
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   core:
     runs-on: ubuntu-latest
@@ -16,17 +19,39 @@ jobs:
           python-version: "3.11"
           cache: pip
           cache-dependency-path: |
-            requirements.txt
-            requirements-dev.txt
+            requirements*.txt
+            pyproject.toml
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          if [ -f pyproject.toml ]; then pip install -e . || echo "Skipping editable install"; fi
 
       - name: Run linters
-        run: make lint
+        run: |
+          if make -n lint >/dev/null 2>&1; then
+            make lint
+          else
+            echo "make lint target missing; running default linters"
+            python -m pip install --quiet black ruff || true
+            if command -v black >/dev/null 2>&1; then
+              black --check .
+            else
+              echo "black not available, skipping format check"
+            fi
+            if command -v ruff >/dev/null 2>&1; then
+              ruff check .
+            else
+              echo "ruff not available, skipping lint check"
+            fi
+          fi
 
       - name: Test with pytest
-        run: pytest -q
+        run: |
+          if compgen -G "tests/test_*.py" > /dev/null; then
+            pytest -q
+          else
+            echo "No pytest tests discovered, skipping."
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   core:
     uses: ./.github/workflows/ci-core.yml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,24 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v5
 
+    - name: Set up Python
+      if: matrix.language == 'python'
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+        cache: pip
+        cache-dependency-path: |
+          requirements*.txt
+          pyproject.toml
+
+    - name: Install Python dependencies
+      if: matrix.language == 'python'
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+        if [ -f pyproject.toml ]; then pip install -e . || echo "Skipping editable install"; fi
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,9 +5,14 @@ on: [pull_request]
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v5

--- a/.github/workflows/deploy-certs.yml
+++ b/.github/workflows/deploy-certs.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   generate-and-upload:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout code
@@ -17,6 +19,10 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.11'
+        cache: pip
+        cache-dependency-path: |
+          requirements*.txt
+          pyproject.toml
 
     - name: Install system dependencies for WeasyPrint
       run: |
@@ -32,15 +38,25 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f pyproject.toml ]; then pip install -e . || echo "Skipping editable install"; fi
 
     - name: Generate all PDFs
       run: |
-        python scripts/generate_pdfs.py --all
+        if [ -f scripts/generate_pdfs.py ]; then
+          python scripts/generate_pdfs.py --all
+        else
+          echo "scripts/generate_pdfs.py not found, skipping"
+        fi
 
     - name: Generate badges
       run: |
-        python scripts/generate_badge.py --all
+        if [ -f scripts/generate_badge.py ]; then
+          python scripts/generate_badge.py --all
+        else
+          echo "scripts/generate_badge.py not found, skipping"
+        fi
 
     - name: List generated artifacts
       run: |

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   core-checks:
     uses: ./.github/workflows/ci-core.yml
@@ -23,6 +27,11 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.11'
+        cache: pip
+        cache-dependency-path: |
+          requirements*.txt
+          docs/requirements-docs.txt
+          pyproject.toml
 
     - name: Verify lesson structure
       run: |
@@ -41,6 +50,8 @@ jobs:
           pip install mkdocs mkdocs-material
         fi
         pip install linkchecker || echo "linkchecker not available"
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f pyproject.toml ]; then pip install -e . || echo "Skipping editable install"; fi
 
     - name: Build documentation
       run: mkdocs build --strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
@@ -18,12 +22,28 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            requirements*.txt
+            docs/requirements-docs.txt
+            pyproject.toml
       - name: Install docs deps
         run: |
           python -m pip install -U pip
-          pip install -r docs/requirements-docs.txt
+          if [ -f docs/requirements-docs.txt ]; then
+            pip install -r docs/requirements-docs.txt
+          else
+            pip install mkdocs mkdocs-material
+          fi
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f pyproject.toml ]; then pip install -e . || echo "Skipping editable install"; fi
       - name: Generate lesson pages
-        run: python tools/build_docs.py
+        run: |
+          if [ -f tools/build_docs.py ]; then
+            python tools/build_docs.py
+          else
+            echo "tools/build_docs.py not found, skipping pre-build step"
+          fi
       - name: Build
         run: mkdocs build --strict
       - name: Deploy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -32,11 +35,30 @@ jobs:
         cache-dependency-path: |
           requirements.txt
           requirements-dev.txt
+          pyproject.toml
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f pyproject.toml ]; then pip install -e . || echo "Skipping editable install"; fi
 
     - name: Run lint checks
-      run: make lint
+      run: |
+        if make -n lint >/dev/null 2>&1; then
+          make lint
+        else
+          echo "make lint target missing; running fallback lint commands"
+          python -m pip install --quiet black ruff || true
+          if command -v black >/dev/null 2>&1; then
+            black --check .
+          else
+            echo "black not available, skipping format check"
+          fi
+          if command -v ruff >/dev/null 2>&1; then
+            ruff check .
+          else
+            echo "ruff not available, skipping lint check"
+          fi
+        fi

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest
@@ -19,11 +23,17 @@ jobs:
         with:
           python-version: '3.11'
           cache: pip
+          cache-dependency-path: |
+            requirements*.txt
+            pyproject.toml
 
       - name: Install benchmark dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pandas
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          if [ -f pyproject.toml ]; then pip install -e . || echo "Skipping editable install"; fi
 
       - name: Run lesson benchmarks
         run: |


### PR DESCRIPTION
## Summary
- add minimal permissions, caching, and concurrency controls to every GitHub workflow
- guard dependency installation and lint/test steps so optional files or targets no longer break the runs
- harden documentation, deployment, and benchmark workflows with conditional scripts and reusable setup

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_690c5b576e4883308c62d663372e465d