### PR TITLE
Unify markdown heading slug generation across renderer and TOC

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -19,6 +19,7 @@ import ExerciseWidget from './ExerciseWidget'
 import MasteryCheck from './MasteryCheck'
 import { glossaryTerms, getGlossaryRegex } from '../utils/glossary'
 import { normalizeAndValidateHref } from '../utils/linkSafety'
+import { createSlugger, extractTextFromReactNode } from '../utils/slug'
 
 /**
  * Custom Prism theme with transparent background for code blocks.
@@ -193,54 +194,19 @@ const LinkComponent = ({ href, children, ...props }: JSX.IntrinsicElements['a'] 
  * @param props - Additional heading attributes
  * @returns H1 element with ID generated from content
  */
-const Heading1 = ({ children, ...props }: JSX.IntrinsicElements['h1'] & ExtraProps) => {
-  const id = String(children)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '')
-  return (
-    <h1 id={id} {...props}>
-      {children}
-    </h1>
-  )
-}
+function createHeadingComponent(
+  Tag: 'h1' | 'h2' | 'h3',
+  slugger: ReturnType<typeof createSlugger>,
+) {
+  return ({ children, ...props }: JSX.IntrinsicElements['h1'] & ExtraProps) => {
+    const id = slugger.slug(extractTextFromReactNode(children))
 
-/**
- * Custom H2 heading component with auto-generated ID for linking.
- *
- * @param children - Heading content
- * @param props - Additional heading attributes
- * @returns H2 element with ID generated from content
- */
-const Heading2 = ({ children, ...props }: JSX.IntrinsicElements['h2'] & ExtraProps) => {
-  const id = String(children)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '')
-  return (
-    <h2 id={id} {...props}>
-      {children}
-    </h2>
-  )
-}
-
-/**
- * Custom H3 heading component with auto-generated ID for linking.
- *
- * @param children - Heading content
- * @param props - Additional heading attributes
- * @returns H3 element with ID generated from content
- */
-const Heading3 = ({ children, ...props }: JSX.IntrinsicElements['h3'] & ExtraProps) => {
-  const id = String(children)
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '')
-  return (
-    <h3 id={id} {...props}>
-      {children}
-    </h3>
-  )
+    return (
+      <Tag id={id} {...props}>
+        {children}
+      </Tag>
+    )
+  }
 }
 
 /**
@@ -485,8 +451,25 @@ function findInteractiveBlocks(content: string): InteractiveBlock[] {
  * @param content - Markdown content to render
  * @returns Rendered content with interactive components
  */
+function createMarkdownComponents(slugger: ReturnType<typeof createSlugger>): Components {
+  return {
+    code: CodeComponent,
+    table: TableComponent,
+    a: LinkComponent,
+    h1: createHeadingComponent('h1', slugger),
+    h2: createHeadingComponent('h2', slugger),
+    h3: createHeadingComponent('h3', slugger),
+    p: ParagraphWithGlossary,
+  }
+}
+
 function InteractiveContent({ content }: { content: string }) {
   const blocks = useMemo(() => findInteractiveBlocks(content), [content])
+  const slugger = useMemo(() => {
+    void content
+    return createSlugger()
+  }, [content])
+  const markdownComponents = useMemo(() => createMarkdownComponents(slugger), [slugger])
 
   if (blocks.length === 0) {
     return (
@@ -572,19 +555,6 @@ function InteractiveContent({ content }: { content: string }) {
   }
 
   return <>{segments}</>
-}
-
-/**
- * Custom component overrides for ReactMarkdown.
- */
-const markdownComponents: Components = {
-  code: CodeComponent,
-  table: TableComponent,
-  a: LinkComponent,
-  h1: Heading1,
-  h2: Heading2,
-  h3: Heading3,
-  p: ParagraphWithGlossary,
 }
 
 /**

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useMemo, useState, useEffect } from 'react'
+import { parseHeadings } from '../utils/toc'
 
 /**
  * Represents a heading entry in the table of contents.
@@ -14,44 +15,6 @@ import { useMemo, useState, useEffect } from 'react'
  * @property text - Display text of the heading
  * @property level - Heading level (2 or 3 for h2/h3)
  */
-interface TocEntry {
-  id: string
-  text: string
-  level: number
-}
-
-/**
- * Parses markdown content to extract h2 and h3 headings.
- * Skips headings inside code blocks.
- *
- * @param content - Markdown content to parse
- * @returns Array of table of contents entries
- */
-function parseHeadings(content: string): TocEntry[] {
-  const entries: TocEntry[] = []
-  const lines = content.split('\n')
-  let inCodeBlock = false
-
-  for (const line of lines) {
-    if (line.trimStart().startsWith('```')) {
-      inCodeBlock = !inCodeBlock
-      continue
-    }
-    if (inCodeBlock) continue
-
-    const match = line.match(/^(#{2,3})\s+(.+)$/)
-    if (match) {
-      const text = match[2]!.replace(/[*_`~]/g, '').trim()
-      const id = text
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/(^-|-$)/g, '')
-      entries.push({ id, text, level: match[1]!.length })
-    }
-  }
-  return entries
-}
-
 /**
  * Props for the TableOfContents component.
  *

--- a/src/components/__tests__/MarkdownRendererHeadings.test.tsx
+++ b/src/components/__tests__/MarkdownRendererHeadings.test.tsx
@@ -1,0 +1,20 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import MarkdownRenderer from '../MarkdownRenderer'
+
+describe('MarkdownRenderer heading ids', () => {
+  it('applies shared slug rules to formatted and repeated headings', () => {
+    const content = [
+      '## **Profit** `Growth` & ROI!!!',
+      '### Profit Growth ROI',
+      '## Repeat Title',
+      '## Repeat Title',
+    ].join('\n')
+
+    const html = renderToStaticMarkup(<MarkdownRenderer content={content} />)
+
+    expect(html).toMatch(/<h2[^>]*id="profit-growth-roi"/)
+    expect(html).toMatch(/<h3[^>]*id="profit-growth-roi-1"/)
+    expect(html).toMatch(/<h2[^>]*id="repeat-title"/)
+    expect(html).toMatch(/<h2[^>]*id="repeat-title-1"/)
+  })
+})

--- a/src/components/__tests__/TableOfContents.test.ts
+++ b/src/components/__tests__/TableOfContents.test.ts
@@ -1,0 +1,20 @@
+import { parseHeadings } from '../../utils/toc'
+
+describe('parseHeadings', () => {
+  it('uses shared slug normalization for emphasis, inline code, symbols, and duplicates', () => {
+    const content = [
+      '# Intro',
+      '## **Profit** `Growth` & ROI!!!',
+      '### Profit Growth ROI',
+      '## Repeat Title',
+      '## Repeat Title',
+    ].join('\n')
+
+    expect(parseHeadings(content)).toEqual([
+      { id: 'profit-growth-roi', text: 'Profit Growth & ROI!!!', level: 2 },
+      { id: 'profit-growth-roi-1', text: 'Profit Growth ROI', level: 3 },
+      { id: 'repeat-title', text: 'Repeat Title', level: 2 },
+      { id: 'repeat-title-1', text: 'Repeat Title', level: 2 },
+    ])
+  })
+})

--- a/src/utils/__tests__/slug.test.ts
+++ b/src/utils/__tests__/slug.test.ts
@@ -1,0 +1,30 @@
+import { createElement } from 'react'
+import { createSlugger, extractTextFromReactNode, stripMarkdownInlineFormatting } from '../slug'
+
+describe('slug utilities', () => {
+  it('strips markdown inline formatting from heading text', () => {
+    expect(stripMarkdownInlineFormatting('**Profit** `Growth` & ROI!!!')).toBe(
+      'Profit Growth & ROI!!!',
+    )
+  })
+
+  it('extracts text from nested React nodes', () => {
+    const node = [
+      'Profit ',
+      createElement('em', { key: '1' }, 'Growth'),
+      ' ',
+      createElement('code', { key: '2' }, 'Q4'),
+      ' & ROI',
+    ]
+
+    expect(extractTextFromReactNode(node)).toBe('Profit Growth Q4 & ROI')
+  })
+
+  it('normalizes symbols, casing, whitespace, and duplicates', () => {
+    const slugger = createSlugger()
+
+    expect(slugger.slug('  Profit   Growth & ROI!!! ')).toBe('profit-growth-roi')
+    expect(slugger.slug('Profit Growth ROI')).toBe('profit-growth-roi-1')
+    expect(slugger.slug('PROFIT growth roi')).toBe('profit-growth-roi-2')
+  })
+})

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,0 +1,47 @@
+import { isValidElement, type ReactNode } from 'react'
+
+function normalizeForSlug(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .trim()
+    .replace(/[\s-]+/g, '-')
+}
+
+export function stripMarkdownInlineFormatting(value: string): string {
+  return value
+    .replace(/\s+#+\s*$/, '')
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/(\*\*|__)(.*?)\1/g, '$2')
+    .replace(/(\*|_)(.*?)\1/g, '$2')
+    .replace(/~~(.*?)~~/g, '$1')
+    .replace(/\\([\\`*_[\]{}()#+\-.!])/g, '$1')
+    .trim()
+}
+
+export function extractTextFromReactNode(node: ReactNode): string {
+  if (node == null || typeof node === 'boolean') return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map((child) => extractTextFromReactNode(child)).join('')
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return extractTextFromReactNode(node.props.children)
+  }
+  return ''
+}
+
+export function createSlugger() {
+  const counts = new Map<string, number>()
+
+  return {
+    slug(value: string): string {
+      const base = normalizeForSlug(value) || 'section'
+      const count = counts.get(base) ?? 0
+      counts.set(base, count + 1)
+      return count === 0 ? base : `${base}-${count}`
+    },
+  }
+}

--- a/src/utils/toc.ts
+++ b/src/utils/toc.ts
@@ -1,0 +1,35 @@
+import { createSlugger, stripMarkdownInlineFormatting } from './slug'
+
+interface TocEntry {
+  id: string
+  text: string
+  level: number
+}
+
+export function parseHeadings(content: string): TocEntry[] {
+  const entries: TocEntry[] = []
+  const lines = content.split('\n')
+  let inCodeBlock = false
+  const slugger = createSlugger()
+
+  for (const line of lines) {
+    if (line.trimStart().startsWith('```')) {
+      inCodeBlock = !inCodeBlock
+      continue
+    }
+    if (inCodeBlock) continue
+
+    const match = line.match(/^(#{1,3})\s+(.+)$/)
+    if (match) {
+      const level = match[1]!.length
+      const text = stripMarkdownInlineFormatting(match[2]!)
+      const id = slugger.slug(text)
+
+      if (level >= 2 && level <= 3) {
+        entries.push({ id, text, level })
+      }
+    }
+  }
+
+  return entries
+}


### PR DESCRIPTION
### Motivation

- Ensure heading IDs are generated consistently between the rendered headings and the table-of-contents so links and scrolling behave predictably.
- Normalize punctuation, casing, whitespace, inline markdown, and diacritics the same way for both renderer and TOC, and handle duplicate titles with suffixes.
- Support headings whose children are React nodes (emphasis, inline code, etc.) by extracting the visible text for slug generation.

### Description

- Added a shared slug utility at `src/utils/slug.ts` that provides `createSlugger`, `stripMarkdownInlineFormatting`, and `extractTextFromReactNode`, with NFKD normalization, diacritic removal, non-alphanumeric collapsing, lowercasing, whitespace collapsing, and duplicate-aware suffixing.
- Moved TOC parsing into `src/utils/toc.ts` and updated `TableOfContents` to use `parseHeadings` which consumes the shared slug rules so IDs match the renderer.
- Updated `src/components/MarkdownRenderer.tsx` to create a per-render slugger and used `createHeadingComponent` (for `h1`/`h2`/`h3`) that extracts text from children and generates IDs via the shared slugger.
- Added focused tests covering emphasis, inline code, symbols, and repeated headings in `src/utils/__tests__/slug.test.ts`, `src/components/__tests__/TableOfContents.test.ts`, and `src/components/__tests__/MarkdownRendererHeadings.test.tsx`.

### Testing

- Ran the unit tests for the affected areas with `npm test -- src/utils/__tests__/slug.test.ts src/components/__tests__/TableOfContents.test.ts src/components/__tests__/MarkdownRendererHeadings.test.tsx`, and all tests passed.
- Ran lint and formatting checks with `npx eslint ...` and `prettier --check` (fixes applied where needed), and the code passes linting/formatting checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698df05541548330bcacc1d943f158e8)