### PR TITLE
Harden MarkdownRenderer link href validation

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -18,6 +18,7 @@ import CodePlayground from './CodePlayground'
 import ExerciseWidget from './ExerciseWidget'
 import MasteryCheck from './MasteryCheck'
 import { glossaryTerms, getGlossaryRegex } from '../utils/glossary'
+import { normalizeAndValidateHref } from '../utils/linkSafety'
 
 /**
  * Custom Prism theme with transparent background for code blocks.
@@ -168,10 +169,15 @@ const TableComponent = ({ children }: { children?: React.ReactNode }) => {
  * @returns A properly configured link element
  */
 const LinkComponent = ({ href, children, ...props }: JSX.IntrinsicElements['a'] & ExtraProps) => {
-  const isExternal = href && (href.startsWith('http') || href.startsWith('//'))
+  const { normalizedHref, isExternal, isSafe } = normalizeAndValidateHref(href)
+
+  if (!isSafe || !normalizedHref) {
+    return <span>{children}</span>
+  }
+
   return (
     <a
-      href={href}
+      href={normalizedHref}
       {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
       {...props}
     >
@@ -628,7 +634,11 @@ const lessonSanitizerSchema: Schema = {
     code: ['className'],
     div: ['className'],
     img: ['src', 'alt', 'title', 'width', 'height', 'loading'],
-    input: [['type', 'checkbox'], ['disabled', true], ['checked', true]],
+    input: [
+      ['type', 'checkbox'],
+      ['disabled', true],
+      ['checked', true],
+    ],
     span: ['className', 'dataDefinition'],
     td: ['align'],
     th: ['align'],

--- a/src/components/__tests__/MarkdownRenderer.test.ts
+++ b/src/components/__tests__/MarkdownRenderer.test.ts
@@ -1,0 +1,43 @@
+import { normalizeAndValidateHref } from '../../utils/linkSafety'
+
+describe('normalizeAndValidateHref', () => {
+  it('rejects javascript URLs', () => {
+    expect(normalizeAndValidateHref('javascript:alert(1)')).toEqual({
+      normalizedHref: null,
+      isExternal: false,
+      isSafe: false,
+    })
+  })
+
+  it('rejects data URLs', () => {
+    expect(normalizeAndValidateHref('data:text/html,<script>alert(1)</script>')).toEqual({
+      normalizedHref: null,
+      isExternal: false,
+      isSafe: false,
+    })
+  })
+
+  it('allows relative paths', () => {
+    expect(normalizeAndValidateHref('/lessons/intro')).toEqual({
+      normalizedHref: '/lessons/intro',
+      isExternal: false,
+      isSafe: true,
+    })
+  })
+
+  it('allows absolute https links and marks them external', () => {
+    expect(normalizeAndValidateHref('https://example.com/docs')).toEqual({
+      normalizedHref: 'https://example.com/docs',
+      isExternal: true,
+      isSafe: true,
+    })
+  })
+
+  it('allows hash links', () => {
+    expect(normalizeAndValidateHref('#chapter-1')).toEqual({
+      normalizedHref: '#chapter-1',
+      isExternal: false,
+      isSafe: true,
+    })
+  })
+})

--- a/src/utils/linkSafety.ts
+++ b/src/utils/linkSafety.ts
@@ -1,0 +1,39 @@
+const SAFE_SCHEMES = new Set(['http:', 'https:', 'mailto:'])
+const URL_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:/
+
+export const normalizeAndValidateHref = (href?: string | null) => {
+  if (typeof href !== 'string') {
+    return { normalizedHref: null, isExternal: false, isSafe: false }
+  }
+
+  const normalizedHref = href.trim()
+
+  if (!normalizedHref || normalizedHref.startsWith('//')) {
+    return { normalizedHref: null, isExternal: false, isSafe: false }
+  }
+
+  if (
+    normalizedHref.startsWith('#') ||
+    normalizedHref.startsWith('/') ||
+    normalizedHref.startsWith('./') ||
+    normalizedHref.startsWith('../') ||
+    !URL_SCHEME_PATTERN.test(normalizedHref)
+  ) {
+    return { normalizedHref, isExternal: false, isSafe: true }
+  }
+
+  try {
+    const url = new URL(normalizedHref)
+    if (!SAFE_SCHEMES.has(url.protocol)) {
+      return { normalizedHref: null, isExternal: false, isSafe: false }
+    }
+
+    return {
+      normalizedHref,
+      isExternal: url.protocol === 'http:' || url.protocol === 'https:',
+      isSafe: true,
+    }
+  } catch {
+    return { normalizedHref: null, isExternal: false, isSafe: false }
+  }
+}


### PR DESCRIPTION
### Motivation
- Prevent unsafe or malformed markdown links from creating clickable attack vectors (e.g. `javascript:` or `data:` URLs). 
- Normalize and validate `href` values centrally so rendering logic is consistent and auditable. 
- Allow only known-safe schemes and common internal link types to preserve expected navigation behavior.

### Description
- Add a new utility `normalizeAndValidateHref` in `src/utils/linkSafety.ts` that trims, normalizes, and classifies `href` values and only accepts `http:`, `https:`, `mailto:`, hash links, and relative paths; it rejects `javascript:`, `data:`, protocol-relative `//...`, and other unsafe values. 
- Update `LinkComponent` in `src/components/MarkdownRenderer.tsx` to call the new utility and render unsafe links as plain text (`<span>{children}</span>`) while rendering safe links with their normalized `href`. 
- Preserve external-link behavior by marking `http`/`https` links as external and adding `target="_blank" rel="noopener noreferrer"` when appropriate. 
- Add unit tests at `src/components/__tests__/MarkdownRenderer.test.ts` covering `javascript:alert(1)`, `data:` URLs, relative paths, absolute `https` links, and hash links.

### Testing
- Ran the unit test file with `npm test -- src/components/__tests__/MarkdownRenderer.test.ts` and all tests passed (`5 passed`).
- Linting with `npx eslint src/components/MarkdownRenderer.tsx src/utils/linkSafety.ts src/components/__tests__/MarkdownRenderer.test.ts` ran without reported errors.
- Ran `npx prettier --write` on the changed files to fix formatting and the pre-commit style checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de58651c08330832dd1cca170d4f1)