### PR TITLE
Add timeout/cancel handling to Python runner execution

### DIFF
--- a/src/components/PythonRunner.tsx
+++ b/src/components/PythonRunner.tsx
@@ -5,14 +5,17 @@
  * Displays run button with loading states and shows execution output or errors.
  */
 
-import { useState, useCallback, forwardRef, useImperativeHandle } from 'react'
+import { useState, useCallback, useRef, forwardRef, useImperativeHandle } from 'react'
 import { usePyodide } from '../hooks/usePyodide'
+
+const DEFAULT_RUN_TIMEOUT_MS = 10_000
 
 /**
  * Handle interface for accessing PythonRunner methods imperatively.
  */
 export interface PythonRunnerHandle {
   run: () => Promise<void>
+  cancel: () => void
 }
 
 /**
@@ -33,6 +36,12 @@ interface PythonRunnerProps {
  * and displays the output or errors. Handles Pyodide loading state
  * and execution state with appropriate UI feedback.
  *
+ * Maintainer note: cancellation/timeout are UI-level controls that race the
+ * Promise returned by `runPythonAsync`. Pyodide does not get forcefully
+ * interrupted here, so long-running code may continue in the background until
+ * execution yields. We guard state updates to prevent stale results from
+ * clobbering newer runs.
+ *
  * @param code - Python code to run
  * @param compact - Use compact visual layout
  * @returns A Python code runner component
@@ -43,54 +52,93 @@ const PythonRunner = forwardRef<PythonRunnerHandle, PythonRunnerProps>(
     const [output, setOutput] = useState<string | null>(null)
     const [error, setError] = useState<string | null>(null)
     const [running, setRunning] = useState(false)
+    const runIdRef = useRef(0)
+    const abortControllerRef = useRef<AbortController | null>(null)
+
+    const cancelRun = useCallback(() => {
+      abortControllerRef.current?.abort()
+      abortControllerRef.current = null
+      setRunning(false)
+    }, [])
 
     /**
      * Executes the Python code and updates output/error state.
      */
     const handleRun = useCallback(async () => {
       if (running || pyodideLoading) return
+      const currentRunId = runIdRef.current + 1
+      runIdRef.current = currentRunId
+      const abortController = new AbortController()
+      abortControllerRef.current = abortController
       setRunning(true)
       setOutput(null)
       setError(null)
-      const result = await runPython(code)
-      setOutput(result.output)
-      setError(result.error)
-      setRunning(false)
+
+      try {
+        const result = await runPython(code, {
+          timeoutMs: DEFAULT_RUN_TIMEOUT_MS,
+          signal: abortController.signal,
+        })
+
+        // Ignore stale resolution from runs that were superseded/cancelled.
+        if (runIdRef.current !== currentRunId) return
+        setOutput(result.output)
+        setError(result.error)
+      } finally {
+        if (runIdRef.current === currentRunId) {
+          abortControllerRef.current = null
+          setRunning(false)
+        }
+      }
     }, [code, runPython, running, pyodideLoading])
 
     useImperativeHandle(
       ref,
       () => ({
         run: handleRun,
+        cancel: cancelRun,
       }),
-      [handleRun],
+      [cancelRun, handleRun],
     )
 
     const isLoading = pyodideLoading || running
 
     return (
       <div className={`python-runner ${compact ? 'python-runner--compact' : ''}`}>
-        <button
-          className="python-runner__btn"
-          onClick={handleRun}
-          disabled={isLoading}
-          aria-label="Run Python code (Shift+Enter)"
-          title="Run (Shift+Enter)"
-        >
-          {pyodideLoading ? (
-            <>
-              <span className="python-runner__spinner" aria-hidden="true" />
-              Loading Python…
-            </>
-          ) : running ? (
-            <>
-              <span className="python-runner__spinner" aria-hidden="true" />
-              Running…
-            </>
-          ) : (
-            <>▶ Run</>
+        <div className="python-runner__controls">
+          <button
+            className="python-runner__btn"
+            onClick={handleRun}
+            disabled={isLoading}
+            aria-label="Run Python code (Shift+Enter)"
+            title="Run (Shift+Enter)"
+          >
+            {pyodideLoading ? (
+              <>
+                <span className="python-runner__spinner" aria-hidden="true" />
+                Loading Python…
+              </>
+            ) : running ? (
+              <>
+                <span className="python-runner__spinner" aria-hidden="true" />
+                Running…
+              </>
+            ) : (
+              <>▶ Run</>
+            )}
+          </button>
+
+          {running && (
+            <button
+              className="python-runner__btn python-runner__btn--cancel"
+              onClick={cancelRun}
+              aria-label="Cancel current Python execution"
+              title="Cancel execution"
+            >
+              ✕ Cancel
+            </button>
           )}
-        </button>
+        </div>
 
         {(output !== null || error) && (
           <div className="python-runner__output" aria-live="polite">

--- a/src/hooks/usePyodide.ts
+++ b/src/hooks/usePyodide.ts
@@ -18,6 +18,17 @@ interface PyodideRunResult {
   error: string | null
 }
 
+interface RunPythonOptions {
+  /**
+   * Maximum time to wait for Pyodide execution before returning a timeout error.
+   */
+  timeoutMs?: number
+  /**
+   * Optional abort signal controlled by the caller.
+   */
+  signal?: AbortSignal
+}
+
 /**
  * Interface for the Pyodide runtime instance.
  */
@@ -185,15 +196,55 @@ export function usePyodide() {
   }, [])
 
   const runPython = useCallback(
-    async (code: string): Promise<PyodideRunResult> => {
+    async (code: string, options: RunPythonOptions = {}): Promise<PyodideRunResult> => {
+      const { timeoutMs, signal } = options
+
       try {
+        if (signal?.aborted) {
+          return { output: '', error: 'Execution cancelled by user.' }
+        }
+
         const pyodide = await ensureLoaded()
         let stdout = ''
         let stderr = ''
         pyodide.setStdout({ batched: (text: string) => (stdout += text + '\n') })
         pyodide.setStderr({ batched: (text: string) => (stderr += text + '\n') })
 
-        const result = await pyodide.runPythonAsync(code)
+        const pythonExecutionPromise = pyodide.runPythonAsync(code)
+
+        // NOTE: Timeout/abort cannot preempt Python code already running in Pyodide.
+        // We resolve early so UI can recover, but the underlying execution may continue
+        // until Pyodide yields/completes.
+        const timeoutPromise =
+          typeof timeoutMs === 'number'
+            ? new Promise<never>((_, reject) => {
+                const timeoutId = window.setTimeout(() => {
+                  reject(new Error(`Python execution timed out after ${timeoutMs}ms.`))
+                }, timeoutMs)
+                pythonExecutionPromise
+                  .finally(() => window.clearTimeout(timeoutId))
+                  .catch(() => undefined)
+              })
+            : null
+
+        const abortPromise = signal
+          ? new Promise<never>((_, reject) => {
+              const onAbort = () => {
+                signal.removeEventListener('abort', onAbort)
+                reject(new Error('Execution cancelled by user.'))
+              }
+              signal.addEventListener('abort', onAbort)
+              pythonExecutionPromise
+                .finally(() => signal.removeEventListener('abort', onAbort))
+                .catch(() => undefined)
+            })
+          : null
+
+        const result = await Promise.race([
+          pythonExecutionPromise,
+          ...(timeoutPromise ? [timeoutPromise] : []),
+          ...(abortPromise ? [abortPromise] : []),
+        ])
 
         // If there's a return value and no stdout, show the return value
         let output = stdout.trimEnd()


### PR DESCRIPTION
### Motivation

- Provide a UI-level way to recover from long-running `runPythonAsync` executions so the runner UI does not hang indefinitely. 
- Surface clear timeout/cancel errors and ensure `loading`/`running` flags recover cleanly after a timeout or user cancel. 

### Description

- Add `RunPythonOptions` with `timeoutMs` and `signal` to `usePyodide().runPython` and race the internal `runPythonAsync` against timeout and abort promises so callers can get an early error when desired. 
- Return explicit error strings for timeout (`Python execution timed out after ...ms.`) and cancellation (`Execution cancelled by user.`) and document that this is an early-return only because Pyodide cannot be forcefully preempted here. 
- Update `PythonRunner` to create a per-run `AbortController`, expose `cancel()` on the imperative handle, use a default timeout (`DEFAULT_RUN_TIMEOUT_MS`), render a `✕ Cancel` button while running, and ignore stale/superseded async resolutions using a `runIdRef` so state is not clobbered. 
- Add maintainer-facing comments describing the limitation that timeout/cancel do not forcibly interrupt Pyodide's internal execution and that the UI only races the promise for responsiveness. 

### Testing

- Ran `npx eslint src/hooks/usePyodide.ts src/components/PythonRunner.tsx` and it completed successfully. 
- Ran `npm run typecheck` which failed due to unrelated, pre-existing TypeScript errors in test files and not due to these changes. 
- Performed a local visual check with Playwright and captured a screenshot of the runner UI showing the Run and Cancel states.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698df6164fd4833099eaf54fd540ca96)