### PR TITLE
🎨 Palette: Add Copy button to Exercise Solution

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-23 - Dynamic Output Accessibility
 **Learning:** Dynamic content updates (like code execution results) are often silent for screen reader users unless explicitly marked.
 **Action:** Use `aria-live="polite"` on the output container so screen readers announce the result automatically when it appears or changes.
+
+## 2025-02-23 - Actionable Revealed Content
+**Learning:** Revealed content, especially code solutions, often leaves the user stranded without an easy way to use that content (e.g., trying it out).
+**Action:** Always include action buttons (like "Copy" or "Try It") within the revealed content area to facilitate immediate interaction, ensuring they are accessible and positioned logically.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,6 +6,6 @@
 **Learning:** Dynamic content updates (like code execution results) are often silent for screen reader users unless explicitly marked.
 **Action:** Use `aria-live="polite"` on the output container so screen readers announce the result automatically when it appears or changes.
 
-## 2025-02-23 - Actionable Revealed Content
+## 2026-02-23 - Actionable Revealed Content
 **Learning:** Revealed content, especially code solutions, often leaves the user stranded without an easy way to use that content (e.g., trying it out).
 **Action:** Always include action buttons (like "Copy" or "Try It") within the revealed content area to facilitate immediate interaction, ensuring they are accessible and positioned logically.

--- a/src/components/ExerciseWidget.tsx
+++ b/src/components/ExerciseWidget.tsx
@@ -10,6 +10,7 @@ import { useState, useId } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import CodePlayground from './CodePlayground'
+import CopyButton from './CopyButton'
 
 /**
  * Custom syntax highlighting theme for solution code display.
@@ -120,26 +121,40 @@ export default function ExerciseWidget({
             aria-hidden={!showSolution}
             inert={!showSolution}
           >
-            <SyntaxHighlighter
-              style={solutionTheme}
-              language="python"
-              PreTag="div"
-              customStyle={{
-                margin: 0,
-                padding: '0.75rem',
-                background: 'var(--bg-code)',
-                fontSize: '0.8125rem',
-                lineHeight: '1.65',
-                borderRadius: 'var(--radius-sm)',
-              }}
-              codeTagProps={{
-                style: {
-                  fontFamily: 'var(--font-mono)',
-                },
-              }}
-            >
-              {solution}
-            </SyntaxHighlighter>
+            <div style={{ position: 'relative' }}>
+              <div
+                style={{
+                  position: 'absolute',
+                  top: '0.5rem',
+                  right: '0.5rem',
+                  zIndex: 10,
+                  backgroundColor: 'var(--bg-card)',
+                  borderRadius: 'var(--radius-sm)',
+                }}
+              >
+                <CopyButton text={solution} className="code-block-copy" showEmoji={true} />
+              </div>
+              <SyntaxHighlighter
+                style={solutionTheme}
+                language="python"
+                PreTag="div"
+                customStyle={{
+                  margin: 0,
+                  padding: '0.75rem',
+                  background: 'var(--bg-code)',
+                  fontSize: '0.8125rem',
+                  lineHeight: '1.65',
+                  borderRadius: 'var(--radius-sm)',
+                }}
+                codeTagProps={{
+                  style: {
+                    fontFamily: 'var(--font-mono)',
+                  },
+                }}
+              >
+                {solution}
+              </SyntaxHighlighter>
+            </div>
           </div>
         </div>
       )}

--- a/src/components/PythonRunner.tsx
+++ b/src/components/PythonRunner.tsx
@@ -125,9 +125,7 @@ const PythonRunner = forwardRef<PythonRunnerHandle, PythonRunnerProps>(
               </>
             ) : (
               <>
-                <kbd className="python-runner__shortcut">
-                  Shift+Enter
-                </kbd>
+                <kbd className="python-runner__shortcut">Shift+Enter</kbd>
               </>
             )}
           </button>


### PR DESCRIPTION
Implemented a micro-UX improvement by adding a "Copy" button to the solution reveal panel in coding exercises. This addresses a user pain point where revealed solutions were not easily actionable. Verified with visual inspection via Playwright and existing unit tests. Updated UX journal with learnings.

---
*PR created automatically by Jules for task [16887119919614424912](https://jules.google.com/task/16887119919614424912) started by @saint2706*