### PR TITLE
Fix duplicate progress tracker display

### DIFF
--- a/docs/assets/js/progress.js
+++ b/docs/assets/js/progress.js
@@ -92,6 +92,12 @@
    * Insert progress bar into page
    */
   function insertProgressBar(progressBar) {
+    // Remove any existing tracker instance to avoid duplicates
+    const existing = document.getElementById('lesson-progress-tracker');
+    if (existing && existing.parentNode) {
+      existing.parentNode.removeChild(existing);
+    }
+
     // Try to insert after navigation or at the top of main content
     const article = document.querySelector('article.md-content__inner');
     const main = document.querySelector('main');
@@ -110,7 +116,12 @@
    * Add CSS styles for progress bar
    */
   function addStyles() {
+    if (document.getElementById('lesson-progress-tracker-styles')) {
+      return;
+    }
+
     const style = document.createElement('style');
+    style.id = 'lesson-progress-tracker-styles';
     style.textContent = `
       .lesson-progress-tracker {
         margin-bottom: 2rem;

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,7 +1,0 @@
-{% extends "base.html" %}
-
-{% block extrahead %}
-  {{ super() }}
-  <!-- Lesson progress tracker -->
-  <script src="{{ 'assets/js/progress.js' | url }}"></script>
-{% endblock %}


### PR DESCRIPTION
## Summary
- prevent the lesson progress bar script from leaving multiple tracker widgets in the DOM
- guard the inline style injection so the stylesheet is added only once per page load
- drop the redundant theme override that was loading the progress tracker script a second time

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df1e965c0833086eca7122e5a5bd6)