### PR TITLE
Add safe localStorage helper and refactor theme/progress storage access

### DIFF
--- a/src/context/ThemeProvider.tsx
+++ b/src/context/ThemeProvider.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useEffect, useCallback, ReactNode } from 'react'
 import { Theme, ThemeContext } from './ThemeContext'
+import { getStoredString, setStoredString } from '../utils/safeStorage'
 
 /**
  * Determines the initial theme based on localStorage and system preferences.
@@ -20,7 +21,7 @@ import { Theme, ThemeContext } from './ThemeContext'
  */
 function getInitialTheme(): Theme {
   // Check localStorage first
-  const stored = localStorage.getItem('theme') as Theme | null
+  const stored = getStoredString('theme')
   if (stored === 'light' || stored === 'dark') return stored
 
   // Respect prefers-color-scheme
@@ -46,7 +47,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // Apply theme to document
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme)
-    localStorage.setItem('theme', theme)
+    setStoredString('theme', theme)
   }, [theme])
 
   // Listen for system preference changes
@@ -54,7 +55,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     const mq = window.matchMedia('(prefers-color-scheme: light)')
     const handler = (e: MediaQueryListEvent) => {
       // Only auto-switch if no explicit preference stored
-      if (!localStorage.getItem('theme')) {
+      if (!getStoredString('theme')) {
         setTheme(e.matches ? 'light' : 'dark')
       }
     }

--- a/src/utils/__tests__/progressTracker.test.ts
+++ b/src/utils/__tests__/progressTracker.test.ts
@@ -82,6 +82,18 @@ describe('progressTracker', () => {
     removeSpy.mockRestore()
   })
 
+  it('returns typed fallbacks when storage reads throw', () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Blocked', 'SecurityError')
+    })
+
+    expect(() => getCompletedLessons()).not.toThrow()
+    expect(getCompletedLessons()).toEqual([])
+    expect(getLastVisited()).toBeNull()
+
+    getItemSpy.mockRestore()
+  })
+
   it('uses memory cache to avoid redundant storage access', () => {
     const getItemSpy = vi.spyOn(Storage.prototype, 'getItem')
 

--- a/src/utils/progressTracker.ts
+++ b/src/utils/progressTracker.ts
@@ -5,6 +5,8 @@
  * Tracks completed lessons and last visited lesson for persistent learning progress.
  */
 
+import { getStoredJson, getStoredString, removeStoredValue, setStoredString } from './safeStorage'
+
 /**
  * localStorage key for storing completed lesson day numbers.
  */
@@ -38,23 +40,9 @@ if (typeof window !== 'undefined') {
 function getCompleted(): Set<number> {
   if (completedCache) return completedCache
 
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) {
-      completedCache = new Set()
-      return completedCache
-    }
-    const parsed: unknown = JSON.parse(raw)
-    if (!Array.isArray(parsed)) {
-      completedCache = new Set()
-      return completedCache
-    }
-    completedCache = new Set(parsed.filter((n): n is number => typeof n === 'number'))
-    return completedCache
-  } catch {
-    completedCache = new Set()
-    return completedCache
-  }
+  const parsed = getStoredJson<unknown[]>(STORAGE_KEY, [], Array.isArray)
+  completedCache = new Set(parsed.filter((n): n is number => typeof n === 'number'))
+  return completedCache
 }
 
 /**
@@ -64,12 +52,7 @@ function getCompleted(): Set<number> {
  */
 function saveCompleted(completed: Set<number>): void {
   completedCache = completed
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify([...completed]))
-  } catch {
-    // Storage may be unavailable in private browsing mode or when quota is exceeded.
-    // Silently ignore persistence failures to keep UI interactions functional.
-  }
+  setStoredString(STORAGE_KEY, JSON.stringify([...completed]))
 }
 
 /**
@@ -157,11 +140,7 @@ export function getCompletedForPhase(phaseLessonDays: number[]): number[] {
  * @param day - Day number of the lesson that was visited
  */
 export function setLastVisited(day: number): void {
-  try {
-    localStorage.setItem(LAST_VISITED_KEY, String(day))
-  } catch {
-    // Storage may be blocked; keep runtime behavior non-fatal.
-  }
+  setStoredString(LAST_VISITED_KEY, String(day))
 }
 
 /**
@@ -170,7 +149,7 @@ export function setLastVisited(day: number): void {
  * @returns Last visited lesson day number, or null if none recorded
  */
 export function getLastVisited(): number | null {
-  const raw = localStorage.getItem(LAST_VISITED_KEY)
+  const raw = getStoredString(LAST_VISITED_KEY)
   if (!raw) return null
   const num = Number(raw)
   return isNaN(num) || num < 1 ? null : num
@@ -182,10 +161,6 @@ export function getLastVisited(): number | null {
  */
 export function clearAllProgress(): void {
   completedCache = null
-  try {
-    localStorage.removeItem(STORAGE_KEY)
-    localStorage.removeItem(LAST_VISITED_KEY)
-  } catch {
-    // Ignore failures for consistency with other storage operations.
-  }
+  removeStoredValue(STORAGE_KEY)
+  removeStoredValue(LAST_VISITED_KEY)
 }

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -1,0 +1,73 @@
+/**
+ * Safe localStorage helpers with typed fallbacks.
+ *
+ * These wrappers prevent localStorage failures (security, quota, private mode)
+ * from crashing runtime logic.
+ */
+
+/**
+ * Gets a raw string value from localStorage with a fallback.
+ *
+ * @param key - localStorage key
+ * @param fallback - value returned when storage is unavailable or key is missing
+ */
+export function getStoredString(key: string, fallback: string | null = null): string | null {
+  try {
+    const value = localStorage.getItem(key)
+    return value ?? fallback
+  } catch {
+    return fallback
+  }
+}
+
+/**
+ * Gets and parses JSON from localStorage with a typed fallback.
+ *
+ * @param key - localStorage key
+ * @param fallback - value returned when storage is unavailable/invalid
+ * @param validate - optional runtime validator for parsed data
+ */
+export function getStoredJson<T>(
+  key: string,
+  fallback: T,
+  validate?: (value: unknown) => value is T,
+): T {
+  const raw = getStoredString(key)
+  if (!raw) return fallback
+
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (validate && !validate(parsed)) return fallback
+    return (parsed as T) ?? fallback
+  } catch {
+    return fallback
+  }
+}
+
+/**
+ * Writes a string value to localStorage.
+ *
+ * @returns true when write succeeds, false when blocked/unavailable
+ */
+export function setStoredString(key: string, value: string): boolean {
+  try {
+    localStorage.setItem(key, value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Removes a key from localStorage.
+ *
+ * @returns true when remove succeeds, false when blocked/unavailable
+ */
+export function removeStoredValue(key: string): boolean {
+  try {
+    localStorage.removeItem(key)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
### Motivation
- Centralize and harden all `localStorage` access so storage failures (security, quota, private mode) don't throw and the app can fall back to typed defaults.
- Reduce duplicated try/catch logic and ensure consistent JSON parsing and validation for persisted progress and theme state.

### Description
- Add `src/utils/safeStorage.ts` with `getStoredString`, `getStoredJson<T>`, `setStoredString`, and `removeStoredValue` to wrap `localStorage` operations and provide typed fallbacks.
- Refactor `src/utils/progressTracker.ts` to use `getStoredJson`, `getStoredString`, `setStoredString`, and `removeStoredValue` for all reads/writes/removals and keep the existing in-memory cache behavior via `getCompleted`/`saveCompleted`.
- Refactor `src/context/ThemeProvider.tsx` to use `getStoredString` and `setStoredString` for initial theme detection, persistence, and the system-preference change guard.
- Add a test in `src/utils/__tests__/progressTracker.test.ts` that simulates `Storage.prototype.getItem` throwing and verifies that `getCompletedLessons()` and `getLastVisited()` return typed fallbacks and do not throw.

### Testing
- Ran `npm run test -- src/utils/__tests__/progressTracker.test.ts` and the test file passed (8 tests) successfully.
- Ran `npm run typecheck` which reported failures unrelated to these changes (missing type declarations in other modules), so typecheck did not pass but the failures pre-existed and were not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698deddeb28c83308e65d64aa78a451b)