### PR TITLE
🎨 Palette: Improve Python Runner accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2026-02-24 - Explicit Action Labels
 **Learning:** Relying solely on keyboard shortcuts (like "Shift+Enter") as button labels obscures the primary action ("Run") for users who scan visually or don't know the shortcut.
 **Action:** Always pair keyboard shortcuts with explicit text labels and icons for primary actions to ensure discoverability and clarity.
+
+## 2026-02-25 - Dynamic State in Disabled Controls
+**Learning:** Disabled controls (like a "Run" button during execution) often retain their static `aria-label`, failing to communicate critical state changes (e.g., "Loading" vs "Running") to screen reader users.
+**Action:** Dynamically update the `aria-label` of disabled controls to reflect their current status, ensuring users are informed of background processes even when interaction is blocked.

--- a/src/components/PythonRunner.tsx
+++ b/src/components/PythonRunner.tsx
@@ -120,7 +120,13 @@ const PythonRunner = forwardRef<PythonRunnerHandle, PythonRunnerProps>(
             className="python-runner__btn"
             onClick={handleRun}
             disabled={isLoading}
-            aria-label="Run Python code (Shift+Enter)"
+            aria-label={
+              pyodideLoading
+                ? 'Loading Python environment...'
+                : running
+                  ? 'Executing Python code...'
+                  : 'Run Python code (Shift+Enter)'
+            }
             title="Run (Shift+Enter)"
           >
             {pyodideLoading ? (

--- a/src/components/__tests__/PythonRunner.test.tsx
+++ b/src/components/__tests__/PythonRunner.test.tsx
@@ -35,7 +35,7 @@ describe('PythonRunner', () => {
       root.render(<PythonRunner code="print('hello')" />)
     })
 
-    const runButton = container.querySelector('button.python-runner__btn')
+    const runButton = container.querySelector('button.python-runner__btn') as HTMLButtonElement
     expect(runButton).toBeTruthy()
     expect(runButton?.disabled).toBe(false)
     expect(runButton?.getAttribute('aria-label')).toBe('Run Python code (Shift+Enter)')
@@ -54,12 +54,10 @@ describe('PythonRunner', () => {
       root.render(<PythonRunner code="print('hello')" />)
     })
 
-    const runButton = container.querySelector('button.python-runner__btn')
+    const runButton = container.querySelector('button.python-runner__btn') as HTMLButtonElement
     expect(runButton).toBeTruthy()
     expect(runButton?.disabled).toBe(true)
 
-    // This is the expected behavior AFTER my fix.
-    // Before fix, it would be 'Run Python code (Shift+Enter)'
     expect(runButton?.getAttribute('aria-label')).toBe('Loading Python environment...')
   })
 })

--- a/src/components/__tests__/PythonRunner.test.tsx
+++ b/src/components/__tests__/PythonRunner.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import PythonRunner from '../PythonRunner'
+import * as usePyodideHook from '../../hooks/usePyodide'
+
+// Mock usePyodide
+vi.mock('../../hooks/usePyodide', () => ({
+  usePyodide: vi.fn(),
+}))
+
+describe('PythonRunner', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    document.body.removeChild(container)
+  })
+
+  it('renders with correct aria-label when idle', async () => {
+    vi.mocked(usePyodideHook.usePyodide).mockReturnValue({
+      loading: false,
+      error: null,
+      runPython: vi.fn(),
+      ensureLoaded: vi.fn(),
+    })
+
+    const root = createRoot(container)
+    await act(async () => {
+      root.render(<PythonRunner code="print('hello')" />)
+    })
+
+    const runButton = container.querySelector('button.python-runner__btn')
+    expect(runButton).toBeTruthy()
+    expect(runButton?.disabled).toBe(false)
+    expect(runButton?.getAttribute('aria-label')).toBe('Run Python code (Shift+Enter)')
+  })
+
+  it('renders with correct aria-label when loading Pyodide', async () => {
+    vi.mocked(usePyodideHook.usePyodide).mockReturnValue({
+      loading: true,
+      error: null,
+      runPython: vi.fn(),
+      ensureLoaded: vi.fn(),
+    })
+
+    const root = createRoot(container)
+    await act(async () => {
+      root.render(<PythonRunner code="print('hello')" />)
+    })
+
+    const runButton = container.querySelector('button.python-runner__btn')
+    expect(runButton).toBeTruthy()
+    expect(runButton?.disabled).toBe(true)
+
+    // This is the expected behavior AFTER my fix.
+    // Before fix, it would be 'Run Python code (Shift+Enter)'
+    expect(runButton?.getAttribute('aria-label')).toBe('Loading Python environment...')
+  })
+})


### PR DESCRIPTION
💡 What:
- Updated the 'Run' button in the Python playground to have a dynamic aria-label.
- The label now reflects the current state: 'Loading Python environment...', 'Executing Python code...', or 'Run Python code (Shift+Enter)'.

🎯 Why:
- Screen reader users were previously not informed when the button state changed to 'Loading' or 'Running' because the aria-label was static and the button was disabled. This change ensures they are aware of the background process.

♿ Accessibility:
- Added dynamic aria-label updates for better state communication to assistive technologies.

📸 Before/After:
- Visuals remain the same (spinner + text).
- Screen readers will now announce the specific loading/running state instead of the static 'Run' label.

---
*PR created automatically by Jules for task [10498078879425116942](https://jules.google.com/task/10498078879425116942) started by @saint2706*