### PR TITLE
🎨 Palette: Improve Python Runner button with explicit label

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-23 - Actionable Revealed Content
 **Learning:** Revealed content, especially code solutions, often leaves the user stranded without an easy way to use that content (e.g., trying it out).
 **Action:** Always include action buttons (like "Copy" or "Try It") within the revealed content area to facilitate immediate interaction, ensuring they are accessible and positioned logically.
+
+## 2026-02-24 - Explicit Action Labels
+**Learning:** relying solely on keyboard shortcuts (like "Shift+Enter") as button labels obscures the primary action ("Run") for users who scan visually or don't know the shortcut.
+**Action:** Always pair keyboard shortcuts with explicit text labels and icons for primary actions to ensure discoverability and clarity.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -11,5 +11,5 @@
 **Action:** Always include action buttons (like "Copy" or "Try It") within the revealed content area to facilitate immediate interaction, ensuring they are accessible and positioned logically.
 
 ## 2026-02-24 - Explicit Action Labels
-**Learning:** relying solely on keyboard shortcuts (like "Shift+Enter") as button labels obscures the primary action ("Run") for users who scan visually or don't know the shortcut.
+**Learning:** Relying solely on keyboard shortcuts (like "Shift+Enter") as button labels obscures the primary action ("Run") for users who scan visually or don't know the shortcut.
 **Action:** Always pair keyboard shortcuts with explicit text labels and icons for primary actions to ensure discoverability and clarity.

--- a/src/components/PythonRunner.tsx
+++ b/src/components/PythonRunner.tsx
@@ -135,6 +135,17 @@ const PythonRunner = forwardRef<PythonRunnerHandle, PythonRunnerProps>(
               </>
             ) : (
               <>
+                <svg
+                  className="python-runner__icon"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  width="16"
+                  height="16"
+                  aria-hidden="true"
+                >
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+                Run
                 <kbd className="python-runner__shortcut">Shift+Enter</kbd>
               </>
             )}

--- a/src/styles/interactive.css
+++ b/src/styles/interactive.css
@@ -34,6 +34,19 @@
   cursor: not-allowed;
 }
 
+.python-runner__shortcut {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  padding: 0.1rem 0.35rem;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 3px;
+  opacity: 0.9;
+}
+
+.python-runner__icon {
+  display: block;
+}
+
 .python-runner__spinner {
   display: inline-block;
   width: 12px;

--- a/verification/verify_run_button.py
+++ b/verification/verify_run_button.py
@@ -11,11 +11,11 @@ def verify_run_button():
         print(f"Navigating to {url}")
         page.goto(url)
 
-        # Wait for the "Run Python code" button
+        # Wait for the "Run Python code (Shift+Enter)" button
         print("Waiting for run button...")
         try:
-            # We are looking for button with "Run Python code" accessible name
-            run_button = page.get_by_role("button", name="Run Python code").first
+            # We are looking for button with full accessible name from aria-label
+            run_button = page.get_by_role("button", name="Run Python code (Shift+Enter)").first
             run_button.wait_for(state="visible", timeout=30000)
             print("Run button found.")
 

--- a/verification/verify_run_button.py
+++ b/verification/verify_run_button.py
@@ -1,0 +1,39 @@
+from playwright.sync_api import sync_playwright
+
+def verify_run_button():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+
+        # Navigate to a lesson with code
+        # Using lesson 1 which usually has code examples
+        url = "http://localhost:5173/Coding-For-MBA/#/lesson/1"
+        print(f"Navigating to {url}")
+        page.goto(url)
+
+        # Wait for the "Run Python code" button
+        print("Waiting for run button...")
+        try:
+            # We are looking for button with "Run Python code" accessible name
+            run_button = page.get_by_role("button", name="Run Python code").first
+            run_button.wait_for(state="visible", timeout=30000)
+            print("Run button found.")
+
+            # Take a screenshot of the button specifically to verify text and icon
+            # Or the whole playground
+            playground = page.locator(".code-playground").first
+            if playground.is_visible():
+                playground.screenshot(path="verification/verification_run_button.png")
+                print("Screenshot saved to verification/verification_run_button.png")
+            else:
+                print("Playground not found, screenshotting whole page.")
+                page.screenshot(path="verification/verification_full_page.png")
+
+        except Exception as e:
+            print(f"Error: {e}")
+            page.screenshot(path="verification/verification_error.png")
+
+        browser.close()
+
+if __name__ == "__main__":
+    verify_run_button()


### PR DESCRIPTION
💡 What: Added a "Run" label and a play icon to the Python Runner button, while keeping the "Shift+Enter" shortcut hint.
🎯 Why: Previously, the button only showed "Shift+Enter", which was confusing for users who didn't know the shortcut or that the button was clickable. This improves discoverability.
📸 Before/After: Added text label and icon.
♿ Accessibility: Kept the existing aria-label but made the visual label explicit.
Updated .Jules/palette.md with learnings.

---
*PR created automatically by Jules for task [4228793189898417947](https://jules.google.com/task/4228793189898417947) started by @saint2706*