### PR TITLE
🛡️ Sentinel: [CRITICAL] Block Python sandbox escape via introspection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Python Sandbox Bypass via Introspection
+**Vulnerability:** Python sandbox escape via `__globals__`, `__subclasses__` and string concatenation.
+**Learning:** Regex-based sanitization is inherently fragile against string manipulation (e.g., `'__glo' + 'bals__'`). Blocking access to critical introspection attributes like `__globals__` and `__subclasses__` is crucial to prevent access to the global scope and sensitive modules.
+**Prevention:** Explicitly block `__globals__`, `__subclasses__`, `__bases__`, `__mro__`, `__getattribute__`, `__code__`, and `__closure__`. Consider AST-based validation for more robust security in the future.

--- a/src/utils/codeSecurity.test.ts
+++ b/src/utils/codeSecurity.test.ts
@@ -161,4 +161,20 @@ print("bad")
     expect(validatePythonCode('obj.compile()').valid).toBe(true)
     expect(validatePythonCode('obj.open()').valid).toBe(true)
   })
+
+  it('should block introspection and escape vectors', () => {
+    expect(validatePythonCode('f.__globals__').valid).toBe(false)
+    expect(validatePythonCode('cls.__subclasses__()').valid).toBe(false)
+    expect(validatePythonCode('cls.__bases__').valid).toBe(false)
+    expect(validatePythonCode('cls.__mro__').valid).toBe(false)
+    expect(validatePythonCode('obj.__getattribute__("x")').valid).toBe(false)
+    expect(validatePythonCode('f.__code__').valid).toBe(false)
+    expect(validatePythonCode('f.__closure__').valid).toBe(false)
+  })
+
+  it('should block obfuscated introspection access', () => {
+    // These should be blocked because the regexes match the string literals 'name'
+    expect(validatePythonCode('getattr(f, "__globals__")').valid).toBe(false)
+    // And also because __globals__ pattern matches
+  })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -62,6 +62,13 @@ export function validatePythonCode(code: string): ValidationResult {
     /\bfrom\s+builtins\s+import/, // from builtins import - prevents direct builtin imports
     /(?<!\.)\b(eval|exec|globals|locals|getattr|setattr|delattr|hasattr|vars|dir|compile|open)\s*\(/, // built-in functions that allow bypass
     /\b__builtins__\b/, // access to __builtins__
+    /\b__globals__\b/, // access to __globals__
+    /\b__subclasses__\b/, // access to __subclasses__
+    /\b__bases__\b/, // access to __bases__
+    /\b__mro__\b/, // access to __mro__
+    /\b__getattribute__\b/, // access to __getattribute__
+    /\b__code__\b/, // access to __code__
+    /\b__closure__\b/, // access to __closure__
   ]
 
   for (const pattern of patterns) {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Python sandbox bypass via `__globals__`, `__subclasses__`, and `__getattribute__`.
🎯 Impact: Attackers could potentially access `__builtins__` and execute arbitrary JavaScript code via `js` module.
🔧 Fix: Added regex patterns to block `__globals__`, `__subclasses__`, `__bases__`, `__mro__`, `__getattribute__`, `__code__`, and `__closure__` in `src/utils/codeSecurity.ts`.
✅ Verification: Added unit tests in `src/utils/codeSecurity.test.ts` covering these cases. Verified locally with reproduction scripts.

---
*PR created automatically by Jules for task [7775271216184988615](https://jules.google.com/task/7775271216184988615) started by @saint2706*