### PR TITLE
Ensure JupyterLite assets are rebuilt during docs workflows

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -56,6 +56,14 @@ jobs:
     - name: Build documentation
       run: mkdocs build --strict
 
+    - name: Build JupyterLite assets
+      run: |
+        if [ -f tools/integrate_jupyterlite.py ]; then
+          python tools/integrate_jupyterlite.py --build-only
+        else
+          echo "tools/integrate_jupyterlite.py not found, skipping JupyterLite build"
+        fi
+
     - name: Check links (if linkchecker available)
       run: |
         if command -v linkchecker &> /dev/null; then

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,6 +46,13 @@ jobs:
           fi
       - name: Build
         run: mkdocs build --strict
+      - name: Build JupyterLite assets
+        run: |
+          if [ -f tools/integrate_jupyterlite.py ]; then
+            python tools/integrate_jupyterlite.py --build-only
+          else
+            echo "tools/integrate_jupyterlite.py not found, skipping JupyterLite build"
+          fi
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -4,3 +4,5 @@ mkdocs-jupyter>=0.24
 mkdocs-redirects>=1.2
 mkdocs-minify-plugin>=0.7
 pymdown-extensions>=10.8
+jupyterlite-core>=0.3.0
+jupyterlite-pyodide-kernel>=0.3.0

--- a/docs/website-improvements.md
+++ b/docs/website-improvements.md
@@ -76,6 +76,11 @@ using WebAssembly.
        jupyter lite build --contents . --output-dir site/jupyterlite
    ```
 
+   > ℹ️ Automated: The `docs.yml` and `docs-ci.yml` workflows now call
+   > `python tools/integrate_jupyterlite.py --build-only` immediately after
+   > `mkdocs build --strict`, ensuring the Lite assets persist in the published
+   > site.
+
 1. **Add launch buttons to lesson pages**:
 
    ```markdown

--- a/tools/integrate_jupyterlite.py
+++ b/tools/integrate_jupyterlite.py
@@ -7,10 +7,14 @@ This script:
 2. Builds a JupyterLite distribution
 3. Adds launch buttons to lesson pages
 4. Configures packages for Pyodide environment
+
+Use ``--build-only`` to skip content updates and just refresh the JupyterLite
+assets inside ``site/jupyterlite``.
 """
 
 from __future__ import annotations
 
+import argparse
 import shutil
 import subprocess
 import sys
@@ -51,14 +55,23 @@ def ensure_jupyterlite_installed() -> bool:
         return False
 
 
-def build_jupyterlite() -> None:
-    """Build JupyterLite distribution."""
+def build_jupyterlite(full_build: bool = True) -> None:
+    """Build JupyterLite distribution.
+
+    Args:
+        full_build: When ``True`` run a full content build (the default).
+            When ``False`` only refresh the assets using ``jupyter lite build``
+            with the configured defaults.
+    """
     if not ensure_jupyterlite_installed():
         print("ERROR: JupyterLite is not installed.")
         print("Install with: pip install jupyterlite-core jupyterlite-pyodide-kernel")
         sys.exit(1)
 
-    print("Building JupyterLite...")
+    if full_build:
+        print("Building JupyterLite with full content refresh...")
+    else:
+        print("Building JupyterLite assets only (no lesson updates)...")
 
     # Clean previous build
     if JUPYTERLITE_DIR.exists():
@@ -71,9 +84,10 @@ def build_jupyterlite() -> None:
         "build",
         "--output-dir",
         str(JUPYTERLITE_DIR),
-        "--contents",
-        str(ROOT),
     ]
+
+    if full_build:
+        cmd.extend(["--contents", str(ROOT)])
 
     try:
         subprocess.run(cmd, check=True, cwd=ROOT)
@@ -305,11 +319,36 @@ Binder provides a cloud-based Jupyter environment with full Python support.
     print(f"✓ Created JupyterLite guide at {index_path}")
 
 
-def main() -> None:
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the integration tool."""
+
+    parser = argparse.ArgumentParser(
+        description="Integrate JupyterLite content and assets into the docs site."
+    )
+    parser.add_argument(
+        "--build-only",
+        action="store_true",
+        help="Only build the JupyterLite assets and skip documentation updates.",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> None:
     """Main integration workflow."""
+    args = parse_args(argv)
+
     print("=" * 60)
     print("JupyterLite Integration Tool")
     print("=" * 60)
+
+    if args.build_only:
+        print("\n[1/1] Building JupyterLite distribution (assets only)...")
+        build_jupyterlite(full_build=False)
+        print("\n" + "=" * 60)
+        print("✓ JupyterLite asset build complete!")
+        print("=" * 60)
+        return
 
     # Step 1: Build JupyterLite
     print("\n[1/4] Building JupyterLite distribution...")
@@ -337,4 +376,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- add JupyterLite dependencies to the documentation requirements file
- add a build-only mode to the JupyterLite integration script
- run the lightweight JupyterLite build step in docs workflows and document the automation

## Testing
- python tools/build_docs.py
- mkdocs build --strict
- python tools/integrate_jupyterlite.py --build-only
- pytest


------
https://chatgpt.com/codex/tasks/task_e_690c911465408330a76e7148aa45fa48