### PR TITLE
Fix search result highlighting and add casing/repeat tests

### DIFF
--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -14,32 +14,7 @@ import { Helmet } from '@dr.pogodin/react-helmet'
 import { search, type SearchResult } from '../utils/searchIndex'
 import { difficultyConfig } from '../utils/contentLoader'
 import Breadcrumb from '../components/Breadcrumb'
-
-/**
- * Highlights matching text segments within a string.
- *
- * Wraps matching portions of text in <mark> elements for visual highlighting.
- * Uses case-insensitive matching and escapes special regex characters.
- *
- * @param text - The text to highlight matches in
- * @param query - The search query to match
- * @returns Array of text nodes and mark elements
- */
-function highlightText(text: string, query: string): React.ReactNode[] {
-  if (!query.trim()) return [text]
-  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const regex = new RegExp(`(${escaped})`, 'gi')
-  const parts = text.split(regex)
-  return parts.map((part, i) =>
-    regex.test(part) ? (
-      <mark key={i} className="search-highlight">
-        {part}
-      </mark>
-    ) : (
-      part
-    ),
-  )
-}
+import { highlightText } from '../utils/searchHighlight'
 
 /**
  * Extracts a relevant snippet of content around the search match.

--- a/src/pages/__tests__/SearchResults.test.tsx
+++ b/src/pages/__tests__/SearchResults.test.tsx
@@ -1,0 +1,28 @@
+import { isValidElement } from 'react'
+import { highlightText } from '../../utils/searchHighlight'
+
+describe('highlightText', () => {
+  it('highlights repeated matching terms', () => {
+    const result = highlightText('data data DATA', 'data')
+
+    const marked = result.filter((part) => isValidElement(part) && part.type === 'mark')
+    expect(marked).toHaveLength(3)
+
+    expect(marked.map((part) => (isValidElement(part) ? part.props.children : part))).toEqual([
+      'data',
+      'data',
+      'DATA',
+    ])
+  })
+
+  it('matches mixed-case queries case-insensitively', () => {
+    const result = highlightText('Python and pyThOn tips', 'PyThOn')
+
+    const marked = result.filter((part) => isValidElement(part) && part.type === 'mark')
+    expect(marked).toHaveLength(2)
+    expect(marked.map((part) => (isValidElement(part) ? part.props.children : part))).toEqual([
+      'Python',
+      'pyThOn',
+    ])
+  })
+})

--- a/src/utils/searchHighlight.tsx
+++ b/src/utils/searchHighlight.tsx
@@ -1,0 +1,24 @@
+import type React from 'react'
+
+/**
+ * Highlights matching text segments within a string.
+ *
+ * Wraps matching portions of text in <mark> elements for visual highlighting.
+ * Uses case-insensitive matching and escapes special regex characters.
+ */
+export function highlightText(text: string, query: string): React.ReactNode[] {
+  if (!query.trim()) return [text]
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const regex = new RegExp(`(${escaped})`, 'gi')
+  const parts = text.split(regex)
+
+  return parts.map((part, i) =>
+    i % 2 === 1 ? (
+      <mark key={i} className="search-highlight">
+        {part}
+      </mark>
+    ) : (
+      part
+    ),
+  )
+}


### PR DESCRIPTION
### Motivation
- Replace fragile use of `RegExp.test` on a global regex to avoid stateful/global-regex issues when highlighting repeated matches.

### Description
- Extracted the highlight logic to `src/utils/searchHighlight.tsx` and exported `highlightText` for reuse in `SearchResults`.
- Rewrote `highlightText` to build a case-insensitive capturing regex and use the capturing-group `split` approach, marking captured segments by index parity (`i % 2 === 1`).
- Updated `src/pages/SearchResults.tsx` to import and use the new `highlightText` utility for titles, snippets, and tags with no change to rendering sites.
- Added unit tests at `src/pages/__tests__/SearchResults.test.tsx` to cover repeated matching terms and mixed-case query matching.

### Testing
- Ran `npm test -- --run src/pages/__tests__/SearchResults.test.tsx` and the tests passed (2 tests, 0 failures).
- Ran `npx eslint src/pages/SearchResults.tsx src/utils/searchHighlight.tsx src/pages/__tests__/SearchResults.test.tsx` and linting succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de672d2388330b2bcb31014204a84)