### PR TITLE
🛡️ Sentinel: Fix External Link Safety Bypass

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The Pyodide runtime script was loaded from a CDN without Subresource Integrity (SRI) validation. This could allow a compromised CDN to inject malicious code into the application context, potentially stealing user data or mining cryptocurrency.
 **Learning:** External dependencies loaded at runtime via `script` tags bypass build-time security checks. Because Pyodide is loaded lazily and not part of the bundle, it was overlooked during standard dependency auditing.
 **Prevention:** Always use SRI hashes for any external scripts. Create a helper function like `loadScript` that enforces integrity checks for known external resources.
+
+## 2026-02-13 - Link Attribute Security Bypass
+**Vulnerability:** External link protection (forcing `target="_blank"` and `rel="noopener noreferrer"`) in the Markdown renderer could be bypassed by user-supplied `rel` attributes. The `LinkComponent` spread user-provided props *after* applying security defaults, allowing malicious or unsafe `rel` values to override the secure configuration.
+**Learning:** Component composition order matters critically for security. When spreading `...props`, always ensure security-critical attributes (like `rel` for external links) take precedence or are explicitly merged/sanitized *after* the spread.
+**Prevention:** Destructure and remove security-sensitive props from user input before spreading, or explicitly set them after spreading user props. Use helper functions to construct safe attribute sets.

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -11,7 +11,7 @@ import ExerciseWidget from './ExerciseWidget'
 import MasteryCheck from './MasteryCheck'
 import CopyButton from './CopyButton'
 import { glossaryTerms, getGlossaryRegex } from '../utils/glossary'
-import { normalizeAndValidateHref } from '../utils/linkSafety'
+import { getSecureLinkAttributes } from '../utils/linkSafety'
 import { createSlugger, extractTextFromReactNode } from '../utils/slug'
 
 const customTheme = {
@@ -106,17 +106,21 @@ const TableComponent = ({ children }: { children?: React.ReactNode }) => {
 }
 
 const LinkComponent = ({ href, children, ...props }: JSX.IntrinsicElements['a'] & ExtraProps) => {
-  const { normalizedHref, isExternal, isSafe } = normalizeAndValidateHref(href)
+  const attributes = getSecureLinkAttributes(href, props)
 
-  if (!isSafe || !normalizedHref) {
+  if (!attributes) {
     return <span>{children}</span>
   }
 
+  // Remove target and rel from props so they don't override secure attributes
+  const { target: _target, rel: _rel, ...rest } = props
+
   return (
     <a
-      href={normalizedHref}
-      {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-      {...props}
+      href={attributes.href}
+      target={attributes.target}
+      rel={attributes.rel}
+      {...rest}
     >
       {children}
     </a>

--- a/src/utils/__tests__/linkSafety.test.ts
+++ b/src/utils/__tests__/linkSafety.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { getSecureLinkAttributes } from '../linkSafety'
+
+describe('getSecureLinkAttributes', () => {
+  it('should handle safe external links', () => {
+    const result = getSecureLinkAttributes('https://example.com')
+    expect(result).toEqual({
+      href: 'https://example.com',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    })
+  })
+
+  it('should preserve existing rel attributes for external links', () => {
+    const result = getSecureLinkAttributes('https://example.com', { rel: 'nofollow' })
+    expect(result).toEqual({
+      href: 'https://example.com',
+      target: '_blank',
+      rel: 'nofollow noopener noreferrer',
+    })
+  })
+
+  it('should handle safe internal links', () => {
+    const result = getSecureLinkAttributes('/lesson/1')
+    expect(result).toEqual({
+      href: '/lesson/1',
+      target: undefined,
+      rel: undefined,
+    })
+  })
+
+  it('should handle internal links with target', () => {
+    const result = getSecureLinkAttributes('/lesson/1', { target: '_self' })
+    expect(result).toEqual({
+      href: '/lesson/1',
+      target: '_self',
+      rel: undefined,
+    })
+  })
+
+  it('should return null for unsafe links', () => {
+    const result = getSecureLinkAttributes('javascript:alert(1)')
+    expect(result).toBeNull()
+  })
+
+  it('should not duplicate noopener noreferrer', () => {
+    const result = getSecureLinkAttributes('https://example.com', { rel: 'noopener' })
+    expect(result?.rel).toBe('noopener noreferrer')
+  })
+})

--- a/src/utils/__tests__/linkSafety.test.ts
+++ b/src/utils/__tests__/linkSafety.test.ts
@@ -20,6 +20,23 @@ describe('getSecureLinkAttributes', () => {
     })
   })
 
+  it('should enforce secure target for external links even if _self is requested', () => {
+    const result = getSecureLinkAttributes('https://example.com', { target: '_self' })
+    expect(result).toEqual({
+      href: 'https://example.com',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    })
+  })
+
+  it('should strip opener from rel for external links', () => {
+    const result = getSecureLinkAttributes('https://example.com', { rel: 'opener' })
+    expect(result).toEqual({
+      href: 'https://example.com',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    })
+  })
   it('should handle safe internal links', () => {
     const result = getSecureLinkAttributes('/lesson/1')
     expect(result).toEqual({

--- a/src/utils/linkSafety.ts
+++ b/src/utils/linkSafety.ts
@@ -37,3 +37,31 @@ export const normalizeAndValidateHref = (href?: string | null) => {
     return { normalizedHref: null, isExternal: false, isSafe: false }
   }
 }
+
+export interface LinkProps {
+  target?: string
+  rel?: string
+}
+
+export const getSecureLinkAttributes = (
+  href?: string | null,
+  props: LinkProps = {},
+) => {
+  const { normalizedHref, isExternal, isSafe } = normalizeAndValidateHref(href)
+
+  if (!isSafe || !normalizedHref) {
+    return null
+  }
+
+  let { target, rel } = props
+
+  if (isExternal) {
+    target = '_blank'
+    const parts = (rel || '').split(/\s+/).filter(Boolean)
+    if (!parts.includes('noopener')) parts.push('noopener')
+    if (!parts.includes('noreferrer')) parts.push('noreferrer')
+    rel = parts.join(' ')
+  }
+
+  return { href: normalizedHref, target, rel }
+}

--- a/src/utils/linkSafety.ts
+++ b/src/utils/linkSafety.ts
@@ -57,9 +57,19 @@ export const getSecureLinkAttributes = (
 
   if (isExternal) {
     target = '_blank'
-    const parts = (rel || '').split(/\s+/).filter(Boolean)
-    if (!parts.includes('noopener')) parts.push('noopener')
-    if (!parts.includes('noreferrer')) parts.push('noreferrer')
+    const parts = (rel || '')
+      .split(/\s+/)
+      .filter(Boolean)
+      .filter(token => token.toLowerCase() !== 'opener')
+    const lowerParts = new Set(parts.map(token => token.toLowerCase()))
+    if (!lowerParts.has('noopener')) {
+      parts.push('noopener')
+      lowerParts.add('noopener')
+    }
+    if (!lowerParts.has('noreferrer')) {
+      parts.push('noreferrer')
+      lowerParts.add('noreferrer')
+    }
     rel = parts.join(' ')
   }
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix External Link Safety Bypass

🚨 **Severity:** HIGH
💡 **Vulnerability:** External links rendered via Markdown could bypass security defaults (target="_blank", rel="noopener noreferrer") if the source content contained explicit `rel` or `target` attributes. The previous implementation spread user props *after* applying security defaults, allowing overrides.
🎯 **Impact:** Vulnerability to reverse tabnabbing attacks if malicious or unsafe content is introduced.
🔧 **Fix:** Refactored `LinkComponent` to use a new `getSecureLinkAttributes` utility that prioritizes security attributes. It explicitly destructs `target` and `rel` from user props to prevent overrides.
✅ **Verification:** Added comprehensive unit tests in `src/utils/__tests__/linkSafety.test.ts` and verified with the existing E2E test suite.

---
*PR created automatically by Jules for task [5075995122203957129](https://jules.google.com/task/5075995122203957129) started by @saint2706*