### PR TITLE
Adjust Dependabot schedules to 10 PM IST

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "22:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 10
+    labels: ["dependencies"]
+    groups:
+      react-stack:
+        patterns: ["react*", "@types/react*", "react-router-dom"]
+      test-tooling:
+        patterns: ["vitest*", "@vitest/*", "@playwright/test", "jsdom"]
+      lint-tooling:
+        patterns: ["eslint*", "@eslint/*", "@typescript-eslint/*", "typescript-eslint", "prettier"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "22:15"
+      timezone: "Asia/Kolkata"
+    labels: ["dependencies", "github-actions"]


### PR DESCRIPTION
### Motivation
- Align Dependabot runs with India Standard Time by moving the scheduled updates from UTC to 10:00 PM IST for `npm` and 10:15 PM IST for `github-actions` per the request.

### Description
- Update `.github/dependabot.yml` to set `timezone: "Asia/Kolkata"` and change `time` to `22:00` for the `npm` entry and `22:15` for the `github-actions` entry while preserving existing `groups`, `open-pull-requests-limit`, and labels.

### Testing
- Verified the file contents with `cat .github/dependabot.yml` and `nl -ba .github/dependabot.yml`, and committed the change with `git commit`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dfa7227548330a20a35ec7674c53f)