### PR TITLE
🛡️ Sentinel: [Security Enhancement] Restrict browser API access in Python runner

### DIFF
--- a/src/components/PythonRunner.tsx
+++ b/src/components/PythonRunner.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useCallback, useRef, forwardRef, useImperativeHandle } from 'react'
 import { usePyodide } from '../hooks/usePyodide'
+import { validatePythonCode } from '../utils/codeSecurity'
 
 const DEFAULT_RUN_TIMEOUT_MS = 10_000
 
@@ -66,6 +67,15 @@ const PythonRunner = forwardRef<PythonRunnerHandle, PythonRunnerProps>(
      */
     const handleRun = useCallback(async () => {
       if (running || pyodideLoading) return
+
+      // Security Check
+      const { valid, error: validationError } = validatePythonCode(code)
+      if (!valid) {
+        setError(validationError || 'Code rejected by security policy.')
+        setOutput(null)
+        return
+      }
+
       const currentRunId = runIdRef.current + 1
       runIdRef.current = currentRunId
       const abortController = new AbortController()

--- a/src/components/PythonRunner.tsx
+++ b/src/components/PythonRunner.tsx
@@ -135,9 +135,7 @@ const PythonRunner = forwardRef<PythonRunnerHandle, PythonRunnerProps>(
               </>
             ) : (
               <>
-                <kbd className="python-runner__shortcut">
-                  Shift+Enter
-                </kbd>
+                <kbd className="python-runner__shortcut">Shift+Enter</kbd>
               </>
             )}
           </button>

--- a/src/utils/codeSecurity.test.ts
+++ b/src/utils/codeSecurity.test.ts
@@ -53,7 +53,9 @@ print("bad")
     expect(validatePythonCode('import importlib').valid).toBe(true)
     expect(validatePythonCode('import importlib.metadata').valid).toBe(true)
     expect(validatePythonCode('import importlib.resources').valid).toBe(true)
-    // Note: import_module() itself is blocked as it's primarily used for dynamic imports
+    // Note: importlib.import_module() is intentionally blocked to prevent dynamic
+    // module loading, which could be used to bypass security restrictions.
+    // This is acceptable for an educational platform where dynamic imports aren't needed.
   })
 
   it('should block string concatenation in __import__', () => {

--- a/src/utils/codeSecurity.test.ts
+++ b/src/utils/codeSecurity.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { validatePythonCode } from './codeSecurity'
+
+describe('validatePythonCode', () => {
+  it('should allow safe code', () => {
+    expect(validatePythonCode('print("Hello")').valid).toBe(true)
+    expect(validatePythonCode('import json').valid).toBe(true)
+    expect(validatePythonCode('import numpy as np').valid).toBe(true)
+    expect(validatePythonCode('from math import sqrt').valid).toBe(true)
+    expect(validatePythonCode('x = "js"').valid).toBe(true) // "js" string
+  })
+
+  it('should block import js', () => {
+    expect(validatePythonCode('import js').valid).toBe(false)
+    expect(validatePythonCode('  import js').valid).toBe(false)
+    expect(validatePythonCode('import js as browser').valid).toBe(false)
+  })
+
+  it('should block from js import', () => {
+    expect(validatePythonCode('from js import window').valid).toBe(false)
+    expect(validatePythonCode('  from   js   import window').valid).toBe(false)
+  })
+
+  it('should block __import__("js")', () => {
+    expect(validatePythonCode("__import__('js')").valid).toBe(false)
+    expect(validatePythonCode('__import__("js")').valid).toBe(false)
+    expect(validatePythonCode("foo = __import__('js')").valid).toBe(false)
+  })
+
+  it('should not block json imports', () => {
+    expect(validatePythonCode('import json').valid).toBe(true)
+    expect(validatePythonCode('from json import load').valid).toBe(true)
+  })
+
+  it('should block multiline imports', () => {
+    const code = `
+import os
+import js
+print("bad")
+`
+    expect(validatePythonCode(code).valid).toBe(false)
+  })
+})

--- a/src/utils/codeSecurity.test.ts
+++ b/src/utils/codeSecurity.test.ts
@@ -44,8 +44,16 @@ print("bad")
   it('should block importlib.import_module("js")', () => {
     expect(validatePythonCode('importlib.import_module("js")').valid).toBe(false)
     expect(validatePythonCode("importlib.import_module('js')").valid).toBe(false)
-    expect(validatePythonCode('import importlib').valid).toBe(false)
-    expect(validatePythonCode('from importlib import import_module').valid).toBe(false)
+    expect(
+      validatePythonCode('from importlib import import_module; import_module("js")').valid,
+    ).toBe(false)
+  })
+
+  it('should allow importlib for legitimate uses', () => {
+    expect(validatePythonCode('import importlib').valid).toBe(true)
+    expect(validatePythonCode('import importlib.metadata').valid).toBe(true)
+    expect(validatePythonCode('import importlib.resources').valid).toBe(true)
+    // Note: import_module() itself is blocked as it's primarily used for dynamic imports
   })
 
   it('should block string concatenation in __import__', () => {

--- a/src/utils/codeSecurity.test.ts
+++ b/src/utils/codeSecurity.test.ts
@@ -40,4 +40,44 @@ print("bad")
 `
     expect(validatePythonCode(code).valid).toBe(false)
   })
+
+  it('should block importlib.import_module("js")', () => {
+    expect(validatePythonCode('importlib.import_module("js")').valid).toBe(false)
+    expect(validatePythonCode("importlib.import_module('js')").valid).toBe(false)
+    expect(validatePythonCode('import importlib').valid).toBe(false)
+    expect(validatePythonCode('from importlib import import_module').valid).toBe(false)
+  })
+
+  it('should block string concatenation in __import__', () => {
+    expect(validatePythonCode('__import__("j" + "s")').valid).toBe(false)
+    expect(validatePythonCode("__import__('j' + 's')").valid).toBe(false)
+    expect(validatePythonCode('__import__(chr(106)+chr(115))').valid).toBe(false)
+  })
+
+  it('should block __builtins__.__import__', () => {
+    expect(validatePythonCode('__builtins__.__import__("js")').valid).toBe(false)
+    expect(validatePythonCode("__builtins__.__import__('js')").valid).toBe(false)
+  })
+
+  it('should allow imports with comments', () => {
+    expect(validatePythonCode('import json  # load data').valid).toBe(true)
+    expect(validatePythonCode('import math  # calculations').valid).toBe(true)
+  })
+
+  it('should block js imports with comments', () => {
+    expect(validatePythonCode('import js  # some comment').valid).toBe(false)
+    expect(validatePythonCode('from js import window  # access browser').valid).toBe(false)
+  })
+
+  it('should allow legitimate math operations', () => {
+    // Ensure we don't break legitimate code with + operators
+    expect(validatePythonCode('x = 1 + 2').valid).toBe(true)
+    expect(validatePythonCode('result = "hello" + "world"').valid).toBe(true)
+  })
+
+  it('should block various obfuscation attempts', () => {
+    // Block various ways to construct 'js' dynamically
+    expect(validatePythonCode('__import__("js".lower())').valid).toBe(false)
+    expect(validatePythonCode('x = __import__("j" + "s")').valid).toBe(false)
+  })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -13,7 +13,7 @@ export interface ValidationResult {
  * Checks for:
  * - Direct access to the 'js' module (browser API access)
  * - Usage of __import__ for 'js'
- * - Dynamic imports via importlib
+ * - Dynamic imports via importlib.import_module
  * - String manipulation to bypass checks
  *
  * @param code - The Python code to validate
@@ -28,10 +28,10 @@ export function validatePythonCode(code: string): ValidationResult {
     /\bimport\s+js\b/, // import js
     /\bfrom\s+js\b/, // from js import ...
     /__import__\s*\(\s*['"]js['"]\s*\)/, // __import__('js')
-    /\bimportlib\b/, // Any use of importlib (dynamic imports)
-    /__import__\s*\([^)]*[+]/, // __import__ with concatenation (simple cases)
-    /__import__\s*\(\s*chr/, // __import__(chr(...) - character obfuscation
-    /__import__\s*\(\s*['"][^'"]*['"][^)]*\.[^)]*\)/, // __import__("...".method()) - string method calls
+    /import_module\s*\(/, // importlib.import_module or direct import_module calls
+    /__import__\s*\(\s*['"][^'"]*['"]\s*\+\s*['"][^'"]*['"]/, // __import__("..." + "...") - string concatenation
+    /__import__\s*\(\s*chr\s*\(/, // __import__(chr(...) - character obfuscation
+    /__import__\s*\(\s*['"][^'"]*['"]\s*\.\s*(lower|upper|strip|replace|format)\s*\(/, // __import__("...".method()) - string method obfuscation
     /__builtins__\s*\.\s*__import__/, // __builtins__.__import__
   ]
 

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -16,6 +16,10 @@ export interface ValidationResult {
  * - Dynamic imports via importlib.import_module
  * - String manipulation to bypass checks
  *
+ * Note: This is a defense-in-depth approach using regex patterns. While not
+ * foolproof, it catches common bypass attempts. For a production environment,
+ * consider using AST-based validation or sandboxing.
+ *
  * @param code - The Python code to validate
  * @returns Validation result
  */
@@ -28,7 +32,8 @@ export function validatePythonCode(code: string): ValidationResult {
     /\bimport\s+js\b/, // import js
     /\bfrom\s+js\b/, // from js import ...
     /__import__\s*\(\s*['"]js['"]\s*\)/, // __import__('js')
-    /import_module\s*\(/, // importlib.import_module or direct import_module calls
+    /\bimportlib\s*\.\s*import_module\s*\(/, // importlib.import_module() - dynamic imports
+    /\bfrom\s+importlib\s+import\s+import_module/, // from importlib import import_module
     /__import__\s*\(\s*['"][^'"]*['"]\s*\+\s*['"][^'"]*['"]/, // __import__("..." + "...") - string concatenation
     /__import__\s*\(\s*chr\s*\(/, // __import__(chr(...) - character obfuscation
     /__import__\s*\(\s*['"][^'"]*['"]\s*\.\s*(lower|upper|strip|replace|format)\s*\(/, // __import__("...".method()) - string method obfuscation

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -1,0 +1,41 @@
+/**
+ * Security validation for Python code execution.
+ */
+
+export interface ValidationResult {
+  valid: boolean
+  error?: string
+}
+
+/**
+ * Validates Python code for potential security risks before execution.
+ *
+ * Checks for:
+ * - Direct access to the 'js' module (browser API access)
+ * - Usage of __import__ for 'js'
+ *
+ * @param code - The Python code to validate
+ * @returns Validation result
+ */
+export function validatePythonCode(code: string): ValidationResult {
+  if (!code) return { valid: true }
+
+  // Regex patterns to detect 'js' module imports
+  // We use \b to ensure we don't match 'json' or 'jsp' etc.
+  const patterns = [
+    /\bimport\s+js\b/,                   // import js
+    /\bfrom\s+js\b/,                     // from js import ...
+    /__import__\s*\(\s*['"]js['"]\s*\)/, // __import__('js')
+  ]
+
+  for (const pattern of patterns) {
+    if (pattern.test(code)) {
+      return {
+        valid: false,
+        error: "Security Error: Direct access to browser APIs via 'js' module is restricted."
+      }
+    }
+  }
+
+  return { valid: true }
+}

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -13,6 +13,8 @@ export interface ValidationResult {
  * Checks for:
  * - Direct access to the 'js' module (browser API access)
  * - Usage of __import__ for 'js'
+ * - Dynamic imports via importlib
+ * - String manipulation to bypass checks
  *
  * @param code - The Python code to validate
  * @returns Validation result
@@ -20,19 +22,24 @@ export interface ValidationResult {
 export function validatePythonCode(code: string): ValidationResult {
   if (!code) return { valid: true }
 
-  // Regex patterns to detect 'js' module imports
+  // Regex patterns to detect 'js' module imports and bypass attempts
   // We use \b to ensure we don't match 'json' or 'jsp' etc.
   const patterns = [
-    /\bimport\s+js\b/,                   // import js
-    /\bfrom\s+js\b/,                     // from js import ...
+    /\bimport\s+js\b/, // import js
+    /\bfrom\s+js\b/, // from js import ...
     /__import__\s*\(\s*['"]js['"]\s*\)/, // __import__('js')
+    /\bimportlib\b/, // Any use of importlib (dynamic imports)
+    /__import__\s*\([^)]*[+]/, // __import__ with concatenation (simple cases)
+    /__import__\s*\(\s*chr/, // __import__(chr(...) - character obfuscation
+    /__import__\s*\(\s*['"][^'"]*['"][^)]*\.[^)]*\)/, // __import__("...".method()) - string method calls
+    /__builtins__\s*\.\s*__import__/, // __builtins__.__import__
   ]
 
   for (const pattern of patterns) {
     if (pattern.test(code)) {
       return {
         valid: false,
-        error: "Security Error: Direct access to browser APIs via 'js' module is restricted."
+        error: "Security Error: Direct access to browser APIs via 'js' module is restricted.",
       }
     }
   }


### PR DESCRIPTION
This PR introduces a security enhancement to the Python execution environment.

**What's new?**
- A new `validatePythonCode` utility in `src/utils/codeSecurity.ts` checks for prohibited import patterns (`import js`, `from js`, etc.).
- The `PythonRunner` component now validates code before sending it to Pyodide.
- If a prohibited pattern is detected, execution is blocked and a user-friendly security error is displayed.

**Why?**
The `js` module in Pyodide provides direct access to the browser's JavaScript environment (DOM, Window, Storage). While this is a feature of Pyodide, in the context of this educational platform ("Coding for MBA"), such access is unnecessary and presents a potential security risk (Self-XSS or accidental environment breakage). By restricting this access, we ensure a safer and more focused learning environment.

**Verification:**
- New unit tests in `src/utils/codeSecurity.test.ts` cover various import patterns.
- Manual verification via Playwright confirmed that `import js` triggers the expected error message in the UI.
- Existing tests passed.

---
*PR created automatically by Jules for task [134253940634831508](https://jules.google.com/task/134253940634831508) started by @saint2706*