### PR TITLE
chore: clean docs and enforce duplicate/dead-comment lint checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint and static quality checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint with duplicate/comment checks
+        run: npm run lint:ci

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,9 @@
 import js from '@eslint/js'
+import eslintComments from 'eslint-plugin-eslint-comments'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import sonarjs from 'eslint-plugin-sonarjs'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
@@ -15,6 +17,10 @@ export default defineConfig([
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
     ],
+    plugins: {
+      sonarjs,
+      'eslint-comments': eslintComments,
+    },
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
@@ -28,6 +34,11 @@ export default defineConfig([
     rules: {
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'eslint-comments/no-unused-disable': 'error',
+      'eslint-comments/no-unlimited-disable': 'error',
+      'sonarjs/no-identical-functions': 'error',
+      'sonarjs/no-duplicated-branches': 'error',
+      'sonarjs/no-all-duplicated-branches': 'error',
     },
   },
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,10 @@
         "@vitejs/plugin-react": "^5.1.1",
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^9.39.1",
+        "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
+        "eslint-plugin-sonarjs": "^3.0.5",
         "globals": "^16.5.0",
         "husky": "^9.1.7",
         "jsdom": "^28.0.0",
@@ -1220,6 +1222,29 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2825,6 +2850,29 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3794,6 +3842,36 @@
         }
       }
     },
+    "node_modules/eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      },
+      "engines": {
+        "node": ">=6.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-comments/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
@@ -3822,6 +3900,57 @@
       "license": "MIT",
       "peerDependencies": {
         "eslint": ">=8.40"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-3.0.7.tgz",
+      "integrity": "sha512-62jB20krIPvcwBLAyG3VVKa2ce2j2lL1yCb8Y0ylMRR/dLvCCTiQx8gQbXb+G81k1alPZ2/I3muZinqWQdBbzw==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@eslint-community/regexpp": "4.12.2",
+        "builtin-modules": "3.3.0",
+        "bytes": "3.1.2",
+        "functional-red-black-tree": "1.0.1",
+        "jsx-ast-utils-x": "0.1.0",
+        "lodash.merge": "4.6.2",
+        "minimatch": "10.1.2",
+        "scslre": "0.3.0",
+        "semver": "7.7.4",
+        "typescript": ">=5"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-scope": {
@@ -4192,6 +4321,13 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fuse.js": {
       "version": "7.1.0",
@@ -4951,6 +5087,16 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsx-ast-utils-x": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
+      "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/keyv": {
@@ -6653,6 +6799,19 @@
         "react": ">= 0.14.0"
       }
     },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/refractor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
@@ -6667,6 +6826,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/rehype-raw": {
@@ -6922,6 +7095,21 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:report": "playwright show-report",
-    "prepare": "husky"
+    "prepare": "husky",
+    "lint:ci": "eslint . --max-warnings=0"
   },
   "dependencies": {
     "@dr.pogodin/react-helmet": "^3.0.6",
@@ -59,7 +60,9 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.55.0",
     "vite": "^7.3.1",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "eslint-plugin-sonarjs": "^3.0.5",
+    "eslint-plugin-eslint-comments": "^3.2.0"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -1473,6 +1476,9 @@ packages:
   hast-util-raw@9.1.0:
     resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
 
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -2034,6 +2040,9 @@ packages:
 
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -3822,6 +3831,12 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      unist-util-position: 5.0.0
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -4629,6 +4644,11 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-raw: 9.1.0
       vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   remark-gfm@4.0.1:
     dependencies:

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -1,11 +1,3 @@
-/**
- * MarkdownRenderer Component
- *
- * A comprehensive Markdown rendering system with custom components,
- * interactive code blocks, glossary tooltips, and automatic parsing
- * of exercises and mastery check questions.
- */
-
 import { useState, useCallback, memo, JSX, useMemo, type ComponentProps } from 'react'
 import ReactMarkdown, { Components, ExtraProps } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -21,9 +13,6 @@ import { glossaryTerms, getGlossaryRegex } from '../utils/glossary'
 import { normalizeAndValidateHref } from '../utils/linkSafety'
 import { createSlugger, extractTextFromReactNode } from '../utils/slug'
 
-/**
- * Custom Prism theme with transparent background for code blocks.
- */
 const customTheme = {
   ...oneDark,
   'pre[class*="language-"]': {
@@ -38,18 +27,9 @@ const customTheme = {
   },
 }
 
-/**
- * Copy button component for code blocks.
- *
- * @param text - The code text to copy to clipboard
- * @returns A copy button that shows feedback on click
- */
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false)
 
-  /**
-   * Copies code text to clipboard and shows confirmation.
-   */
   const handleCopy = useCallback(() => {
     navigator.clipboard.writeText(text).then(() => {
       setCopied(true)
@@ -64,13 +44,6 @@ function CopyButton({ text }: { text: string }) {
   )
 }
 
-/**
- * Enhanced code block with syntax highlighting and optional Python playground.
- *
- * @param className - Language class name (e.g., "language-python")
- * @param children - Code content
- * @returns A styled code block with copy and "Try It" features
- */
 function CodeBlock({ className, children }: { className?: string; children: React.ReactNode }) {
   const match = /language-(\w+)/.exec(className || '')
   const lang = match ? match[1]! : ''
@@ -127,13 +100,6 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
   )
 }
 
-/**
- * Custom code component for ReactMarkdown.
- * Delegates to CodeBlock for language-specific code, renders inline code otherwise.
- *
- * @param props - Code element props from ReactMarkdown
- * @returns Either a CodeBlock or inline code element
- */
 const CodeComponent = (props: JSX.IntrinsicElements['code'] & ExtraProps) => {
   const { children, className, ...rest } = props
   const match = /language-(\w+)/.exec(className || '')
@@ -147,12 +113,6 @@ const CodeComponent = (props: JSX.IntrinsicElements['code'] & ExtraProps) => {
   )
 }
 
-/**
- * Custom table wrapper component that makes tables horizontally scrollable.
- *
- * @param children - Table content
- * @returns A wrapped table with overflow handling
- */
 const TableComponent = ({ children }: { children?: React.ReactNode }) => {
   return (
     <div className="table-wrapper">
@@ -161,14 +121,6 @@ const TableComponent = ({ children }: { children?: React.ReactNode }) => {
   )
 }
 
-/**
- * Custom link component that opens external links in new tabs.
- *
- * @param href - Link URL
- * @param children - Link content
- * @param props - Additional link attributes
- * @returns A properly configured link element
- */
 const LinkComponent = ({ href, children, ...props }: JSX.IntrinsicElements['a'] & ExtraProps) => {
   const { normalizedHref, isExternal, isSafe } = normalizeAndValidateHref(href)
 
@@ -187,13 +139,6 @@ const LinkComponent = ({ href, children, ...props }: JSX.IntrinsicElements['a'] 
   )
 }
 
-/**
- * Custom H1 heading component with auto-generated ID for linking.
- *
- * @param children - Heading content
- * @param props - Additional heading attributes
- * @returns H1 element with ID generated from content
- */
 function createHeadingComponent(
   Tag: 'h1' | 'h2' | 'h3',
   slugger: ReturnType<typeof createSlugger>,
@@ -209,18 +154,9 @@ function createHeadingComponent(
   }
 }
 
-/**
- * Global regex for matching glossary terms in content.
- */
 const glossaryRegex = getGlossaryRegex()
 
-/**
- * Processes text and wraps glossary terms with tooltip spans.
- * Only wraps the first occurrence of each term to avoid overwhelming the reader.
- *
- * @param text - The text content to process
- * @returns Array of text and JSX elements with wrapped glossary terms
- */
+/** Wrap only the first occurrence of each glossary term in a text node. */
 function addGlossaryTooltips(text: string): (string | JSX.Element)[] {
   const parts: (string | JSX.Element)[] = []
   const matched = new Set<string>()
@@ -235,7 +171,6 @@ function addGlossaryTooltips(text: string): (string | JSX.Element)[] {
     }
 
     const termLower = match[1]!.toLowerCase()
-    // Only wrap first occurrence of each term
     if (matched.has(termLower)) {
       parts.push(remaining.slice(0, match.index + match[0].length))
       remaining = remaining.slice(match.index + match[0].length)
@@ -244,7 +179,6 @@ function addGlossaryTooltips(text: string): (string | JSX.Element)[] {
     }
 
     matched.add(termLower)
-    // Find the definition (case-insensitive key lookup)
     const defKey = Object.keys(glossaryTerms).find((k) => k.toLowerCase() === termLower)
     const definition = defKey ? glossaryTerms[defKey] : undefined
 
@@ -269,12 +203,6 @@ function addGlossaryTooltips(text: string): (string | JSX.Element)[] {
   return parts
 }
 
-/**
- * Recursively processes React children to add glossary tooltips to text nodes.
- *
- * @param children - React children to process
- * @returns Processed children with glossary tooltips applied
- */
 function processGlossaryChildren(children: React.ReactNode): React.ReactNode {
   if (typeof children === 'string') {
     const parts = addGlossaryTooltips(children)
@@ -296,27 +224,10 @@ function processGlossaryChildren(children: React.ReactNode): React.ReactNode {
   return children
 }
 
-/**
- * Custom paragraph component that automatically adds glossary tooltips.
- *
- * @param children - Paragraph content
- * @param props - Additional paragraph attributes
- * @returns Paragraph with glossary terms wrapped in tooltips
- */
 const ParagraphWithGlossary = ({ children, ...props }: JSX.IntrinsicElements['p'] & ExtraProps) => (
   <p {...props}>{processGlossaryChildren(children)}</p>
 )
 
-/**
- * Represents a parsed exercise from markdown content.
- *
- * @property title - Exercise title
- * @property goal - Learning goal
- * @property instructions - Step-by-step instructions
- * @property starterCode - Initial code template
- * @property expectedOutput - Expected output text
- * @property solution - Complete solution code
- */
 interface ParsedExercise {
   title: string
   goal: string
@@ -326,15 +237,6 @@ interface ParsedExercise {
   solution: string
 }
 
-/**
- * Represents a parsed mastery check question from markdown content.
- *
- * @property questionNumber - Question number
- * @property title - Question title
- * @property questionText - Question description
- * @property codeSnippet - Optional code snippet for the question
- * @property answer - Correct answer explanation
- */
 interface ParsedMasteryQuestion {
   questionNumber: number
   title: string
@@ -343,14 +245,6 @@ interface ParsedMasteryQuestion {
   answer: string
 }
 
-/**
- * Represents an interactive block (exercise or mastery question) in the markdown.
- *
- * @property type - Block type (exercise or mastery)
- * @property startIndex - Start position in the markdown content
- * @property endIndex - End position in the markdown content
- * @property data - Parsed block data
- */
 interface InteractiveBlock {
   type: 'exercise' | 'mastery'
   startIndex: number
@@ -358,12 +252,6 @@ interface InteractiveBlock {
   data: ParsedExercise | ParsedMasteryQuestion
 }
 
-/**
- * Extracts the first code block from text and returns it with remaining text.
- *
- * @param text - Text containing code blocks
- * @returns Object with extracted code and remaining text
- */
 function extractCodeBlock(text: string): { code: string; remaining: string } {
   const codeMatch = text.match(/```(?:python|py)?\s*\n([\s\S]*?)```/)
   if (codeMatch) {
@@ -375,16 +263,10 @@ function extractCodeBlock(text: string): { code: string; remaining: string } {
   return { code: '', remaining: text }
 }
 
-/**
- * Finds and parses all interactive blocks (exercises and mastery checks) in markdown content.
- *
- * @param content - Raw markdown content to parse
- * @returns Array of parsed interactive blocks with their positions
- */
+/** Parse exercise and mastery sections so they can render as interactive widgets. */
 function findInteractiveBlocks(content: string): InteractiveBlock[] {
   const blocks: InteractiveBlock[] = []
 
-  // Find exercise blocks
   const exerciseRegex =
     /### Exercise \d+:\s*(.+?)\n([\s\S]*?)(?=\n### Exercise \d+:|\n## |\n---\s*\n## |$)/g
   let match
@@ -416,7 +298,6 @@ function findInteractiveBlocks(content: string): InteractiveBlock[] {
     })
   }
 
-  // Find mastery check questions
   const questionRegex =
     /### Question (\d+):\s*(.+?)\n([\s\S]*?)<details>\s*\n<summary>.*?<\/summary>\s*\n([\s\S]*?)<\/details>/g
   while ((match = questionRegex.exec(content)) !== null) {
@@ -440,17 +321,10 @@ function findInteractiveBlocks(content: string): InteractiveBlock[] {
     })
   }
 
-  // Sort by startIndex
   blocks.sort((a, b) => a.startIndex - b.startIndex)
   return blocks
 }
 
-/**
- * Renders markdown content with interactive blocks replaced by custom components.
- *
- * @param content - Markdown content to render
- * @returns Rendered content with interactive components
- */
 function createMarkdownComponents(slugger: ReturnType<typeof createSlugger>): Components {
   return {
     code: CodeComponent,
@@ -483,14 +357,12 @@ function InteractiveContent({ content }: { content: string }) {
     )
   }
 
-  // Split content into segments: plain markdown and interactive blocks
   const segments: JSX.Element[] = []
   let lastEnd = 0
 
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i]!
 
-    // Add the markdown before this block
     if (block.startIndex > lastEnd) {
       const markdownChunk = content.slice(lastEnd, block.startIndex)
       if (markdownChunk.trim()) {
@@ -537,7 +409,6 @@ function InteractiveContent({ content }: { content: string }) {
     lastEnd = block.endIndex
   }
 
-  // Add remaining markdown
   if (lastEnd < content.length) {
     const remaining = content.slice(lastEnd)
     if (remaining.trim()) {
@@ -557,14 +428,8 @@ function InteractiveContent({ content }: { content: string }) {
   return <>{segments}</>
 }
 
-/**
- * Remark plugins for markdown processing.
- */
 const remarkPlugins = [remarkGfm]
 
-/**
- * Rehype plugins for HTML processing.
- */
 const lessonSanitizerSchema: Schema = {
   tagNames: [
     'a',
@@ -625,29 +490,13 @@ const rehypePlugins: NonNullable<ComponentProps<typeof ReactMarkdown>['rehypePlu
   [rehypeSanitize, lessonSanitizerSchema],
 ]
 
-/**
- * Props for the MarkdownRenderer component.
- *
- * @property content - Markdown content to render
- */
 interface MarkdownRendererProps {
   content: string
 }
 
 /**
- * Main markdown renderer component.
- *
- * Renders markdown content with:
- * - Syntax-highlighted code blocks
- * - Interactive Python playgrounds
- * - Glossary term tooltips
- * - Custom-styled headings with IDs
- * - Responsive tables
- * - Auto-parsed exercises and mastery checks
- * - External link handling
- *
- * @param content - Markdown content to render
- * @returns Rendered markdown with all enhancements
+ * Render lesson markdown with safe HTML, custom code blocks, glossary tooltips,
+ * and interactive exercise/mastery widgets.
  */
 function MarkdownRenderer({ content }: MarkdownRendererProps) {
   if (!content) {

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -1,19 +1,6 @@
-/**
- * Content Loader Module
- *
- * Provides utilities for loading, parsing, and enriching lesson content from markdown files.
- * This module handles frontmatter extraction, lesson/phase data management, exercise parsing,
- * and content enrichment features like reading time estimation and related content discovery.
- */
-
 import { parseMarkdown } from './frontmatter'
 
-// --- Public types ---
-
-/**
- * Represents a single lesson in the curriculum.
- * Contains lesson metadata from frontmatter and the rendered content.
- */
+/** Lesson metadata and markdown body loaded from a lesson README. */
 export interface Lesson {
   day: number
   title: string
@@ -27,10 +14,7 @@ export interface Lesson {
   [key: string]: unknown
 }
 
-/**
- * Represents a phase (group of lessons) in the curriculum.
- * Contains phase metadata and overview content.
- */
+/** Phase metadata and overview markdown content. */
 export interface Phase {
   phase: number
   title: string
@@ -42,16 +26,13 @@ export interface Phase {
   [key: string]: unknown
 }
 
-/**
- * Styling information for difficulty badges.
- */
+/** UI token set for rendering difficulty badges. */
 export interface DifficultyInfo {
   label: string
   color: string
   bg: string
 }
 
-// Import all markdown files at build time
 const lessonFiles = import.meta.glob('/Lessons/**/README.md', {
   query: '?raw',
   import: 'default',
@@ -64,7 +45,6 @@ const phaseFiles = import.meta.glob('/Lessons/**/Phase_Overview.md', {
   eager: true,
 }) as Record<string, string>
 
-// Parse all lessons
 const lessons: Lesson[] = Object.entries(lessonFiles)
   .map(([path, raw]) => {
     const { frontmatter, content } = parseMarkdown(raw)
@@ -76,7 +56,6 @@ const lessons: Lesson[] = Object.entries(lessonFiles)
   })
   .sort((a, b) => (a.day || 0) - (b.day || 0))
 
-// Parse all phase overviews
 const phases: Phase[] = Object.entries(phaseFiles)
   .map(([path, raw]) => {
     const { frontmatter, content } = parseMarkdown(raw)
@@ -88,60 +67,32 @@ const phases: Phase[] = Object.entries(phaseFiles)
   })
   .sort((a, b) => (a.phase || 0) - (b.phase || 0))
 
-/**
- * Retrieves all phases in the curriculum.
- *
- * @returns Array of all phase objects, sorted by phase number
- */
+/** Return all phases sorted by phase number. */
 export function getAllPhases(): readonly ImmutablePhase[] {
   return immutablePhases
 }
 
-/**
- * Retrieves a specific phase by its number.
- *
- * @param phaseNum - Phase number (1-9)
- * @returns The phase object if found, otherwise undefined
- */
+/** Return a phase by number. */
 export function getPhase(phaseNum: string | number): ImmutablePhase | undefined {
   return immutablePhases.find((p) => p.phase === Number(phaseNum))
 }
 
-/**
- * Retrieves all lessons in the curriculum.
- *
- * @returns Array of all lesson objects, sorted by day number
- */
+/** Return all lessons sorted by day number. */
 export function getAllLessons(): readonly ImmutableLesson[] {
   return immutableLessons
 }
 
-/**
- * Retrieves a specific lesson by its day number.
- *
- * @param dayNum - Day number (1-108)
- * @returns The lesson object if found, otherwise undefined
- */
+/** Return a lesson by day number. */
 export function getLesson(dayNum: string | number): ImmutableLesson | undefined {
   return immutableLessons.find((l) => l.day === Number(dayNum))
 }
 
-/**
- * Retrieves all lessons belonging to a specific phase.
- *
- * @param phaseNum - Phase number (1-9)
- * @returns Array of lessons in the specified phase
- */
+/** Return all lessons in a phase. */
 export function getLessonsByPhase(phaseNum: string | number): readonly ImmutableLesson[] {
   return immutableLessons.filter((l) => l.phase === Number(phaseNum))
 }
 
-/**
- * Finds the previous and next lessons relative to a given day.
- *
- * @param dayNum - Current lesson day number
- * @returns Object containing prev and next lesson references (or null if at boundaries)
- */
+/** Return previous and next lessons around the given day. */
 export function getAdjacentLessons(dayNum: string | number): {
   prev: ImmutableLesson | null
   next: ImmutableLesson | null
@@ -157,11 +108,7 @@ export function getAdjacentLessons(dayNum: string | number): {
   }
 }
 
-// --- Exercise extraction ---
-
-/**
- * Represents a coding exercise extracted from lesson content.
- */
+/** Exercise parsed from lesson markdown. */
 export interface Exercise {
   day: number
   lessonTitle: string
@@ -173,15 +120,7 @@ export interface Exercise {
   tags: readonly string[]
 }
 
-/**
- * Extracts all exercises from a lesson's markdown content.
- *
- * Parses sections matching "### Exercise N: Title" pattern and extracts
- * the goal description and starter code blocks.
- *
- * @param lesson - The lesson object to extract exercises from
- * @returns Array of exercise objects found in the lesson
- */
+/** Parse exercise sections from a lesson markdown body. */
 function extractExercisesFromLesson(lesson: Lesson): Exercise[] {
   const exercises: Exercise[] = []
   const regex =
@@ -221,20 +160,12 @@ const immutableLessons = Object.freeze(lessons.map(freezeLesson))
 const immutablePhases = Object.freeze(phases.map(freezePhase))
 const immutableExercises = Object.freeze(allExercises.map(freezeExercise))
 
-/**
- * Retrieves all exercises from all lessons.
- *
- * @returns Array of all exercises across the entire curriculum
- */
+/** Return all parsed exercises across lessons. */
 export function getAllExercises(): readonly ImmutableExercise[] {
   return immutableExercises
 }
 
-// --- Notebook loading ---
-
-/**
- * Represents a single cell in a Jupyter notebook.
- */
+/** Jupyter notebook cell shape used by imported phase notebooks. */
 export interface NotebookCell {
   cell_type: 'code' | 'markdown' | 'raw'
   source: readonly string[]
@@ -249,9 +180,7 @@ export interface NotebookCell {
   execution_count?: number | null
 }
 
-/**
- * Represents a Jupyter notebook containing solution code for a phase.
- */
+/** Parsed notebook metadata for a phase solution file. */
 export interface Notebook {
   phase: number
   cells: readonly NotebookCell[]
@@ -335,11 +264,7 @@ const notebookFiles = import.meta.glob('/Lessons/**/Phase_*_Solutions.ipynb', {
   eager: true,
 }) as Record<string, string>
 
-/**
- * Parses all Jupyter notebook files from the Lessons directory.
- *
- * @returns Array of notebook objects with phase numbers and parsed cells
- */
+/** Parse notebook files and map each one to a phase number. */
 function parseNotebooks(): Notebook[] {
   return Object.entries(notebookFiles)
     .map(([path, raw]) => {
@@ -359,56 +284,32 @@ function parseNotebooks(): Notebook[] {
 const notebooks = parseNotebooks()
 const immutableNotebooks = Object.freeze(notebooks.map(freezeNotebook))
 
-/**
- * Retrieves all Jupyter notebooks.
- *
- * @returns Array of all notebook objects, sorted by phase number
- */
+/** Return all parsed notebooks sorted by phase number. */
 export function getAllNotebooks(): readonly ImmutableNotebook[] {
   return immutableNotebooks
 }
 
-/**
- * Retrieves a specific notebook by phase number.
- *
- * @param phaseNum - Phase number (1-9)
- * @returns The notebook object if found, otherwise undefined
- */
+/** Return a notebook by phase number. */
 export function getNotebook(phaseNum: string | number): ImmutableNotebook | undefined {
   return immutableNotebooks.find((n) => n.phase === Number(phaseNum))
 }
 
-// --- Content enrichment helpers ---
-
-/**
- * Estimates reading time in minutes (word count ÷ 200 wpm).
- *
- * Strips code blocks, frontmatter, and markdown syntax before counting words.
- * Uses an average reading speed of 200 words per minute.
- *
- * @param content - Raw markdown content to analyze
- * @returns Estimated reading time in minutes (minimum 1 minute)
- */
+/** Estimate reading time in minutes after removing markdown syntax noise. */
 export function getReadingTime(content: string): number {
   const stripped = content
-    .replace(/```[\s\S]*?```/g, '') // remove code blocks
-    .replace(/`[^`]+`/g, '') // remove inline code
-    .replace(/!\[.*?\]\(.*?\)/g, '') // remove images
-    .replace(/\[([^\]]+)\]\(.*?\)/g, '$1') // links → text
-    .replace(/#{1,6}\s/g, '') // remove heading markers
-    .replace(/[*_~>|`-]/g, '') // remove markdown formatting
-    .replace(/<[^>]+>/g, '') // remove HTML tags
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/`[^`]+`/g, '')
+    .replace(/!\[.*?\]\(.*?\)/g, '')
+    .replace(/\[([^\]]+)\]\(.*?\)/g, '$1')
+    .replace(/#{1,6}\s/g, '')
+    .replace(/[*_~>|`-]/g, '')
+    .replace(/<[^>]+>/g, '')
     .trim()
   const words = stripped.split(/\s+/).filter((w) => w.length > 0).length
   return Math.max(1, Math.round(words / 200))
 }
 
-/**
- * Looks up prerequisite Lesson objects from the lesson's prerequisites array.
- *
- * @param lesson - The lesson to get prerequisites for
- * @returns Array of prerequisite lesson objects
- */
+/** Resolve prerequisite day references into lesson objects. */
 export function getPrerequisiteLessons(lesson: Readonly<Lesson>): readonly ImmutableLesson[] {
   const prereqs = lesson.prerequisites as readonly number[] | undefined
   if (!prereqs || !Array.isArray(prereqs) || prereqs.length === 0) return []
@@ -417,19 +318,7 @@ export function getPrerequisiteLessons(lesson: Readonly<Lesson>): readonly Immut
     .filter((l): l is ImmutableLesson => l !== undefined)
 }
 
-/**
- * Finds related lessons by scoring shared tags, concepts, and phase proximity.
- *
- * Uses a scoring algorithm that awards points for:
- * - Shared tags (2 points each)
- * - Shared concepts (3 points each)
- * - Same phase (1 point)
- * - Adjacent phase (0.5 points)
- *
- * @param lesson - The lesson to find related lessons for
- * @param count - Maximum number of related lessons to return (default: 4)
- * @returns Array of the top related lesson objects, excluding self and prerequisites
- */
+/** Return top related lessons ranked by shared tags/concepts and phase proximity. */
 export function getRelatedLessons(lesson: Readonly<Lesson>, count = 4): readonly ImmutableLesson[] {
   const prereqs = new Set((lesson.prerequisites as readonly number[]) || [])
   const myTags = new Set((lesson.tags as readonly string[]) || [])
@@ -442,17 +331,13 @@ export function getRelatedLessons(lesson: Readonly<Lesson>, count = 4): readonly
       const lTags = (l.tags as readonly string[]) || []
       const lConcepts = (l.concepts as readonly string[]) || []
 
-      // Shared tags (2 pts each)
       lTags.forEach((t) => {
         if (myTags.has(t)) score += 2
       })
-      // Shared concepts (3 pts each)
       lConcepts.forEach((c) => {
         if (myConcepts.has(c)) score += 3
       })
-      // Same phase bonus (1 pt)
       if (l.phase === lesson.phase) score += 1
-      // Phase proximity bonus (0.5 pts for adjacent phases)
       if (Math.abs(l.phase - lesson.phase) === 1) score += 0.5
 
       return { lesson: l, score, sharedTags: lTags.filter((t) => myTags.has(t)) }
@@ -473,10 +358,7 @@ export function getRelatedLessons(lesson: Readonly<Lesson>, count = 4): readonly
   )
 }
 
-/**
- * Configuration mapping difficulty levels to display information.
- * Includes label, color, and background color for UI rendering.
- */
+/** Difficulty-level display metadata used by the lesson UI. */
 export const difficultyConfig: Record<string, DifficultyInfo> = {
   beginner: { label: 'Beginner', color: '#22c55e', bg: 'rgba(34,197,94,0.12)' },
   intermediate: { label: 'Intermediate', color: '#f59e0b', bg: 'rgba(245,158,11,0.12)' },
@@ -484,18 +366,5 @@ export const difficultyConfig: Record<string, DifficultyInfo> = {
   expert: { label: 'Expert', color: '#ef4444', bg: 'rgba(239,68,68,0.12)' },
 }
 
-/**
- * Emoji icons representing each phase of the curriculum.
- * Array indices correspond to phase numbers (0-8 for phases 1-9).
- */
-export const phaseIcons: string[] = [
-  '🐍', // Phase 1: Python Foundations
-  '🔧', // Phase 2: Functions & Modularity
-  '🌐', // Phase 3: Data Eng & Web Dev
-  '📐', // Phase 4: Math & ML
-  '🧠', // Phase 5: Advanced ML
-  '🚀', // Phase 6: Cutting Edge ML
-  '📊', // Phase 7: BI Analytics
-  '🗄️', // Phase 8: SQL Mastery
-  '⚡', // Phase 9: Enterprise SQL
-]
+/** Phase icon lookup (index 0 => phase 1). */
+export const phaseIcons: string[] = ['🐍', '🔧', '🌐', '📐', '🧠', '🚀', '📊', '🗄️', '⚡']


### PR DESCRIPTION
### Motivation
- Reduce repetitive inline narration in two large modules and keep comments focused on observable behavior and public API boundaries.
- Add automated checks to catch duplicated logic and dead/commented-out code so regressions are detected in CI.

### Description
- Cleaned up documentation and removed repetitive comments in `src/components/MarkdownRenderer.tsx`, preserving runtime behavior and concise boundary docstrings for public components.
- Simplified and tightened public API docstrings in `src/utils/contentLoader.ts`, compressed verbose inline comments, and collapsed multi-line icon comments into a compact data form.
- Extended ESLint configuration (`eslint.config.js`) to enable `sonarjs` and `eslint-comments` checks and to enable rules: `sonarjs/no-identical-functions`, `sonarjs/no-duplicated-branches`, `sonarjs/no-all-duplicated-branches`, `eslint-comments/no-unused-disable`, and `eslint-comments/no-unlimited-disable`.
- Added `lint:ci` script to `package.json`, installed the required lint plugins as dev dependencies, and added a GitHub Actions workflow at `.github/workflows/lint.yml` to run the strict lint step on PRs and pushes to `main`.

### Testing
- Ran `npm run lint:ci` (ESLint with new rules) and it completed successfully. 
- Ran `npm run typecheck` (`tsc -b`) which failed due to pre-existing unrelated test typing issues in `src/pages/__tests__/SearchResults.test.tsx` and `src/utils/__tests__/validate-content-script.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698df4b7304083308aac2dcbe2bf46f6)