### PR TITLE
🎨 Palette: Add visual keyboard shortcut to Run button

### DIFF
--- a/src/components/CodePlayground.tsx
+++ b/src/components/CodePlayground.tsx
@@ -112,6 +112,7 @@ export default function CodePlayground({ initialCode, expectedOutput }: CodePlay
             className="code-playground__btn code-playground__btn--reset"
             onClick={handleReset}
             aria-label="Reset code to original"
+            title="Reset code to original"
           >
             ↺ Reset
           </button>

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -116,12 +116,7 @@ const LinkComponent = ({ href, children, ...props }: JSX.IntrinsicElements['a'] 
   const { target: _target, rel: _rel, ...rest } = props
 
   return (
-    <a
-      href={attributes.href}
-      target={attributes.target}
-      rel={attributes.rel}
-      {...rest}
-    >
+    <a href={attributes.href} target={attributes.target} rel={attributes.rel} {...rest}>
       {children}
     </a>
   )

--- a/src/components/PythonRunner.tsx
+++ b/src/components/PythonRunner.tsx
@@ -124,7 +124,25 @@ const PythonRunner = forwardRef<PythonRunnerHandle, PythonRunnerProps>(
                 Running…
               </>
             ) : (
-              <>▶ Run</>
+              <>
+                ▶ Run
+                <kbd
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: '0.7em',
+                    padding: '0.1em 0.4em',
+                    background: 'rgba(255,255,255,0.2)',
+                    borderRadius: '3px',
+                    border: '1px solid rgba(255,255,255,0.3)',
+                    marginLeft: '0.5em',
+                    verticalAlign: 'middle',
+                    opacity: 0.9,
+                    fontWeight: 'normal',
+                  }}
+                >
+                  Shift+Enter
+                </kbd>
+              </>
             )}
           </button>
 

--- a/src/components/PythonRunner.tsx
+++ b/src/components/PythonRunner.tsx
@@ -125,20 +125,7 @@ const PythonRunner = forwardRef<PythonRunnerHandle, PythonRunnerProps>(
               </>
             ) : (
               <>
-                ▶ Run
-                <kbd
-                  style={{
-                    fontFamily: 'var(--font-mono)',
-                    fontSize: '0.7em',
-                    padding: '0.1em 0.4em',
-                    background: 'rgba(255,255,255,0.2)',
-                    borderRadius: '3px',
-                    border: '1px solid rgba(255,255,255,0.3)',
-                    verticalAlign: 'middle',
-                    opacity: 0.9,
-                    fontWeight: 'normal',
-                  }}
-                >
+                <kbd className="python-runner__shortcut">
                   Shift+Enter
                 </kbd>
               </>

--- a/src/components/PythonRunner.tsx
+++ b/src/components/PythonRunner.tsx
@@ -134,7 +134,6 @@ const PythonRunner = forwardRef<PythonRunnerHandle, PythonRunnerProps>(
                     background: 'rgba(255,255,255,0.2)',
                     borderRadius: '3px',
                     border: '1px solid rgba(255,255,255,0.3)',
-                    marginLeft: '0.5em',
                     verticalAlign: 'middle',
                     opacity: 0.9,
                     fontWeight: 'normal',

--- a/src/utils/linkSafety.ts
+++ b/src/utils/linkSafety.ts
@@ -43,10 +43,7 @@ export interface LinkProps {
   rel?: string
 }
 
-export const getSecureLinkAttributes = (
-  href?: string | null,
-  props: LinkProps = {},
-) => {
+export const getSecureLinkAttributes = (href?: string | null, props: LinkProps = {}) => {
   const { normalizedHref, isExternal, isSafe } = normalizeAndValidateHref(href)
 
   if (!isSafe || !normalizedHref) {
@@ -60,8 +57,8 @@ export const getSecureLinkAttributes = (
     const parts = (rel || '')
       .split(/\s+/)
       .filter(Boolean)
-      .filter(token => token.toLowerCase() !== 'opener')
-    const lowerParts = new Set(parts.map(token => token.toLowerCase()))
+      .filter((token) => token.toLowerCase() !== 'opener')
+    const lowerParts = new Set(parts.map((token) => token.toLowerCase()))
     if (!lowerParts.has('noopener')) {
       parts.push('noopener')
       lowerParts.add('noopener')


### PR DESCRIPTION
💡 What: Added a visual "Shift+Enter" hint to the Run button in Python code playgrounds and a tooltip to the Reset button.
🎯 Why: To improve discoverability of keyboard shortcuts and button functions for better UX and accessibility.
📸 Before/After: Screenshot verified.
♿ Accessibility: Maintains existing ARIA labels while adding visual cues for sighted users.

---
*PR created automatically by Jules for task [11077410658317906139](https://jules.google.com/task/11077410658317906139) started by @saint2706*