### PR TITLE
Add client-side spaced-repetition review workflow (card generation, scheduler, UI, storage)

### DIFF
--- a/docs/review-cards.md
+++ b/docs/review-cards.md
@@ -1,0 +1,29 @@
+# Review Card Generation Rules
+
+The review system generates cards client-side from each lesson `README.md` at build/runtime via `contentLoader.ts`.
+
+## Sources
+
+For each lesson, cards are created from:
+
+1. **Frontmatter `concepts`**
+   - One card per concept.
+   - Prompt asks the learner to explain the concept.
+2. **Markdown headings (`##` + `###`)**
+   - Every H2/H3 in lesson content creates one card.
+   - Prompt asks for the key idea of that section.
+3. **Exercises (`### Exercise N:` blocks)**
+   - Reuses existing exercise extraction.
+   - Prompt asks how to solve the exercise.
+   - Answer guide uses `**Goal**` text when available.
+
+## Determinism
+
+- Card IDs are deterministic: `d{day}-{sourceType}-{normalized-text}`.
+- Normalization lowercases and slugifies text to keep IDs stable.
+- Review state stays in localStorage and is mapped by card ID.
+
+## Scheduling
+
+- Uses a simple SM-2 style scheduler with ratings: Again / Hard / Good / Easy.
+- Entirely client-side; no network calls.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ const Exercises = lazy(() => import('./pages/Exercises'))
 const NotebookViewer = lazy(() => import('./pages/NotebookViewer'))
 const ConceptGraphPage = lazy(() => import('./pages/ConceptGraphPage'))
 const ContentStats = lazy(() => import('./pages/ContentStats'))
+const Review = lazy(() => import('./pages/Review'))
 const NotFound = lazy(() => import('./pages/NotFound'))
 
 export default function App() {
@@ -62,6 +63,7 @@ export default function App() {
               <Route path="/search" element={<SearchResults />} />
               <Route path="/concepts" element={<ConceptGraphPage />} />
               <Route path="/stats" element={<ContentStats />} />
+              <Route path="/review" element={<Review />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </Suspense>

--- a/src/components/CodePlayground.tsx
+++ b/src/components/CodePlayground.tsx
@@ -64,124 +64,130 @@ interface CodePlaygroundProps {
  * @param expectedOutput - Optional expected output to show users
  * @returns An interactive code playground component
  */
-const CodePlayground = forwardRef<CodePlaygroundHandle, CodePlaygroundProps>(({ initialCode, expectedOutput }, ref) => {
-  const [code, setCode] = useState(initialCode)
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const preRef = useRef<HTMLDivElement>(null)
-  const runnerRef = useRef<PythonRunnerHandle>(null)
+const CodePlayground = forwardRef<CodePlaygroundHandle, CodePlaygroundProps>(
+  ({ initialCode, expectedOutput }, ref) => {
+    const [code, setCode] = useState(initialCode)
+    const textareaRef = useRef<HTMLTextAreaElement>(null)
+    const preRef = useRef<HTMLDivElement>(null)
+    const runnerRef = useRef<PythonRunnerHandle>(null)
 
-  /**
-   * Resets the code editor to its initial state.
-   */
-  const handleReset = useCallback(() => {
-    setCode(initialCode)
-  }, [initialCode])
+    /**
+     * Resets the code editor to its initial state.
+     */
+    const handleReset = useCallback(() => {
+      setCode(initialCode)
+    }, [initialCode])
 
-  useImperativeHandle(ref, () => ({
-    run: () => {
-      if (runnerRef.current) {
-        runnerRef.current.run()
+    useImperativeHandle(
+      ref,
+      () => ({
+        run: () => {
+          if (runnerRef.current) {
+            runnerRef.current.run()
+          }
+        },
+        setCode: (newCode: string) => setCode(newCode),
+        reset: handleReset,
+      }),
+      [handleReset],
+    )
+
+    /**
+     * Synchronizes scroll position between textarea and syntax highlighter.
+     */
+    useEffect(() => {
+      const ta = textareaRef.current
+      if (ta) {
+        ta.style.height = 'auto'
+        ta.style.height = ta.scrollHeight + 'px'
       }
-    },
-    setCode: (newCode: string) => setCode(newCode),
-    reset: handleReset
-  }), [handleReset])
+    }, [code])
 
-  /**
-   * Synchronizes scroll position between textarea and syntax highlighter.
-   */
-  useEffect(() => {
-    const ta = textareaRef.current
-    if (ta) {
-      ta.style.height = 'auto'
-      ta.style.height = ta.scrollHeight + 'px'
-    }
-  }, [code])
+    /**
+     * Handles scroll synchronization between textarea and highlight layer.
+     */
+    const handleScroll = useCallback(() => {
+      const ta = textareaRef.current
+      const pre = preRef.current
+      if (ta && pre) {
+        pre.scrollTop = ta.scrollTop
+        pre.scrollLeft = ta.scrollLeft
+      }
+    }, [])
 
-  /**
-   * Handles scroll synchronization between textarea and highlight layer.
-   */
-  const handleScroll = useCallback(() => {
-    const ta = textareaRef.current
-    const pre = preRef.current
-    if (ta && pre) {
-      pre.scrollTop = ta.scrollTop
-      pre.scrollLeft = ta.scrollLeft
-    }
-  }, [])
+    /**
+     * Handles keyboard shortcuts for running code.
+     */
+    const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+      // Run code on Shift+Enter, Ctrl+Enter, or Meta+Enter
+      if ((e.shiftKey || e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+        e.preventDefault()
+        runnerRef.current?.run()
+      }
+    }, [])
 
-  /**
-   * Handles keyboard shortcuts for running code.
-   */
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    // Run code on Shift+Enter, Ctrl+Enter, or Meta+Enter
-    if ((e.shiftKey || e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-      e.preventDefault()
-      runnerRef.current?.run()
-    }
-  }, [])
-
-  return (
-    <div className="code-playground">
-      <div className="code-playground__toolbar">
-        <span className="code-playground__label">🐍 Python Playground</span>
-        <div className="code-playground__actions">
-          <CopyButton text={code} className="code-playground__btn" showEmoji={true} />
-          <button
-            className="code-playground__btn code-playground__btn--reset"
-            onClick={handleReset}
-            aria-label="Reset code to original"
-            title="Reset code to original"
-          >
-            ↺ Reset
-          </button>
+    return (
+      <div className="code-playground">
+        <div className="code-playground__toolbar">
+          <span className="code-playground__label">🐍 Python Playground</span>
+          <div className="code-playground__actions">
+            <CopyButton text={code} className="code-playground__btn" showEmoji={true} />
+            <button
+              className="code-playground__btn code-playground__btn--reset"
+              onClick={handleReset}
+              aria-label="Reset code to original"
+              title="Reset code to original"
+            >
+              ↺ Reset
+            </button>
+          </div>
         </div>
+
+        <div className="code-playground__editor-area">
+          <div className="code-playground__highlight" ref={preRef} aria-hidden="true">
+            <SyntaxHighlighter
+              style={highlightTheme}
+              language="python"
+              PreTag="div"
+              customStyle={{
+                margin: 0,
+                padding: '0.6rem 0.75rem',
+                background: 'transparent',
+                fontSize: '0.875rem',
+                lineHeight: '1.6',
+                fontFamily: 'var(--font-mono)',
+              }}
+              codeTagProps={{
+                style: { fontFamily: 'var(--font-mono)' },
+              }}
+            >
+              {code + '\n'}
+            </SyntaxHighlighter>
+          </div>
+          <textarea
+            ref={textareaRef}
+            className="code-playground__textarea"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            onScroll={handleScroll}
+            onKeyDown={handleKeyDown}
+            spellCheck={false}
+            aria-label="Python code editor. Press Shift+Enter to run."
+          />
+        </div>
+
+        <PythonRunner ref={runnerRef} code={code} />
+
+        {expectedOutput && (
+          <div className="code-playground__expected">
+            <div className="code-playground__expected-header">Expected Output</div>
+            <pre className="code-playground__expected-body">{expectedOutput}</pre>
+          </div>
+        )}
       </div>
-
-      <div className="code-playground__editor-area">
-        <div className="code-playground__highlight" ref={preRef} aria-hidden="true">
-          <SyntaxHighlighter
-            style={highlightTheme}
-            language="python"
-            PreTag="div"
-            customStyle={{
-              margin: 0,
-              padding: '0.6rem 0.75rem',
-              background: 'transparent',
-              fontSize: '0.875rem',
-              lineHeight: '1.6',
-              fontFamily: 'var(--font-mono)',
-            }}
-            codeTagProps={{
-              style: { fontFamily: 'var(--font-mono)' },
-            }}
-          >
-            {code + '\n'}
-          </SyntaxHighlighter>
-        </div>
-        <textarea
-          ref={textareaRef}
-          className="code-playground__textarea"
-          value={code}
-          onChange={(e) => setCode(e.target.value)}
-          onScroll={handleScroll}
-          onKeyDown={handleKeyDown}
-          spellCheck={false}
-          aria-label="Python code editor. Press Shift+Enter to run."
-        />
-      </div>
-
-      <PythonRunner ref={runnerRef} code={code} />
-
-      {expectedOutput && (
-        <div className="code-playground__expected">
-          <div className="code-playground__expected-header">Expected Output</div>
-          <pre className="code-playground__expected-body">{expectedOutput}</pre>
-        </div>
-      )}
-    </div>
-  )
-})
+    )
+  },
+)
 
 CodePlayground.displayName = 'CodePlayground'
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -59,8 +59,8 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
   }, [location.pathname, phases])
 
   const [manualOpen, setManualOpen] = useState<number | null>(null)
-  const dueByPhase = getReviewDueCountByPhase()
-  const reviewStreak = getReviewStreak()
+  const dueByPhase = useMemo(() => getReviewDueCountByPhase(), [])
+  const reviewStreak = useMemo(() => getReviewStreak(), [])
 
   /**
    * Determines currently open phase: manual toggle takes precedence over auto-derived.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import { useState, useMemo, useEffect, useRef } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { getAllPhases, getLessonsByPhase, phaseIcons } from '../utils/contentLoader'
 import { isLessonComplete, getCompletedForPhase } from '../utils/progressTracker'
+import { getReviewDueCountByPhase, getReviewStreak } from '../utils/reviewTracker'
 
 /**
  * Props for the Sidebar component.
@@ -58,6 +59,8 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
   }, [location.pathname, phases])
 
   const [manualOpen, setManualOpen] = useState<number | null>(null)
+  const dueByPhase = getReviewDueCountByPhase()
+  const reviewStreak = getReviewStreak()
 
   /**
    * Determines currently open phase: manual toggle takes precedence over auto-derived.
@@ -158,6 +161,18 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
             🧪 Exercises
           </Link>
 
+          <Link
+            to="/review"
+            className={`day-link ${location.pathname === '/review' ? 'active' : ''}`}
+            style={{ paddingLeft: '1.25rem', fontWeight: 600, marginBottom: '0.5rem' }}
+            onClick={onClose}
+          >
+            🧠 Review
+          </Link>
+          <div className="sidebar-review-stats">
+            <small>Review streak: {reviewStreak} day(s)</small>
+          </div>
+
           {phases.map((phase) => {
             const lessons = getLessonsByPhase(phase.phase)
             const isActive = openPhase === phase.phase
@@ -179,11 +194,9 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                   <span className="phase-toggle-label">
                     Phase {phase.phase}: {phase.title}
                   </span>
-                  {completedInPhase.length > 0 && (
-                    <span className="phase-toggle-progress">
-                      {completedInPhase.length}/{lessons.length}
-                    </span>
-                  )}
+                  <span className="phase-toggle-progress">
+                    {completedInPhase.length}/{lessons.length} · 🧠 {dueByPhase[phase.phase] || 0}
+                  </span>
                   <span className="phase-toggle-arrow">▶</span>
                 </button>
 

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -1,0 +1,86 @@
+import { useMemo, useState } from 'react'
+import { Helmet } from '@dr.pogodin/react-helmet'
+import Breadcrumb from '../components/Breadcrumb'
+import {
+  getDueReviewCards,
+  getReviewStreak,
+  rateReviewCard,
+  type ReviewCard,
+} from '../utils/reviewTracker'
+import type { ReviewRating } from '../utils/reviewScheduler'
+
+function getRatingLabel(rating: ReviewRating): string {
+  return rating.charAt(0).toUpperCase() + rating.slice(1)
+}
+
+export default function Review() {
+  const [now, setNow] = useState(() => new Date())
+  const [showAnswer, setShowAnswer] = useState(false)
+  const dueCards = useMemo(() => getDueReviewCards(now), [now])
+  const currentCard: ReviewCard | null = dueCards[0] || null
+  const streak = useMemo(() => getReviewStreak(now), [now])
+
+  const handleRate = (rating: ReviewRating) => {
+    if (!currentCard) return
+    rateReviewCard(currentCard.id, rating, new Date())
+    setShowAnswer(false)
+    setNow(new Date())
+  }
+
+  return (
+    <div className="page-container review-page">
+      <Helmet>
+        <title>Review — Coding for MBA</title>
+      </Helmet>
+
+      <Breadcrumb items={[{ label: 'Home', to: '/' }, { label: 'Review' }]} />
+
+      <div className="section-header" style={{ marginBottom: '1.5rem' }}>
+        <h2>Spaced Repetition Review</h2>
+        <p>
+          Due cards: {dueCards.length} · Streak: {streak} day(s)
+        </p>
+      </div>
+
+      {!currentCard ? (
+        <div className="progress-stats-card">
+          <p>No cards are due right now. Great job!</p>
+        </div>
+      ) : (
+        <div className="review-card">
+          <div className="review-card-meta">
+            <span>
+              Phase {currentCard.phase} · Day {currentCard.day}
+            </span>
+            <span>{currentCard.sourceType}</span>
+          </div>
+          <h3>{currentCard.prompt}</h3>
+          <p className="review-card-lesson">From: {currentCard.lessonTitle}</p>
+
+          {showAnswer ? (
+            <div className="review-answer">
+              <strong>Answer guide:</strong>
+              <p>{currentCard.answer}</p>
+            </div>
+          ) : (
+            <button className="review-answer-btn" onClick={() => setShowAnswer(true)}>
+              Show Answer
+            </button>
+          )}
+
+          <div className="review-actions">
+            {(['again', 'hard', 'good', 'easy'] as const).map((rating) => (
+              <button
+                key={rating}
+                className={`review-action-btn review-${rating}`}
+                onClick={() => handleRate(rating)}
+              >
+                {getRatingLabel(rating)}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -1,3 +1,14 @@
+/**
+ * Spaced Repetition Review Page
+ *
+ * This page provides a spaced repetition review system for reinforcing learning.
+ * It displays review cards that are due based on an SM-2-like scheduling algorithm,
+ * allows users to reveal answers, and rate their recall difficulty. The page also
+ * shows current review streak and total due cards count.
+ *
+ * @module pages/Review
+ */
+
 import { useMemo, useState } from 'react'
 import { Helmet } from '@dr.pogodin/react-helmet'
 import Breadcrumb from '../components/Breadcrumb'
@@ -13,6 +24,18 @@ function getRatingLabel(rating: ReviewRating): string {
   return rating.charAt(0).toUpperCase() + rating.slice(1)
 }
 
+/**
+ * Review page component for spaced repetition learning.
+ *
+ * Features:
+ * - Displays due review cards one at a time
+ * - Shows review streak and total due count
+ * - Allows users to reveal answers before rating
+ * - Provides four difficulty ratings: again, hard, good, easy
+ * - Automatically advances to next card after rating
+ *
+ * @returns The Review page component
+ */
 export default function Review() {
   const [now, setNow] = useState(() => new Date())
   const [showAnswer, setShowAnswer] = useState(false)
@@ -63,7 +86,7 @@ export default function Review() {
               <p>{currentCard.answer}</p>
             </div>
           ) : (
-            <button className="review-answer-btn" onClick={() => setShowAnswer(true)}>
+            <button type="button" className="review-answer-btn" onClick={() => setShowAnswer(true)}>
               Show Answer
             </button>
           )}
@@ -72,6 +95,7 @@ export default function Review() {
             {(['again', 'hard', 'good', 'easy'] as const).map((rating) => (
               <button
                 key={rating}
+                type="button"
                 className={`review-action-btn review-${rating}`}
                 onClick={() => handleRate(rating)}
               >

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -12,6 +12,7 @@
 @import './markdown.css';
 @import './interactive.css';
 @import './exercises.css';
+@import './review.css';
 @import './navigation.css';
 @import './responsive.css';
 @import './content-features.css';

--- a/src/styles/review.css
+++ b/src/styles/review.css
@@ -1,0 +1,54 @@
+.review-page .review-card {
+  background: var(--surface-elevated, #fff);
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 12px;
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.review-card-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: var(--text-secondary, #6b7280);
+}
+
+.review-answer {
+  background: var(--surface-subtle, #f9fafb);
+  border-radius: 10px;
+  padding: 0.75rem;
+}
+
+.review-answer-btn,
+.review-action-btn {
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 8px;
+  padding: 0.55rem 0.8rem;
+  font-weight: 600;
+  background: var(--surface-elevated, #fff);
+}
+
+.review-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.review-again {
+  border-color: #ef4444;
+}
+.review-hard {
+  border-color: #f59e0b;
+}
+.review-good {
+  border-color: #10b981;
+}
+.review-easy {
+  border-color: #3b82f6;
+}
+
+.sidebar-review-stats {
+  padding: 0 1.25rem 0.75rem;
+  color: var(--text-secondary, #6b7280);
+}

--- a/src/utils/__tests__/contentLoader.test.ts
+++ b/src/utils/__tests__/contentLoader.test.ts
@@ -2,6 +2,7 @@ import {
   getAdjacentLessons,
   getAllExercises,
   getAllLessons,
+  getAllReviewCardSeeds,
   getAllNotebooks,
   getAllPhases,
   getLesson,
@@ -129,6 +130,17 @@ test words repeated `.repeat(120)
     const freshLessons = getAllLessons()
     expect(freshLessons.length).toBe(baselineLessons.length)
     expect(freshLessons[0]?.title).toBe(baselineFirst?.title)
+  })
+
+  it('generates deterministic review card seeds from concepts/headings/exercises', () => {
+    const cards = getAllReviewCardSeeds()
+    expect(cards.length).toBeGreaterThan(100)
+    expect(cards.every((card) => typeof card.id === 'string' && card.id.length > 0)).toBe(true)
+    const unique = new Set(cards.map((card) => card.id))
+    expect(unique.size).toBe(cards.length)
+    expect(cards.some((card) => card.sourceType === 'heading')).toBe(true)
+    expect(cards.some((card) => card.sourceType === 'exercise')).toBe(true)
+    expect(cards.some((card) => card.sourceType === 'concept')).toBe(true)
   })
 
   it('prevents nested collection mutation from changing source exercise data', () => {

--- a/src/utils/__tests__/reviewScheduler.test.ts
+++ b/src/utils/__tests__/reviewScheduler.test.ts
@@ -1,0 +1,45 @@
+import { createInitialSchedulingState, isCardDue, scheduleReview } from '../reviewScheduler'
+
+describe('reviewScheduler', () => {
+  it('creates deterministic initial state', () => {
+    const now = new Date('2025-01-01T00:00:00.000Z')
+    const state = createInitialSchedulingState(now)
+
+    expect(state.repetitions).toBe(0)
+    expect(state.intervalDays).toBe(0)
+    expect(state.easeFactor).toBe(2.5)
+    expect(state.dueAt).toBe(now.toISOString())
+  })
+
+  it('applies SM-2 style intervals based on ratings', () => {
+    const now = new Date('2025-01-01T00:00:00.000Z')
+    const initial = createInitialSchedulingState(now)
+
+    const good = scheduleReview(initial, 'good', now)
+    expect(good.intervalDays).toBe(1)
+
+    const goodAgain = scheduleReview(good, 'good', new Date('2025-01-02T00:00:00.000Z'))
+    expect(goodAgain.intervalDays).toBe(3)
+
+    const easy = scheduleReview(goodAgain, 'easy', new Date('2025-01-05T00:00:00.000Z'))
+    expect(easy.intervalDays).toBeGreaterThanOrEqual(4)
+    expect(easy.easeFactor).toBeGreaterThan(goodAgain.easeFactor)
+  })
+
+  it('resets repetitions on again and never drops ease below minimum', () => {
+    const now = new Date('2025-01-01T00:00:00.000Z')
+    let state = createInitialSchedulingState(now)
+
+    for (let i = 0; i < 20; i += 1) {
+      state = scheduleReview(state, 'again', now)
+    }
+
+    expect(state.repetitions).toBe(0)
+    expect(state.easeFactor).toBe(1.3)
+  })
+
+  it('determines card due status correctly', () => {
+    expect(isCardDue('2025-01-01T00:00:00.000Z', new Date('2025-01-02T00:00:00.000Z'))).toBe(true)
+    expect(isCardDue('2025-01-03T00:00:00.000Z', new Date('2025-01-02T00:00:00.000Z'))).toBe(false)
+  })
+})

--- a/src/utils/__tests__/reviewTracker.test.ts
+++ b/src/utils/__tests__/reviewTracker.test.ts
@@ -1,0 +1,61 @@
+import {
+  clearReviewState,
+  getDueReviewCards,
+  getReviewCards,
+  rateReviewCard,
+  reviewStorageKey,
+} from '../reviewTracker'
+
+describe('reviewTracker', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    clearReviewState()
+  })
+
+  it('initializes all generated cards with default schedule', () => {
+    const cards = getReviewCards(new Date('2025-01-01T00:00:00.000Z'))
+    expect(cards.length).toBeGreaterThan(100)
+    expect(cards.every((card) => card.state.repetitions === 0)).toBe(true)
+  })
+
+  it('updates card schedule and due filtering after rating', () => {
+    const now = new Date('2025-01-01T00:00:00.000Z')
+    const [first] = getReviewCards(now)
+    expect(first).toBeDefined()
+
+    rateReviewCard(first!.id, 'easy', now)
+    const dueAfter = getDueReviewCards(new Date('2025-01-02T00:00:00.000Z'))
+
+    expect(dueAfter.some((card) => card.id === first!.id)).toBe(false)
+  })
+
+  it('migrates legacy v1 object schema into versioned schema', () => {
+    localStorage.setItem(
+      reviewStorageKey,
+      JSON.stringify({
+        'legacy-card': {
+          repetitions: 2,
+          intervalDays: 5,
+          easeFactor: 2.3,
+          dueAt: '2025-01-01T00:00:00.000Z',
+          lastReviewedAt: '2024-12-28T00:00:00.000Z',
+        },
+      }),
+    )
+
+    getReviewCards(new Date('2025-01-02T00:00:00.000Z'))
+    const persisted = JSON.parse(localStorage.getItem(reviewStorageKey) || '{}') as {
+      version?: number
+      cards?: unknown[]
+    }
+
+    expect(persisted.version).toBe(2)
+    expect(Array.isArray(persisted.cards)).toBe(true)
+  })
+
+  it('drops invalid schema payloads safely', () => {
+    localStorage.setItem(reviewStorageKey, JSON.stringify({ version: 2, cards: [{ bad: true }] }))
+    const cards = getReviewCards()
+    expect(cards.length).toBeGreaterThan(0)
+  })
+})

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -125,6 +125,16 @@ export interface Exercise {
   tags: readonly string[]
 }
 
+export interface ReviewCardSeed {
+  id: string
+  day: number
+  phase: number
+  lessonTitle: string
+  sourceType: 'concept' | 'heading' | 'exercise'
+  prompt: string
+  answer: string
+}
+
 /** Parse exercise sections from a lesson markdown body. */
 function extractExercisesFromLesson(lesson: Lesson): Exercise[] {
   const exercises: Exercise[] = []
@@ -160,10 +170,77 @@ function extractExercisesFromLesson(lesson: Lesson): Exercise[] {
   return exercises
 }
 
+function normalizeIdPart(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .trim()
+    .replace(/\s+/g, '-')
+}
+
+function extractHeadingsFromLessonContent(content: string): string[] {
+  const headingRegex = /^###?\s+(.+)$/gm
+  const headings = new Set<string>()
+  let match
+  while ((match = headingRegex.exec(content)) !== null) {
+    const headingText = match[1]
+    if (!headingText) continue
+    const cleaned = headingText.trim()
+    if (cleaned) headings.add(cleaned)
+  }
+  return [...headings]
+}
+
+function buildReviewCardsFromLesson(lesson: Lesson): ReviewCardSeed[] {
+  const cards: ReviewCardSeed[] = []
+  const concepts = lesson.concepts || []
+  const headings = extractHeadingsFromLessonContent(lesson.content)
+  const exercises = extractExercisesFromLesson(lesson)
+
+  concepts.forEach((concept) => {
+    cards.push({
+      id: `d${lesson.day}-concept-${normalizeIdPart(concept)}`,
+      day: lesson.day,
+      phase: lesson.phase,
+      lessonTitle: lesson.title,
+      sourceType: 'concept',
+      prompt: `Explain this concept from Day ${lesson.day}: ${concept}`,
+      answer: `Concept from Day ${lesson.day} (${lesson.title}): ${concept}`,
+    })
+  })
+
+  headings.forEach((heading) => {
+    cards.push({
+      id: `d${lesson.day}-heading-${normalizeIdPart(heading)}`,
+      day: lesson.day,
+      phase: lesson.phase,
+      lessonTitle: lesson.title,
+      sourceType: 'heading',
+      prompt: `What is the key idea in this section: ${heading}?`,
+      answer: `Review section “${heading}” in Day ${lesson.day} (${lesson.title}).`,
+    })
+  })
+
+  exercises.forEach((exercise, index) => {
+    cards.push({
+      id: `d${lesson.day}-exercise-${index + 1}-${normalizeIdPart(exercise.title)}`,
+      day: lesson.day,
+      phase: lesson.phase,
+      lessonTitle: lesson.title,
+      sourceType: 'exercise',
+      prompt: `How would you solve exercise: ${exercise.title}?`,
+      answer: exercise.goal || `Practice solving: ${exercise.title}`,
+    })
+  })
+
+  return cards
+}
+
 const immutableLessons = Object.freeze(lessons.map(freezeLesson))
 const immutablePhases = Object.freeze(phases.map(freezePhase))
 
 let immutableExercises: readonly ImmutableExercise[] | null = null
+let immutableReviewCards: readonly ImmutableReviewCardSeed[] | null = null
 
 /** Return all parsed exercises across lessons. */
 export function getAllExercises(): readonly ImmutableExercise[] {
@@ -172,6 +249,14 @@ export function getAllExercises(): readonly ImmutableExercise[] {
     immutableExercises = Object.freeze(allExercises.map(freezeExercise))
   }
   return immutableExercises
+}
+
+export function getAllReviewCardSeeds(): readonly ImmutableReviewCardSeed[] {
+  if (!immutableReviewCards) {
+    const cards = lessons.flatMap(buildReviewCardsFromLesson)
+    immutableReviewCards = Object.freeze(cards.map(freezeReviewCardSeed))
+  }
+  return immutableReviewCards
 }
 
 /** Jupyter notebook cell shape used by imported phase notebooks. */
@@ -198,6 +283,7 @@ export interface Notebook {
 type ImmutableLesson = Readonly<Lesson>
 type ImmutablePhase = Readonly<Phase>
 type ImmutableExercise = Readonly<Exercise>
+type ImmutableReviewCardSeed = Readonly<ReviewCardSeed>
 type ImmutableNotebookCell = Readonly<NotebookCell>
 type ImmutableNotebook = Readonly<Notebook>
 
@@ -230,6 +316,10 @@ function freezeExercise(exercise: Exercise): ImmutableExercise {
     ...exercise,
     tags: Object.freeze([...exercise.tags]),
   })
+}
+
+function freezeReviewCardSeed(card: ReviewCardSeed): ImmutableReviewCardSeed {
+  return Object.freeze({ ...card })
 }
 
 function freezeNotebookCell(cell: NotebookCell): ImmutableNotebookCell {

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -186,7 +186,10 @@ function extractHeadingsFromLessonContent(content: string): string[] {
     const headingText = match[1]
     if (!headingText) continue
     const cleaned = headingText.trim()
-    if (cleaned) headings.add(cleaned)
+    if (!cleaned) continue
+    // Skip exercise headings like "Exercise 1: Title" since exercises are handled separately
+    if (/^Exercise\s+\d+/i.test(cleaned)) continue
+    headings.add(cleaned)
   }
   return [...headings]
 }
@@ -196,10 +199,24 @@ function buildReviewCardsFromLesson(lesson: Lesson): ReviewCardSeed[] {
   const concepts = lesson.concepts || []
   const headings = extractHeadingsFromLessonContent(lesson.content)
   const exercises = extractExercisesFromLesson(lesson)
+  const seenIds = new Set<string>()
+
+  const createUniqueId = (baseId: string): string => {
+    let uniqueId = baseId
+    let counter = 1
+    while (seenIds.has(uniqueId)) {
+      // Append counter to disambiguate collisions
+      uniqueId = `${baseId}-${counter}`
+      counter += 1
+    }
+    seenIds.add(uniqueId)
+    return uniqueId
+  }
 
   concepts.forEach((concept) => {
+    const baseId = `d${lesson.day}-concept-${normalizeIdPart(concept)}`
     cards.push({
-      id: `d${lesson.day}-concept-${normalizeIdPart(concept)}`,
+      id: createUniqueId(baseId),
       day: lesson.day,
       phase: lesson.phase,
       lessonTitle: lesson.title,
@@ -210,8 +227,9 @@ function buildReviewCardsFromLesson(lesson: Lesson): ReviewCardSeed[] {
   })
 
   headings.forEach((heading) => {
+    const baseId = `d${lesson.day}-heading-${normalizeIdPart(heading)}`
     cards.push({
-      id: `d${lesson.day}-heading-${normalizeIdPart(heading)}`,
+      id: createUniqueId(baseId),
       day: lesson.day,
       phase: lesson.phase,
       lessonTitle: lesson.title,
@@ -222,8 +240,9 @@ function buildReviewCardsFromLesson(lesson: Lesson): ReviewCardSeed[] {
   })
 
   exercises.forEach((exercise, index) => {
+    const baseId = `d${lesson.day}-exercise-${index + 1}-${normalizeIdPart(exercise.title)}`
     cards.push({
-      id: `d${lesson.day}-exercise-${index + 1}-${normalizeIdPart(exercise.title)}`,
+      id: createUniqueId(baseId),
       day: lesson.day,
       phase: lesson.phase,
       lessonTitle: lesson.title,

--- a/src/utils/reviewScheduler.ts
+++ b/src/utils/reviewScheduler.ts
@@ -1,25 +1,60 @@
+/**
+ * Review Scheduler Module
+ *
+ * Implements an SM-2-like spaced repetition scheduling algorithm for review cards.
+ * Manages scheduling state including repetition count, interval days, ease factor,
+ * and due dates based on user ratings of recall difficulty.
+ */
+
 export type ReviewRating = 'again' | 'hard' | 'good' | 'easy'
 
+/**
+ * Represents the scheduling state for a single review card.
+ */
 export interface SchedulingState {
+  /** Number of successful repetitions */
   repetitions: number
+  /** Current interval in days between reviews */
   intervalDays: number
+  /** Ease factor multiplier for interval calculation (SM-2 algorithm) */
   easeFactor: number
+  /** ISO timestamp when card is next due for review */
   dueAt: string
+  /** ISO timestamp of last review, or null if never reviewed */
   lastReviewedAt: string | null
 }
 
 const MIN_EASE = 1.3
 
+/**
+ * Clamps ease factor to minimum allowed value.
+ *
+ * @param value - The ease factor value to clamp
+ * @returns Clamped ease factor, minimum 1.3
+ */
 function clampEase(value: number): number {
   return Math.max(MIN_EASE, Number(value.toFixed(2)))
 }
 
+/**
+ * Adds specified number of days to a base date and returns ISO string.
+ *
+ * @param baseDate - The starting date
+ * @param days - Number of days to add (minimum 1)
+ * @returns ISO timestamp string of the future date
+ */
 function addDays(baseDate: Date, days: number): string {
   const next = new Date(baseDate)
   next.setDate(next.getDate() + Math.max(1, Math.round(days)))
   return next.toISOString()
 }
 
+/**
+ * Creates initial scheduling state for a new review card.
+ *
+ * @param now - Current date/time (defaults to now)
+ * @returns Initial scheduling state with default values
+ */
 export function createInitialSchedulingState(now = new Date()): SchedulingState {
   return {
     repetitions: 0,
@@ -30,6 +65,20 @@ export function createInitialSchedulingState(now = new Date()): SchedulingState 
   }
 }
 
+/**
+ * Schedules the next review for a card based on user rating.
+ *
+ * Implements SM-2-like algorithm with four difficulty levels:
+ * - again: Reset to 1 day, decrease ease factor
+ * - hard: Small interval increase, slight ease decrease
+ * - good: Standard SM-2 intervals (1, 3, then ease-multiplied)
+ * - easy: Larger intervals, increase ease factor
+ *
+ * @param current - Current scheduling state
+ * @param rating - User's difficulty rating for the recall
+ * @param now - Current date/time (defaults to now)
+ * @returns Updated scheduling state with new due date
+ */
 export function scheduleReview(
   current: SchedulingState,
   rating: ReviewRating,
@@ -93,6 +142,13 @@ export function scheduleReview(
   }
 }
 
+/**
+ * Checks if a review card is currently due.
+ *
+ * @param dueAt - ISO timestamp string of when card is due
+ * @param now - Current date/time (defaults to now)
+ * @returns True if the card is due for review
+ */
 export function isCardDue(dueAt: string, now = new Date()): boolean {
   return new Date(dueAt).getTime() <= now.getTime()
 }

--- a/src/utils/reviewScheduler.ts
+++ b/src/utils/reviewScheduler.ts
@@ -1,0 +1,98 @@
+export type ReviewRating = 'again' | 'hard' | 'good' | 'easy'
+
+export interface SchedulingState {
+  repetitions: number
+  intervalDays: number
+  easeFactor: number
+  dueAt: string
+  lastReviewedAt: string | null
+}
+
+const MIN_EASE = 1.3
+
+function clampEase(value: number): number {
+  return Math.max(MIN_EASE, Number(value.toFixed(2)))
+}
+
+function addDays(baseDate: Date, days: number): string {
+  const next = new Date(baseDate)
+  next.setDate(next.getDate() + Math.max(1, Math.round(days)))
+  return next.toISOString()
+}
+
+export function createInitialSchedulingState(now = new Date()): SchedulingState {
+  return {
+    repetitions: 0,
+    intervalDays: 0,
+    easeFactor: 2.5,
+    dueAt: now.toISOString(),
+    lastReviewedAt: null,
+  }
+}
+
+export function scheduleReview(
+  current: SchedulingState,
+  rating: ReviewRating,
+  now = new Date(),
+): SchedulingState {
+  const state = { ...current }
+
+  if (rating === 'again') {
+    return {
+      ...state,
+      repetitions: 0,
+      intervalDays: 1,
+      easeFactor: clampEase(state.easeFactor - 0.2),
+      dueAt: addDays(now, 1),
+      lastReviewedAt: now.toISOString(),
+    }
+  }
+
+  if (rating === 'hard') {
+    const interval = state.repetitions <= 1 ? 2 : Math.max(2, Math.round(state.intervalDays * 1.2))
+    return {
+      ...state,
+      repetitions: state.repetitions + 1,
+      intervalDays: interval,
+      easeFactor: clampEase(state.easeFactor - 0.15),
+      dueAt: addDays(now, interval),
+      lastReviewedAt: now.toISOString(),
+    }
+  }
+
+  if (rating === 'good') {
+    const interval =
+      state.repetitions === 0
+        ? 1
+        : state.repetitions === 1
+          ? 3
+          : Math.max(3, Math.round(state.intervalDays * state.easeFactor))
+
+    return {
+      ...state,
+      repetitions: state.repetitions + 1,
+      intervalDays: interval,
+      easeFactor: clampEase(state.easeFactor),
+      dueAt: addDays(now, interval),
+      lastReviewedAt: now.toISOString(),
+    }
+  }
+
+  const interval =
+    state.repetitions <= 1
+      ? 4
+      : Math.max(4, Math.round(state.intervalDays * (state.easeFactor + 0.3)))
+
+  return {
+    ...state,
+    repetitions: state.repetitions + 1,
+    intervalDays: interval,
+    easeFactor: clampEase(state.easeFactor + 0.15),
+    dueAt: addDays(now, interval),
+    lastReviewedAt: now.toISOString(),
+  }
+}
+
+export function isCardDue(dueAt: string, now = new Date()): boolean {
+  return new Date(dueAt).getTime() <= now.getTime()
+}

--- a/src/utils/reviewTracker.ts
+++ b/src/utils/reviewTracker.ts
@@ -1,3 +1,12 @@
+/**
+ * Review Tracker Module
+ *
+ * Manages persistent storage and state tracking for spaced repetition review cards.
+ * Handles localStorage persistence with versioned schema, migration from legacy formats,
+ * in-memory caching, and provides APIs for querying due cards, rating cards, computing
+ * statistics, and managing review state.
+ */
+
 import { getAllReviewCardSeeds } from './contentLoader'
 import { getStoredJson, removeStoredValue, setStoredString } from './safeStorage'
 import {
@@ -10,20 +19,32 @@ import {
 
 const REVIEW_STORAGE_KEY = 'coding-for-mba-review-state'
 
+/**
+ * Stored review card entry with ID and scheduling state.
+ */
 interface StoredReviewCard {
   id: string
   state: SchedulingState
 }
 
+/**
+ * Current review state schema (version 2).
+ */
 interface ReviewStateV2 {
   version: 2
   cards: StoredReviewCard[]
 }
 
+/**
+ * Legacy review state schema (version 1) for migration.
+ */
 interface LegacyReviewStateV1 {
   [cardId: string]: SchedulingState
 }
 
+/**
+ * Full review card data including seed metadata and scheduling state.
+ */
 export interface ReviewCard extends StoredReviewCard {
   day: number
   phase: number
@@ -35,6 +56,22 @@ export interface ReviewCard extends StoredReviewCard {
 
 let reviewStateCache: Map<string, SchedulingState> | null = null
 
+// Invalidate cache when storage is updated in another tab
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+  window.addEventListener('storage', (event: StorageEvent) => {
+    if (event.storageArea !== window.localStorage) return
+    if (event.key === null || event.key === REVIEW_STORAGE_KEY) {
+      reviewStateCache = null
+    }
+  })
+}
+
+/**
+ * Type guard to validate if a value is a valid SchedulingState.
+ *
+ * @param value - Value to check
+ * @returns True if value is a valid SchedulingState
+ */
 function isSchedulingState(value: unknown): value is SchedulingState {
   if (!value || typeof value !== 'object') return false
   const state = value as Record<string, unknown>
@@ -47,6 +84,12 @@ function isSchedulingState(value: unknown): value is SchedulingState {
   )
 }
 
+/**
+ * Type guard to validate if a value is a valid ReviewStateV2.
+ *
+ * @param value - Value to check
+ * @returns True if value is a valid ReviewStateV2
+ */
 function isReviewStateV2(value: unknown): value is ReviewStateV2 {
   if (!value || typeof value !== 'object') return false
   const payload = value as Record<string, unknown>
@@ -58,6 +101,12 @@ function isReviewStateV2(value: unknown): value is ReviewStateV2 {
   })
 }
 
+/**
+ * Migrates legacy v1 state format to current Map structure.
+ *
+ * @param value - Potential legacy state object
+ * @returns Map of card IDs to scheduling states
+ */
 function migrateLegacyState(value: unknown): Map<string, SchedulingState> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return new Map()
   const records = Object.entries(value as LegacyReviewStateV1).filter((entry) =>
@@ -66,6 +115,11 @@ function migrateLegacyState(value: unknown): Map<string, SchedulingState> {
   return new Map(records as Array<[string, SchedulingState]>)
 }
 
+/**
+ * Loads review state from cache or localStorage.
+ *
+ * @returns Map of card IDs to scheduling states
+ */
 function loadReviewState(): Map<string, SchedulingState> {
   if (reviewStateCache) return reviewStateCache
 
@@ -78,6 +132,11 @@ function loadReviewState(): Map<string, SchedulingState> {
   return reviewStateCache
 }
 
+/**
+ * Persists review state to localStorage and updates cache.
+ *
+ * @param state - Map of card IDs to scheduling states
+ */
 function persistReviewState(state: Map<string, SchedulingState>): void {
   const payload: ReviewStateV2 = {
     version: 2,
@@ -87,6 +146,12 @@ function persistReviewState(state: Map<string, SchedulingState>): void {
   setStoredString(REVIEW_STORAGE_KEY, JSON.stringify(payload))
 }
 
+/**
+ * Retrieves all review cards with their current scheduling state.
+ *
+ * @param now - Current date/time (defaults to now)
+ * @returns Array of all review cards
+ */
 export function getReviewCards(now = new Date()): ReviewCard[] {
   const stored = loadReviewState()
   const seeds = getAllReviewCardSeeds()
@@ -97,10 +162,24 @@ export function getReviewCards(now = new Date()): ReviewCard[] {
   }))
 }
 
+/**
+ * Retrieves review cards that are currently due for review.
+ *
+ * @param now - Current date/time (defaults to now)
+ * @returns Array of due review cards
+ */
 export function getDueReviewCards(now = new Date()): ReviewCard[] {
   return getReviewCards(now).filter((card) => isCardDue(card.state.dueAt, now))
 }
 
+/**
+ * Records a user rating for a review card and updates its scheduling state.
+ *
+ * @param cardId - Unique identifier for the review card
+ * @param rating - User's difficulty rating (again, hard, good, easy)
+ * @param now - Current date/time (defaults to now)
+ * @returns Updated scheduling state for the card
+ */
 export function rateReviewCard(
   cardId: string,
   rating: ReviewRating,
@@ -114,6 +193,12 @@ export function rateReviewCard(
   return updated
 }
 
+/**
+ * Counts due review cards grouped by phase number.
+ *
+ * @param now - Current date/time (defaults to now)
+ * @returns Object mapping phase numbers to count of due cards
+ */
 export function getReviewDueCountByPhase(now = new Date()): Record<number, number> {
   const counts: Record<number, number> = {}
   getDueReviewCards(now).forEach((card) => {
@@ -122,18 +207,33 @@ export function getReviewDueCountByPhase(now = new Date()): Record<number, numbe
   return counts
 }
 
+/**
+ * Computes the current review streak (consecutive days with reviews).
+ * Uses local date calculations to avoid timezone issues.
+ *
+ * @param now - Current date/time (defaults to now)
+ * @returns Number of consecutive days with completed reviews
+ */
 export function getReviewStreak(now = new Date()): number {
+  // Helper to format date as YYYY-MM-DD in local timezone
+  const formatLocalDate = (date: Date): string => {
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+    return `${year}-${month}-${day}`
+  }
+
   const reviewedDates = new Set(
     getReviewCards(now)
       .map((card) => card.state.lastReviewedAt)
       .filter((value): value is string => Boolean(value))
-      .map((value) => value.slice(0, 10)),
+      .map((value) => formatLocalDate(new Date(value))),
   )
 
   let streak = 0
   const cursor = new Date(now)
   while (true) {
-    const dayKey = cursor.toISOString().slice(0, 10)
+    const dayKey = formatLocalDate(cursor)
     if (!reviewedDates.has(dayKey)) break
     streak += 1
     cursor.setDate(cursor.getDate() - 1)
@@ -141,6 +241,9 @@ export function getReviewStreak(now = new Date()): number {
   return streak
 }
 
+/**
+ * Clears all review state from localStorage and cache.
+ */
 export function clearReviewState(): void {
   reviewStateCache = null
   removeStoredValue(REVIEW_STORAGE_KEY)

--- a/src/utils/reviewTracker.ts
+++ b/src/utils/reviewTracker.ts
@@ -1,0 +1,149 @@
+import { getAllReviewCardSeeds } from './contentLoader'
+import { getStoredJson, removeStoredValue, setStoredString } from './safeStorage'
+import {
+  createInitialSchedulingState,
+  isCardDue,
+  scheduleReview,
+  type ReviewRating,
+  type SchedulingState,
+} from './reviewScheduler'
+
+const REVIEW_STORAGE_KEY = 'coding-for-mba-review-state'
+
+interface StoredReviewCard {
+  id: string
+  state: SchedulingState
+}
+
+interface ReviewStateV2 {
+  version: 2
+  cards: StoredReviewCard[]
+}
+
+interface LegacyReviewStateV1 {
+  [cardId: string]: SchedulingState
+}
+
+export interface ReviewCard extends StoredReviewCard {
+  day: number
+  phase: number
+  lessonTitle: string
+  sourceType: 'concept' | 'heading' | 'exercise'
+  prompt: string
+  answer: string
+}
+
+let reviewStateCache: Map<string, SchedulingState> | null = null
+
+function isSchedulingState(value: unknown): value is SchedulingState {
+  if (!value || typeof value !== 'object') return false
+  const state = value as Record<string, unknown>
+  return (
+    typeof state.repetitions === 'number' &&
+    typeof state.intervalDays === 'number' &&
+    typeof state.easeFactor === 'number' &&
+    typeof state.dueAt === 'string' &&
+    (typeof state.lastReviewedAt === 'string' || state.lastReviewedAt === null)
+  )
+}
+
+function isReviewStateV2(value: unknown): value is ReviewStateV2 {
+  if (!value || typeof value !== 'object') return false
+  const payload = value as Record<string, unknown>
+  if (payload.version !== 2 || !Array.isArray(payload.cards)) return false
+  return payload.cards.every((entry) => {
+    if (!entry || typeof entry !== 'object') return false
+    const card = entry as Record<string, unknown>
+    return typeof card.id === 'string' && isSchedulingState(card.state)
+  })
+}
+
+function migrateLegacyState(value: unknown): Map<string, SchedulingState> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return new Map()
+  const records = Object.entries(value as LegacyReviewStateV1).filter((entry) =>
+    isSchedulingState(entry[1]),
+  )
+  return new Map(records as Array<[string, SchedulingState]>)
+}
+
+function loadReviewState(): Map<string, SchedulingState> {
+  if (reviewStateCache) return reviewStateCache
+
+  const parsed = getStoredJson<unknown>(REVIEW_STORAGE_KEY, {})
+  reviewStateCache = isReviewStateV2(parsed)
+    ? new Map(parsed.cards.map((card) => [card.id, card.state]))
+    : migrateLegacyState(parsed)
+
+  persistReviewState(reviewStateCache)
+  return reviewStateCache
+}
+
+function persistReviewState(state: Map<string, SchedulingState>): void {
+  const payload: ReviewStateV2 = {
+    version: 2,
+    cards: [...state.entries()].map(([id, cardState]) => ({ id, state: cardState })),
+  }
+  reviewStateCache = state
+  setStoredString(REVIEW_STORAGE_KEY, JSON.stringify(payload))
+}
+
+export function getReviewCards(now = new Date()): ReviewCard[] {
+  const stored = loadReviewState()
+  const seeds = getAllReviewCardSeeds()
+
+  return seeds.map((seed) => ({
+    ...seed,
+    state: stored.get(seed.id) || createInitialSchedulingState(now),
+  }))
+}
+
+export function getDueReviewCards(now = new Date()): ReviewCard[] {
+  return getReviewCards(now).filter((card) => isCardDue(card.state.dueAt, now))
+}
+
+export function rateReviewCard(
+  cardId: string,
+  rating: ReviewRating,
+  now = new Date(),
+): SchedulingState {
+  const current = loadReviewState()
+  const existing = current.get(cardId) || createInitialSchedulingState(now)
+  const updated = scheduleReview(existing, rating, now)
+  current.set(cardId, updated)
+  persistReviewState(current)
+  return updated
+}
+
+export function getReviewDueCountByPhase(now = new Date()): Record<number, number> {
+  const counts: Record<number, number> = {}
+  getDueReviewCards(now).forEach((card) => {
+    counts[card.phase] = (counts[card.phase] || 0) + 1
+  })
+  return counts
+}
+
+export function getReviewStreak(now = new Date()): number {
+  const reviewedDates = new Set(
+    getReviewCards(now)
+      .map((card) => card.state.lastReviewedAt)
+      .filter((value): value is string => Boolean(value))
+      .map((value) => value.slice(0, 10)),
+  )
+
+  let streak = 0
+  const cursor = new Date(now)
+  while (true) {
+    const dayKey = cursor.toISOString().slice(0, 10)
+    if (!reviewedDates.has(dayKey)) break
+    streak += 1
+    cursor.setDate(cursor.getDate() - 1)
+  }
+  return streak
+}
+
+export function clearReviewState(): void {
+  reviewStateCache = null
+  removeStoredValue(REVIEW_STORAGE_KEY)
+}
+
+export const reviewStorageKey = REVIEW_STORAGE_KEY

--- a/src/utils/reviewTracker.ts
+++ b/src/utils/reviewTracker.ts
@@ -216,7 +216,7 @@ export function getReviewDueCountByPhase(now = new Date()): Record<number, numbe
  */
 export function getReviewStreak(now = new Date()): number {
   // Helper to format date as YYYY-MM-DD in local timezone
-  const formatLocalDate = (date: Date): string => {
+  const toLocalDateString = (date: Date): string => {
     const year = date.getFullYear()
     const month = String(date.getMonth() + 1).padStart(2, '0')
     const day = String(date.getDate()).padStart(2, '0')
@@ -227,13 +227,13 @@ export function getReviewStreak(now = new Date()): number {
     getReviewCards(now)
       .map((card) => card.state.lastReviewedAt)
       .filter((value): value is string => Boolean(value))
-      .map((value) => formatLocalDate(new Date(value))),
+      .map((value) => toLocalDateString(new Date(value))),
   )
 
   let streak = 0
   const cursor = new Date(now)
   while (true) {
-    const dayKey = formatLocalDate(cursor)
+    const dayKey = toLocalDateString(cursor)
     if (!reviewedDates.has(dayKey)) break
     streak += 1
     cursor.setDate(cursor.getDate() - 1)


### PR DESCRIPTION
### Motivation

- Provide a lightweight spaced-repetition review system so lessons surface repeatable “review cards” for retention. 
- Generate cards deterministically from existing lesson sources (frontmatter concepts, H2/H3 headings, and exercises) to map review state to stable IDs. 
- Keep scheduling and storage purely client-side and integrate with existing safeStorage/progressTracker patterns without altering current progress behavior. 
- Ship tests and a small developer doc to make generation and migration rules explicit.

### Description

- Added deterministic card seed generation in `contentLoader.ts` producing `ReviewCardSeed` from frontmatter `concepts`, H2/H3 headings, and extracted exercise blocks, with stable `d{day}-{type}-{slug}` IDs and frozen outputs. (new API `getAllReviewCardSeeds`).
- Implemented an SM-2-like scheduler in `src/utils/reviewScheduler.ts` with ratings `again|hard|good|easy`, ease clamping, interval computation, and `isCardDue` helper.
- Implemented review state management in `src/utils/reviewTracker.ts` that persists a versioned schema to localStorage, includes v1->v2 migration, in-memory cache, due-card filtering, per-phase due counts, streak computation, and safe access via existing `safeStorage` helpers.
- Added a `/review` page (`src/pages/Review.tsx`) that shows due cards, revealable answer guidance, and rating buttons wired to the scheduler; added review UI styles (`src/styles/review.css`) and imported into global styles.
- Updated `Sidebar.tsx` and `App.tsx` to expose the Review page, show streak stats and per-phase due counts; left existing progress tracking APIs intact.
- Added developer documentation `docs/review-cards.md` explaining generation rules and determinism.
- Added unit tests for scheduler logic and storage behavior and added review-seed assertions to content loader tests (`src/utils/__tests__/reviewScheduler.test.ts`, `src/utils/__tests__/reviewTracker.test.ts`, updated `contentLoader.test.ts`).

### Testing

- Ran the full test suite with `npm test` and all tests passed (17 test files, 86 tests). 
- Ran type checking with `npm run typecheck` which succeeded. 
- Ran lint/format checks via `npm run lint` which succeeded after formatting fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994216289bc83308ffe0df1414b8cc2)