### PR TITLE
Restrict Surge workflow triggers and document deployment roles

### DIFF
--- a/.github/workflows/deploy-surge.yml
+++ b/.github/workflows/deploy-surge.yml
@@ -1,9 +1,9 @@
 name: Deploy to Surge
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@
 
 **[saint2706.github.io/Coding-For-MBA](https://saint2706.github.io/Coding-For-MBA)**
 
+## 🚢 Deployment Environments
+
+- **Primary production environment:** GitHub Pages via `.github/workflows/deploy.yml`.
+- **Surge (`coding-for-mba.surge.sh`) usage:** optional preview/release deployment, triggered manually (`workflow_dispatch`) or on published GitHub releases.
+- **Default behavior:** pushes to `main` continue to rely on the GitHub Pages deployment workflow.
+
 ## 📚 What's Inside
 
 | Phase | Topic                       | Days   |


### PR DESCRIPTION
### Motivation

- Avoid automatic Surge deployments on every push to `main` while keeping Surge available for manual or release-driven deployments.

### Description

- Updated `.github/workflows/deploy-surge.yml` to remove the `push` on `main`, retain `workflow_dispatch` for manual runs, and add a `release` trigger with `types: [published]` for optional release deployments.
- Added a `## 🚢 Deployment Environments` section to `README.md` clarifying that GitHub Pages (`.github/workflows/deploy.yml`) is the primary production environment and that Surge (`coding-for-mba.surge.sh`) is intended for manual previews or release-based deployments.
- No changes were made to build or runtime code; this change only adjusts CI/CD triggers and documentation.

### Testing

- Ran pre-commit hooks which executed `prettier --check` and the check passed for the modified files.
- Attempted YAML parsing via a small Python script using `yaml.safe_load`, but the run failed because `PyYAML` is not installed in the environment.
- Verified the updated workflow and README contents via file inspection to confirm the trigger removal/addition and new documentation section.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dfa6d9ffc8330ab80ed20aaf2826c)