### PR TITLE
🎨 Palette: Add 'Try Solution' button to ExerciseWidget

### DIFF
--- a/src/components/CodePlayground.tsx
+++ b/src/components/CodePlayground.tsx
@@ -6,7 +6,7 @@
  * and optional expected output display.
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react'
+import { useState, useCallback, useRef, useEffect, forwardRef, useImperativeHandle } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import PythonRunner, { type PythonRunnerHandle } from './PythonRunner'
@@ -27,6 +27,15 @@ const highlightTheme = {
     ...(oneDark['code[class*="language-"]'] as object),
     background: 'transparent',
   },
+}
+
+/**
+ * Handle interface for accessing CodePlayground methods imperatively.
+ */
+export interface CodePlaygroundHandle {
+  run: () => void
+  setCode: (code: string) => void
+  reset: () => void
 }
 
 /**
@@ -55,7 +64,7 @@ interface CodePlaygroundProps {
  * @param expectedOutput - Optional expected output to show users
  * @returns An interactive code playground component
  */
-export default function CodePlayground({ initialCode, expectedOutput }: CodePlaygroundProps) {
+const CodePlayground = forwardRef<CodePlaygroundHandle, CodePlaygroundProps>(({ initialCode, expectedOutput }, ref) => {
   const [code, setCode] = useState(initialCode)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const preRef = useRef<HTMLDivElement>(null)
@@ -67,6 +76,16 @@ export default function CodePlayground({ initialCode, expectedOutput }: CodePlay
   const handleReset = useCallback(() => {
     setCode(initialCode)
   }, [initialCode])
+
+  useImperativeHandle(ref, () => ({
+    run: () => {
+      if (runnerRef.current) {
+        runnerRef.current.run()
+      }
+    },
+    setCode: (newCode: string) => setCode(newCode),
+    reset: handleReset
+  }), [handleReset])
 
   /**
    * Synchronizes scroll position between textarea and syntax highlighter.
@@ -162,4 +181,8 @@ export default function CodePlayground({ initialCode, expectedOutput }: CodePlay
       )}
     </div>
   )
-}
+})
+
+CodePlayground.displayName = 'CodePlayground'
+
+export default CodePlayground

--- a/src/components/ExerciseWidget.tsx
+++ b/src/components/ExerciseWidget.tsx
@@ -6,10 +6,10 @@
  * and an optional solution that can be revealed on demand.
  */
 
-import { useState, useId } from 'react'
+import { useState, useId, useRef } from 'react'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
-import CodePlayground from './CodePlayground'
+import CodePlayground, { type CodePlaygroundHandle } from './CodePlayground'
 import CopyButton from './CopyButton'
 
 /**
@@ -76,6 +76,7 @@ export default function ExerciseWidget({
 }: ExerciseWidgetProps) {
   const [showSolution, setShowSolution] = useState(false)
   const solutionId = useId()
+  const playgroundRef = useRef<CodePlaygroundHandle>(null)
 
   return (
     <div className="exercise-widget">
@@ -100,7 +101,11 @@ export default function ExerciseWidget({
         </div>
       )}
 
-      <CodePlayground initialCode={starterCode} expectedOutput={expectedOutput} />
+      <CodePlayground
+        ref={playgroundRef}
+        initialCode={starterCode}
+        expectedOutput={expectedOutput}
+      />
 
       {solution && (
         <div className="exercise-widget__solution">
@@ -130,8 +135,24 @@ export default function ExerciseWidget({
                   zIndex: 10,
                   backgroundColor: 'var(--bg-card)',
                   borderRadius: 'var(--radius-sm)',
+                  display: 'flex',
+                  gap: '0.5rem',
+                  alignItems: 'center',
                 }}
               >
+                <button
+                  className="code-block-copy"
+                  onClick={() => playgroundRef.current?.setCode(solution)}
+                  aria-label="Load solution into playground"
+                  title="Try Solution"
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.35rem',
+                  }}
+                >
+                  🚀 Try Solution
+                </button>
                 <CopyButton text={solution} className="code-block-copy" showEmoji={true} />
               </div>
               <SyntaxHighlighter

--- a/src/components/__tests__/CodePlaygroundRef.test.tsx
+++ b/src/components/__tests__/CodePlaygroundRef.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React, { createRef, act } from 'react'
+import { createRoot } from 'react-dom/client'
+import CodePlayground, { CodePlaygroundHandle } from '../CodePlayground'
+
+// Mock sub-components to simplify testing
+vi.mock('../PythonRunner', () => ({
+  default: () => <div data-testid="python-runner" />
+}))
+
+vi.mock('../CopyButton', () => ({
+  default: () => <button>Copy</button>
+}))
+
+// Mock SyntaxHighlighter because it might use canvas or complex DOM
+vi.mock('react-syntax-highlighter', () => ({
+  Prism: ({ children }: { children: React.ReactNode }) => <div className="syntax-highlighter">{children}</div>
+}))
+
+vi.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({
+  oneDark: {}
+}))
+
+describe('CodePlayground Ref', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    document.body.removeChild(container)
+  })
+
+  it('exposes setCode via ref', async () => {
+    const ref = createRef<CodePlaygroundHandle>()
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(<CodePlayground initialCode="initial" ref={ref} />)
+    })
+
+    // Check initial render
+    const textarea = container.querySelector('textarea')
+    expect(textarea?.value).toBe('initial')
+
+    // Update code via ref
+    await act(async () => {
+      ref.current?.setCode('updated')
+    })
+
+    expect(textarea?.value).toBe('updated')
+
+    // Reset code via ref
+    await act(async () => {
+      ref.current?.reset()
+    })
+
+    expect(textarea?.value).toBe('initial')
+  })
+})

--- a/src/components/__tests__/CodePlaygroundRef.test.tsx
+++ b/src/components/__tests__/CodePlaygroundRef.test.tsx
@@ -12,7 +12,7 @@ interface MockPythonRunnerProps {
 }
 
 vi.mock('../PythonRunner', () => ({
-  default: forwardRef((props: MockPythonRunnerProps, ref: React.Ref<unknown>) => {
+  default: forwardRef((_props: MockPythonRunnerProps, ref: React.Ref<unknown>) => {
     useImperativeHandle(ref, () => ({
       run: mockRunFn,
       cancel: vi.fn(),

--- a/src/components/__tests__/CodePlaygroundRef.test.tsx
+++ b/src/components/__tests__/CodePlaygroundRef.test.tsx
@@ -1,24 +1,39 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import React, { createRef, act } from 'react'
+import React, { createRef, act, forwardRef, useImperativeHandle } from 'react'
 import { createRoot } from 'react-dom/client'
 import CodePlayground, { CodePlaygroundHandle } from '../CodePlayground'
 
-// Mock sub-components to simplify testing
+// Mock PythonRunner with ref support
+const mockRunFn = vi.fn()
+
+interface MockPythonRunnerProps {
+  code: string
+  compact?: boolean
+}
+
 vi.mock('../PythonRunner', () => ({
-  default: () => <div data-testid="python-runner" />
+  default: forwardRef((props: MockPythonRunnerProps, ref: React.Ref<unknown>) => {
+    useImperativeHandle(ref, () => ({
+      run: mockRunFn,
+      cancel: vi.fn(),
+    }))
+    return <div data-testid="python-runner" />
+  }),
 }))
 
 vi.mock('../CopyButton', () => ({
-  default: () => <button>Copy</button>
+  default: () => <button>Copy</button>,
 }))
 
 // Mock SyntaxHighlighter because it might use canvas or complex DOM
 vi.mock('react-syntax-highlighter', () => ({
-  Prism: ({ children }: { children: React.ReactNode }) => <div className="syntax-highlighter">{children}</div>
+  Prism: ({ children }: { children: React.ReactNode }) => (
+    <div className="syntax-highlighter">{children}</div>
+  ),
 }))
 
 vi.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({
-  oneDark: {}
+  oneDark: {},
 }))
 
 describe('CodePlayground Ref', () => {
@@ -27,6 +42,7 @@ describe('CodePlayground Ref', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
+    mockRunFn.mockClear()
   })
 
   afterEach(() => {
@@ -58,5 +74,22 @@ describe('CodePlayground Ref', () => {
     })
 
     expect(textarea?.value).toBe('initial')
+  })
+
+  it('exposes run via ref and calls PythonRunner run method', async () => {
+    const ref = createRef<CodePlaygroundHandle>()
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(<CodePlayground initialCode="print('test')" ref={ref} />)
+    })
+
+    // Call run via ref
+    await act(async () => {
+      ref.current?.run()
+    })
+
+    // Verify that PythonRunner's run method was called
+    expect(mockRunFn).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Implemented a "Try Solution" button in the `ExerciseWidget` component.

*   Refactored `CodePlayground` to use `forwardRef` and expose an imperative handle (`setCode`, `run`, `reset`).
*   Updated `ExerciseWidget` to use the new handle to load solution code into the playground when the button is clicked.
*   Added a test `src/components/__tests__/CodePlaygroundRef.test.tsx` to verify the new ref functionality.
*   Verified frontend changes with Playwright screenshot.

---
*PR created automatically by Jules for task [1331186338991255030](https://jules.google.com/task/1331186338991255030) started by @saint2706*