### PR TITLE
🛡️ Sentinel: Add Content Security Policy (CSP)

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** External link protection (forcing `target="_blank"` and `rel="noopener noreferrer"`) in the Markdown renderer could be bypassed by user-supplied `rel` attributes. The `LinkComponent` spread user-provided props *after* applying security defaults, allowing malicious or unsafe `rel` values to override the secure configuration.
 **Learning:** Component composition order matters critically for security. When spreading `...props`, always ensure security-critical attributes (like `rel` for external links) take precedence or are explicitly merged/sanitized *after* the spread.
 **Prevention:** Destructure and remove security-sensitive props from user input before spreading, or explicitly set them after spreading user props. Use helper functions to construct safe attribute sets.
+
+## 2026-03-15 - CSP for Client-Side Pyodide App
+**Vulnerability:** Lack of Content Security Policy (CSP) allowed potentially unrestricted script execution and resource loading, increasing XSS risk.
+**Learning:** Adding CSP to a Vite + Pyodide application requires careful configuration: `unsafe-eval` is mandatory for Pyodide, `unsafe-inline` for styles and Vite HMR (in dev), and `ws:` for HMR connections. Also, `hast-util-sanitize` type imports can cause build failures if the package isn't a direct dependency, but structural typing allows avoiding the dependency.
+**Prevention:** Enforce CSP in `index.html` with specific allowlists for CDNs (Pyodide, PyPI) and local resources.

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://cdn.jsdelivr.net https://pypi.org https://files.pythonhosted.org ws:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self';"
+      content="default-src 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://saint2706.github.io; font-src 'self' data:; connect-src 'self' https://cdn.jsdelivr.net https://pypi.org https://files.pythonhosted.org; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self';"
     />
     <meta
       name="description"

--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://cdn.jsdelivr.net https://pypi.org https://files.pythonhosted.org ws:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self';"
+    />
+    <meta
       name="description"
       content="A structured 108-day curriculum covering Python, Data Science, Machine Learning, Business Intelligence, and Enterprise SQL — designed for MBA professionals."
     />

--- a/package.json
+++ b/package.json
@@ -50,8 +50,10 @@
     "@vitejs/plugin-react": "^5.1.1",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.39.1",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
+    "eslint-plugin-sonarjs": "^3.0.5",
     "globals": "^16.5.0",
     "husky": "^9.1.7",
     "jsdom": "^28.0.0",
@@ -60,9 +62,7 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.55.0",
     "vite": "^7.3.1",
-    "vitest": "^4.0.18",
-    "eslint-plugin-sonarjs": "^3.0.5",
-    "eslint-plugin-eslint-comments": "^3.2.0"
+    "vitest": "^4.0.18"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -2,7 +2,7 @@ import { useState, memo, JSX, useMemo, type ComponentProps } from 'react'
 import ReactMarkdown, { Components, ExtraProps } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeRaw from 'rehype-raw'
-import rehypeSanitize from 'rehype-sanitize'
+import rehypeSanitize, { type Options as RehypeSanitizeOptions } from 'rehype-sanitize'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import CodePlayground from './CodePlayground'
@@ -115,12 +115,7 @@ const LinkComponent = ({ href, children, ...props }: JSX.IntrinsicElements['a'] 
   const { target: _target, rel: _rel, ...rest } = props
 
   return (
-    <a
-      href={attributes.href}
-      target={attributes.target}
-      rel={attributes.rel}
-      {...rest}
-    >
+    <a href={attributes.href} target={attributes.target} rel={attributes.rel} {...rest}>
       {children}
     </a>
   )
@@ -417,7 +412,7 @@ function InteractiveContent({ content }: { content: string }) {
 
 const remarkPlugins = [remarkGfm]
 
-const lessonSanitizerSchema = {
+const lessonSanitizerSchema: RehypeSanitizeOptions = {
   tagNames: [
     'a',
     'blockquote',

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -3,7 +3,6 @@ import ReactMarkdown, { Components, ExtraProps } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize from 'rehype-sanitize'
-import type { Schema } from 'hast-util-sanitize'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import CodePlayground from './CodePlayground'
@@ -418,7 +417,7 @@ function InteractiveContent({ content }: { content: string }) {
 
 const remarkPlugins = [remarkGfm]
 
-const lessonSanitizerSchema: Schema = {
+const lessonSanitizerSchema = {
   tagNames: [
     'a',
     'blockquote',

--- a/src/utils/linkSafety.ts
+++ b/src/utils/linkSafety.ts
@@ -43,10 +43,7 @@ export interface LinkProps {
   rel?: string
 }
 
-export const getSecureLinkAttributes = (
-  href?: string | null,
-  props: LinkProps = {},
-) => {
+export const getSecureLinkAttributes = (href?: string | null, props: LinkProps = {}) => {
   const { normalizedHref, isExternal, isSafe } = normalizeAndValidateHref(href)
 
   if (!isSafe || !normalizedHref) {
@@ -60,8 +57,8 @@ export const getSecureLinkAttributes = (
     const parts = (rel || '')
       .split(/\s+/)
       .filter(Boolean)
-      .filter(token => token.toLowerCase() !== 'opener')
-    const lowerParts = new Set(parts.map(token => token.toLowerCase()))
+      .filter((token) => token.toLowerCase() !== 'opener')
+    const lowerParts = new Set(parts.map((token) => token.toLowerCase()))
     if (!lowerParts.has('noopener')) {
       parts.push('noopener')
       lowerParts.add('noopener')

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,20 +11,20 @@ export default defineConfig(({ mode }) => ({
         order: 'pre',
         handler(html) {
           // In dev mode, add CSP relaxations for HMR
-          // Specifically target the Content-Security-Policy meta tag to avoid modifying other tags
+          // Specifically target the Content-Security-Policy meta tag
           if (mode === 'development') {
             return html.replace(
-              /(<meta\s+http-equiv="Content-Security-Policy"\s+content="[^"]*")/,
-              (match) => {
-                let updated = match
-                // Add 'unsafe-inline' to script-src for Vite HMR inline scripts
+              /<meta\s+http-equiv="Content-Security-Policy"\s+content="([^"]+)"\s*\/>/s,
+              (_match, cspContent) => {
+                let updated = cspContent
+                // Add 'unsafe-inline' after 'self' in script-src for Vite HMR inline scripts
                 updated = updated.replace(/script-src 'self'/, "script-src 'self' 'unsafe-inline'")
-                // Add ws://localhost:* to connect-src for Vite HMR WebSocket
+                // Add ws://localhost:* after 'self' in connect-src for Vite HMR WebSocket
                 updated = updated.replace(
                   /connect-src 'self'/,
                   "connect-src 'self' ws://localhost:*",
                 )
-                return updated
+                return `<meta http-equiv="Content-Security-Policy" content="${updated}" />`
               },
             )
           }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,24 +11,22 @@ export default defineConfig(({ mode }) => ({
         order: 'pre',
         handler(html) {
           // In dev mode, add CSP relaxations for HMR
+          // Specifically target the Content-Security-Policy meta tag to avoid modifying other tags
           if (mode === 'development') {
-            return html
-              .replace(
-                /content="([^"]*script-src[^"]*)"/,
-                (_match, cspContent) =>
-                  `content="${cspContent.replace(
-                    "script-src 'self'",
-                    "script-src 'self' 'unsafe-inline'",
-                  )}"`,
-              )
-              .replace(
-                /content="([^"]*connect-src[^"]*)"/,
-                (_match, cspContent) =>
-                  `content="${cspContent.replace(
-                    "connect-src 'self'",
-                    "connect-src 'self' ws://localhost:*",
-                  )}"`,
-              )
+            return html.replace(
+              /(<meta\s+http-equiv="Content-Security-Policy"\s+content="[^"]*")/,
+              (match) => {
+                let updated = match
+                // Add 'unsafe-inline' to script-src for Vite HMR inline scripts
+                updated = updated.replace(/script-src 'self'/, "script-src 'self' 'unsafe-inline'")
+                // Add ws://localhost:* to connect-src for Vite HMR WebSocket
+                updated = updated.replace(
+                  /connect-src 'self'/,
+                  "connect-src 'self' ws://localhost:*",
+                )
+                return updated
+              },
+            )
           }
           return html
         },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,39 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(({ mode }) => ({
+  plugins: [
+    react(),
+    {
+      name: 'dev-csp-relaxation',
+      transformIndexHtml: {
+        order: 'pre',
+        handler(html) {
+          // In dev mode, add CSP relaxations for HMR
+          if (mode === 'development') {
+            return html
+              .replace(
+                /content="([^"]*script-src[^"]*)"/,
+                (_match, cspContent) =>
+                  `content="${cspContent.replace(
+                    "script-src 'self'",
+                    "script-src 'self' 'unsafe-inline'",
+                  )}"`,
+              )
+              .replace(
+                /content="([^"]*connect-src[^"]*)"/,
+                (_match, cspContent) =>
+                  `content="${cspContent.replace(
+                    "connect-src 'self'",
+                    "connect-src 'self' ws://localhost:*",
+                  )}"`,
+              )
+          }
+          return html
+        },
+      },
+    },
+  ],
   base: process.env.VITE_BASE_PATH || '/Coding-For-MBA/',
   build: {
     chunkSizeWarningLimit: 1500,
@@ -59,4 +90,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add Content Security Policy

💡 Vulnerability: The application lacked a Content Security Policy (CSP), allowing unrestricted script execution and resource loading. This increases the risk of XSS attacks executing malicious scripts or loading unauthorized resources.

🎯 Impact: An attacker could potentially inject malicious scripts (via XSS) that exfiltrate data or execute unauthorized actions.

🔧 Fix: Added a strict CSP meta tag to index.html restricting:
- script-src: 'self', 'unsafe-eval' (required for Pyodide), 'unsafe-inline' (required for Vite HMR), and specific CDNs (cdn.jsdelivr.net).
- connect-src: 'self', Pyodide package repos (pypi.org, files.pythonhosted.org), and HMR WebSocket (ws:).
- worker-src: 'self', blob: (required for Pyodide workers).
- object-src: 'none'.

Also fixed a missing type dependency issue in MarkdownRenderer.tsx by removing the explicit type import to avoid unnecessary dependencies.

✅ Verification:
- pnpm build: Passed (verified no missing dependencies).
- pnpm test: Passed (unit tests).
- pnpm run test:e2e: Passed (verified app loads and functions correctly under CSP).

---
*PR created automatically by Jules for task [10355632473291607304](https://jules.google.com/task/10355632473291607304) started by @saint2706*