### PR TITLE
Add Thebe integration for inline executable examples

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -59,7 +59,22 @@ jupyter notebook
 Navigate to any `Day_XX_*` directory and open the lesson notebook. Each folder includes scripts,
 notebooks, and (when applicable) solutions.
 
-## 6. Run a single lesson script
+## 6. Run Python inline with Thebe
+
+Activate interactive examples directly on the site by clicking the **Run** button that appears on
+hover. Thebe launches a Binder-backed kernel the first time you execute a cell; subsequent runs reuse
+the existing session.
+
+<div class="executable" data-executable="true">
+
+```python
+message = "Welcome to Coding for MBA!"
+message.upper()
+```
+
+</div>
+
+## 7. Run a single lesson script
 
 ```bash
 python Day_30_Web_Scraping/lesson.py
@@ -68,7 +83,7 @@ python Day_30_Web_Scraping/lesson.py
 Swap the folder name to execute any other lesson. The scripts are designed to run independently and
 print their own instructions or outputs.
 
-## 7. Use the Makefile for common tasks
+## 8. Use the Makefile for common tasks
 
 ```bash
 make setup       # bootstrap a fresh checkout

--- a/docs/javascripts/thebe-config.js
+++ b/docs/javascripts/thebe-config.js
@@ -1,0 +1,58 @@
+(function () {
+  const POLLING_INTERVAL_MS = 250;
+  const EXECUTABLE_SELECTOR = '[data-executable="true"]';
+
+  function ensureExecutableWrapper(element) {
+    if (!element.classList.contains('executable')) {
+      element.classList.add('executable');
+    }
+  }
+
+  function tagExecutableBlocks() {
+    document.querySelectorAll(EXECUTABLE_SELECTOR).forEach((element) => {
+      ensureExecutableWrapper(element);
+      if (!element.hasAttribute('data-language')) {
+        const codeBlock = element.querySelector('pre code');
+        if (codeBlock && codeBlock.className) {
+          const language = Array.from(codeBlock.classList).find((cls) =>
+            cls.startsWith('language-')
+          );
+          if (language) {
+            element.setAttribute('data-language', language.replace('language-', ''));
+          }
+        }
+      }
+    });
+  }
+
+  function bootstrapThebe() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (!window.thebelab) {
+      window.setTimeout(bootstrapThebe, POLLING_INTERVAL_MS);
+      return;
+    }
+
+    tagExecutableBlocks();
+
+    window.thebelab.bootstrap({
+      requestKernel: true,
+      binderOptions: {
+        repo: 'saint2706/Coding-For-MBA',
+        ref: 'main',
+      },
+      kernelOptions: {
+        name: 'python3',
+        kernelName: 'python3',
+      },
+      selector: EXECUTABLE_SELECTOR,
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    tagExecutableBlocks();
+    bootstrapThebe();
+  });
+})();

--- a/docs/website-improvements.md
+++ b/docs/website-improvements.md
@@ -32,7 +32,8 @@ learning experience.
 - 🚧 **Pyodide widgets are prototyped** – `docs/javascripts/pyodide-console.js` ships an interactive widget, but no production lessons embed it yet.
 - ✅ **Lesson progress tracking shipped** – `docs/javascripts/progress-tracker.js` and the MkDocs override add completion buttons and sidebar stats.
 - 🚧 **Accessibility enhancements ongoing** – baseline focus/contrast styles live in `docs/stylesheets/extra.css`, yet skip links and broader ARIA coverage still need wiring.
-- ⏳ **Thebe, enhanced search, quizzes, analytics, and feedback widgets** – configuration files and content for these features are not in the repo, so they remain future work.
+- ✅ **Thebe integration live** – MkDocs now loads the CDN bundle and `docs/javascripts/thebe-config.js`, enabling inline Binder-backed execution for marked code blocks.
+- ⏳ **Enhanced search, quizzes, analytics, and feedback widgets** – configuration files and content for these features are not in the repo, so they remain future work.
 
 ______________________________________________________________________
 
@@ -103,9 +104,9 @@ using WebAssembly.
 
 **Estimated Effort**: 4-6 hours **Impact**: HIGH - Enables full interactive coding experience
 
-#### 1.2 Thebe Integration _(Status: ⏳ Not started)_
+#### 1.2 Thebe Integration _(Status: ✅ Delivered)_
 
-> **Current state**: There is no Thebe configuration in `mkdocs.yml`, and `docs/javascripts/` only ships Pyodide and progress-tracker scripts. Implementing Thebe would still require adding the CDN assets and config file described below.
+> **Current state**: The MkDocs configuration now loads the Thebe CDN bundle alongside `docs/javascripts/thebe-config.js`, which boots Binder-backed kernels for any code block wrapped in an element marked `data-executable="true"`.
 
 **What**: Thebe makes static HTML pages interactive by connecting code cells to a Jupyter kernel
 (via Binder).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,8 @@ extra_css:
 - stylesheets/extra.css
 - stylesheets/interactive-widgets.css
 extra_javascript:
+- https://unpkg.com/thebe@latest/lib/index.js
+- javascripts/thebe-config.js
 - https://cdn.jsdelivr.net/pyodide/v0.25.0/full/pyodide.js
 - javascripts/pyodide-console.js
 - javascripts/progress-tracker.js


### PR DESCRIPTION
## Summary
- load the Thebe CDN bundle and bootstrap script in MkDocs so marked code blocks become executable
- add a reusable Thebe configuration script that connects to the repo's Binder image
- document the feature in the getting started guide and update the website improvements status report

## Testing
- mkdocs build --strict *(fails: mkdocs-jupyter plugin is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_690c95cb02888330ac0088742c26594e