### PR TITLE
Normalize validate-content parsing and add LF/CRLF fixtures

### DIFF
--- a/scripts/__fixtures__/validate-content/sample-crlf.md
+++ b/scripts/__fixtures__/validate-content/sample-crlf.md
@@ -1,0 +1,8 @@
+---
+day: 1
+title: Sample Lesson
+phase: 1
+difficulty: beginner
+duration: 30
+---
+This is a sample lesson body with enough content to pass validation checks because it clearly exceeds one hundred characters in total length.

--- a/scripts/__fixtures__/validate-content/sample-lf.md
+++ b/scripts/__fixtures__/validate-content/sample-lf.md
@@ -1,0 +1,8 @@
+---
+day: 1
+title: Sample Lesson
+phase: 1
+difficulty: beginner
+duration: 30
+---
+This is a sample lesson body with enough content to pass validation checks because it clearly exceeds one hundred characters in total length.

--- a/scripts/frontmatter-parser.ts
+++ b/scripts/frontmatter-parser.ts
@@ -1,5 +1,17 @@
-import { parseMarkdown } from '../src/utils/frontmatter.ts'
+import {
+  normalizeMarkdownLineEndings,
+  parseMarkdown,
+  parseNormalizedMarkdown,
+} from '../src/utils/frontmatter.ts'
 
 export function parseMarkdownForScripts(raw: string) {
   return parseMarkdown(raw)
+}
+
+export function normalizeLineEndingsForScripts(raw: string) {
+  return normalizeMarkdownLineEndings(raw)
+}
+
+export function parseNormalizedMarkdownForScripts(normalized: string) {
+  return parseNormalizedMarkdown(normalized)
 }

--- a/scripts/validate-content.js
+++ b/scripts/validate-content.js
@@ -8,51 +8,42 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { parseMarkdownForScripts } from './frontmatter-parser.ts'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import {
+  normalizeLineEndingsForScripts,
+  parseNormalizedMarkdownForScripts,
+} from './frontmatter-parser.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const LESSONS_DIR = path.join(__dirname, '..', 'Lessons')
 const REQUIRED_FIELDS = ['day', 'title', 'phase', 'difficulty', 'duration']
 
-let totalFiles = 0
-let passCount = 0
-let failCount = 0
-const errors = []
-
-// Find all lesson README.md files
-function findReadmes(dir) {
+export function findReadmes(dir, lessonsDir = LESSONS_DIR) {
   const results = []
   if (!fs.existsSync(dir)) return results
 
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const fullPath = path.join(dir, entry.name)
     if (entry.isDirectory()) {
-      results.push(...findReadmes(fullPath))
-    } else if (entry.name === 'README.md' && dir !== LESSONS_DIR) {
+      results.push(...findReadmes(fullPath, lessonsDir))
+    } else if (entry.name === 'README.md' && dir !== lessonsDir) {
       results.push(fullPath)
     }
   }
+
   return results
 }
 
-const readmes = findReadmes(LESSONS_DIR).sort()
-totalFiles = readmes.length
-
-console.log(`\n📋 Validating ${totalFiles} lesson files...\n`)
-
-for (const filePath of readmes) {
-  const relativePath = path.relative(LESSONS_DIR, filePath)
-  const fileContent = fs.readFileSync(filePath, 'utf8')
-  const { frontmatter: fields, content } = parseMarkdownForScripts(fileContent)
+export function validateLessonContent(rawContent) {
+  const normalizedContent = normalizeLineEndingsForScripts(rawContent)
+  const { frontmatter: fields, content: body } =
+    parseNormalizedMarkdownForScripts(normalizedContent)
+  const fileErrors = []
 
   if (Object.keys(fields).length === 0) {
-    failCount++
-    errors.push({ file: relativePath, issues: ['Missing frontmatter block'] })
-    continue
+    fileErrors.push('Missing frontmatter block')
+    return fileErrors
   }
-
-  const fileErrors = []
 
   for (const field of REQUIRED_FIELDS) {
     if (!(field in fields)) {
@@ -60,7 +51,6 @@ for (const filePath of readmes) {
     }
   }
 
-  // Type checks
   if (fields.day !== undefined && isNaN(Number(fields.day))) {
     fileErrors.push(`"day" should be a number, got: ${fields.day}`)
   }
@@ -71,31 +61,56 @@ for (const filePath of readmes) {
     fileErrors.push(`"duration" should be a number, got: ${fields.duration}`)
   }
 
-  // Content length check
-  if (content.trim().length < 100) {
+  if (body.trim().length < 100) {
     fileErrors.push('Content body is suspiciously short (< 100 chars)')
   }
 
-  if (fileErrors.length > 0) {
-    failCount++
-    errors.push({ file: relativePath, issues: fileErrors })
-  } else {
-    passCount++
-  }
+  return fileErrors
 }
 
-// Report
-console.log(`✅ Passed: ${passCount}/${totalFiles}`)
-if (failCount > 0) {
-  console.log(`❌ Failed: ${failCount}/${totalFiles}\n`)
-  for (const { file, issues } of errors) {
-    console.log(`  📄 ${file}`)
-    for (const issue of issues) {
-      console.log(`     ⚠ ${issue}`)
+export function runValidation(lessonsDir = LESSONS_DIR) {
+  const readmes = findReadmes(lessonsDir, lessonsDir).sort()
+  const totalFiles = readmes.length
+  let passCount = 0
+  let failCount = 0
+  const errors = []
+
+  console.log(`\n📋 Validating ${totalFiles} lesson files...\n`)
+
+  for (const filePath of readmes) {
+    const relativePath = path.relative(lessonsDir, filePath)
+    const fileContent = fs.readFileSync(filePath, 'utf8')
+    const fileErrors = validateLessonContent(fileContent)
+
+    if (fileErrors.length > 0) {
+      failCount++
+      errors.push({ file: relativePath, issues: fileErrors })
+    } else {
+      passCount++
     }
-    console.log()
   }
-  process.exit(1)
-} else {
+
+  console.log(`✅ Passed: ${passCount}/${totalFiles}`)
+
+  if (failCount > 0) {
+    console.log(`❌ Failed: ${failCount}/${totalFiles}\n`)
+    for (const { file, issues } of errors) {
+      console.log(`  📄 ${file}`)
+      for (const issue of issues) {
+        console.log(`     ⚠ ${issue}`)
+      }
+      console.log()
+    }
+    return 1
+  }
+
   console.log('\n🎉 All lessons have valid frontmatter!\n')
+  return 0
+}
+
+const isMainModule =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href
+
+if (isMainModule) {
+  process.exit(runValidation())
 }

--- a/src/utils/__tests__/validate-content-script.test.ts
+++ b/src/utils/__tests__/validate-content-script.test.ts
@@ -1,0 +1,29 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { validateLessonContent } from '../../../scripts/validate-content.js'
+
+const FIXTURES_DIR = path.join(
+  import.meta.dirname,
+  '..',
+  '..',
+  '..',
+  'scripts',
+  '__fixtures__',
+  'validate-content',
+)
+
+function readFixture(fileName: string) {
+  return fs.readFileSync(path.join(FIXTURES_DIR, fileName), 'utf8')
+}
+
+describe('validateLessonContent', () => {
+  it('validates LF and CRLF fixture content identically', () => {
+    const lfErrors = validateLessonContent(readFixture('sample-lf.md'))
+    const crlfErrors = validateLessonContent(readFixture('sample-crlf.md'))
+
+    expect(lfErrors).toEqual([])
+    expect(crlfErrors).toEqual([])
+    expect(crlfErrors).toEqual(lfErrors)
+  })
+})

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -12,6 +12,8 @@ export interface ParsedMarkdown {
 }
 
 const BLOCKED_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+const FRONTMATTER_START_DELIMITER = '---\n'
+const FRONTMATTER_END_DELIMITER = '\n---\n'
 
 function coerceScalar(rawValue: string): string | number | boolean {
   const unquoted = rawValue.replace(/^["']|["']$/g, '')
@@ -23,20 +25,22 @@ function coerceScalar(rawValue: string): string | number | boolean {
   return unquoted
 }
 
-export function parseMarkdown(raw: string): ParsedMarkdown {
-  const normalized = raw.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+export function normalizeMarkdownLineEndings(raw: string): string {
+  return raw.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+}
 
-  if (!normalized.startsWith('---\n')) {
+export function parseNormalizedMarkdown(normalized: string): ParsedMarkdown {
+  if (!normalized.startsWith(FRONTMATTER_START_DELIMITER)) {
     return { frontmatter: Object.create(null), content: normalized }
   }
 
-  const endIndex = normalized.indexOf('\n---\n', 4)
+  const endIndex = normalized.indexOf(FRONTMATTER_END_DELIMITER, FRONTMATTER_START_DELIMITER.length)
   if (endIndex === -1) {
     return { frontmatter: Object.create(null), content: normalized }
   }
 
-  const yamlStr = normalized.slice(4, endIndex)
-  const content = normalized.slice(endIndex + 5)
+  const yamlStr = normalized.slice(FRONTMATTER_START_DELIMITER.length, endIndex)
+  const content = normalized.slice(endIndex + FRONTMATTER_END_DELIMITER.length)
   const frontmatter: Frontmatter = Object.create(null)
 
   let currentKey: string | null = null
@@ -92,4 +96,8 @@ export function parseMarkdown(raw: string): ParsedMarkdown {
   }
 
   return { frontmatter, content }
+}
+
+export function parseMarkdown(raw: string): ParsedMarkdown {
+  return parseNormalizedMarkdown(normalizeMarkdownLineEndings(raw))
 }


### PR DESCRIPTION
### Motivation
- Ensure frontmatter parsing and body extraction behave identically for LF and CRLF files by normalizing line endings once and reusing the same delimiter logic used by the app parser. 
- Remove the brittle hard-coded body-slice offset and centralize frontmatter delimiters to avoid parsing inconsistencies. 
- Make the validation script testable and reusable by extracting validation logic into exported functions.

### Description
- Added line-ending normalization and normalized-parser helpers to `src/utils/frontmatter.ts` (`normalizeMarkdownLineEndings`, `parseNormalizedMarkdown`, and delimiter constants) and made `parseMarkdown` call the normalized flow. 
- Extended `scripts/frontmatter-parser.ts` to export `normalizeLineEndingsForScripts` and `parseNormalizedMarkdownForScripts` so scripts can reuse the same parsing helpers. 
- Refactored `scripts/validate-content.js` to expose `findReadmes`, `validateLessonContent`, and `runValidation`, to normalize file content once, parse the normalized markdown for frontmatter and body (no hard-coded offsets), and keep the original CLI behavior via a main check. 
- Added LF and CRLF sample fixtures at `scripts/__fixtures__/validate-content/sample-lf.md` and `sample-crlf.md`. 
- Added a Vitest test at `src/utils/__tests__/validate-content-script.test.ts` that asserts both fixtures validate identically.

### Testing
- Ran the unit test with `npm test -- src/utils/__tests__/validate-content-script.test.ts` and it passed. 
- Ran the full validator with `npm run validate-content` and it reported `✅ Passed: 108/108`. 
- Ran formatting/lint checks (`npx prettier` and `npx eslint`) as part of the commit hooks and fixed formatting issues before committing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698df392f9e48330b30b1b3c31fe7dfb)