### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2026-02-25 - Dynamic State in Disabled Controls
 **Learning:** Disabled controls (like a "Run" button during execution) often retain their static `aria-label`, failing to communicate critical state changes (e.g., "Loading" vs "Running") to screen reader users.
 **Action:** Dynamically update the `aria-label` of disabled controls to reflect their current status, ensuring users are informed of background processes even when interaction is blocked.
+
+## 2026-02-27 - Current Page Indication
+**Learning:** Navigation links often lack a programmatic indication of the current page (e.g., visual highlighting is present but not semantic), leaving screen reader users lost in the site structure.
+**Action:** Use `aria-current="page"` on the active navigation link to explicitly communicate the user's current location to assistive technologies.

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -94,13 +94,25 @@ export default function Navbar({ onToggleSidebar }: NavbarProps) {
         >
           {theme === 'dark' ? '☀️' : '🌙'}
         </button>
-        <Link to="/" className={location.pathname === '/' ? 'active' : ''}>
+        <Link
+          to="/"
+          className={location.pathname === '/' ? 'active' : ''}
+          aria-current={location.pathname === '/' ? 'page' : undefined}
+        >
           Home
         </Link>
-        <Link to="/curriculum" className={location.pathname === '/curriculum' ? 'active' : ''}>
+        <Link
+          to="/curriculum"
+          className={location.pathname === '/curriculum' ? 'active' : ''}
+          aria-current={location.pathname === '/curriculum' ? 'page' : undefined}
+        >
           Curriculum
         </Link>
-        <Link to="/search" className={location.pathname === '/search' ? 'active' : ''}>
+        <Link
+          to="/search"
+          className={location.pathname === '/search' ? 'active' : ''}
+          aria-current={location.pathname === '/search' ? 'page' : undefined}
+        >
           Search
         </Link>
         <a

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -131,6 +131,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
           <Link
             to="/"
             className={`day-link ${location.pathname === '/' ? 'active' : ''}`}
+            aria-current={location.pathname === '/' ? 'page' : undefined}
             style={{ paddingLeft: '1.25rem', fontWeight: 600, marginBottom: '0.5rem' }}
             onClick={onClose}
           >
@@ -139,6 +140,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
           <Link
             to="/curriculum"
             className={`day-link ${location.pathname === '/curriculum' ? 'active' : ''}`}
+            aria-current={location.pathname === '/curriculum' ? 'page' : undefined}
             style={{ paddingLeft: '1.25rem', fontWeight: 600, marginBottom: '0.75rem' }}
             onClick={onClose}
           >
@@ -147,6 +149,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
           <Link
             to="/progress"
             className={`day-link ${location.pathname === '/progress' ? 'active' : ''}`}
+            aria-current={location.pathname === '/progress' ? 'page' : undefined}
             style={{ paddingLeft: '1.25rem', fontWeight: 600, marginBottom: '0.75rem' }}
             onClick={onClose}
           >
@@ -155,6 +158,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
           <Link
             to="/exercises"
             className={`day-link ${location.pathname === '/exercises' ? 'active' : ''}`}
+            aria-current={location.pathname === '/exercises' ? 'page' : undefined}
             style={{ paddingLeft: '1.25rem', fontWeight: 600, marginBottom: '0.75rem' }}
             onClick={onClose}
           >
@@ -164,6 +168,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
           <Link
             to="/review"
             className={`day-link ${location.pathname === '/review' ? 'active' : ''}`}
+            aria-current={location.pathname === '/review' ? 'page' : undefined}
             style={{ paddingLeft: '1.25rem', fontWeight: 600, marginBottom: '0.5rem' }}
             onClick={onClose}
           >
@@ -209,6 +214,9 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                   <Link
                     to={`/phase/${phase.phase}`}
                     className={`day-link ${location.pathname === `/phase/${phase.phase}` ? 'active' : ''}`}
+                    aria-current={
+                      location.pathname === `/phase/${phase.phase}` ? 'page' : undefined
+                    }
                     onClick={onClose}
                   >
                     📄 Phase Overview
@@ -218,6 +226,9 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                       key={lesson.day}
                       to={`/lesson/${lesson.day}`}
                       className={`day-link ${location.pathname === `/lesson/${lesson.day}` ? 'active' : ''}`}
+                      aria-current={
+                        location.pathname === `/lesson/${lesson.day}` ? 'page' : undefined
+                      }
                       onClick={onClose}
                     >
                       {isLessonComplete(lesson.day) && (

--- a/src/components/__tests__/Navigation.test.tsx
+++ b/src/components/__tests__/Navigation.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { act } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import Sidebar from '../Sidebar'
+import Navbar from '../Navbar'
+
+// Mock dependencies
+vi.mock('../../utils/contentLoader', () => ({
+  getAllPhases: () => [
+    { phase: 1, title: 'Phase 1', days: [1, 2] },
+    { phase: 2, title: 'Phase 2', days: [3, 4] },
+  ],
+  getLessonsByPhase: (phaseNum: number) => {
+    if (phaseNum === 1) {
+      return [
+        { day: 1, title: 'Lesson 1', phase: 1 },
+        { day: 2, title: 'Lesson 2', phase: 1 },
+      ]
+    }
+    return []
+  },
+  phaseIcons: ['🐍', '🔧'],
+}))
+
+vi.mock('../../utils/progressTracker', () => ({
+  isLessonComplete: () => false,
+  getCompletedForPhase: () => [],
+}))
+
+vi.mock('../../utils/reviewTracker', () => ({
+  getReviewDueCountByPhase: () => ({ 1: 0, 2: 0 }),
+  getReviewStreak: () => 0,
+}))
+
+vi.mock('../context/useTheme', () => ({
+  useTheme: () => ({ theme: 'light', toggleTheme: vi.fn() }),
+}))
+
+// Mock scrollIntoView
+Element.prototype.scrollIntoView = vi.fn()
+
+describe('Navigation Accessibility', () => {
+  let container: HTMLDivElement
+  let root: any
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    document.body.removeChild(container)
+  })
+
+  it('Sidebar renders correctly and should highlight the active link with aria-current="page"', async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={['/curriculum']}>
+          <Sidebar isOpen={true} onClose={() => {}} />
+        </MemoryRouter>
+      )
+    })
+
+    // Check if "Full Curriculum" link is active
+    // We need to query the DOM inside the container
+    const links = Array.from(container.querySelectorAll('a'))
+    const curriculumLink = links.find(l => l.textContent?.includes('Full Curriculum'))
+
+    expect(curriculumLink).not.toBeUndefined()
+    expect(curriculumLink?.className).toContain('active')
+
+    // Check if it has aria-current="page"
+    // This assertion is expected to fail initially
+    expect(curriculumLink?.getAttribute('aria-current')).toBe('page')
+  })
+
+  it('Sidebar renders active lesson link with aria-current="page"', async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={['/lesson/1']}>
+          <Sidebar isOpen={true} onClose={() => {}} />
+        </MemoryRouter>
+      )
+    })
+
+    // Wait for effects to run (e.g. timeout in Sidebar)
+    await new Promise(resolve => setTimeout(resolve, 150))
+
+    const links = Array.from(container.querySelectorAll('a'))
+    const lessonLink = links.find(l => l.textContent?.includes('Day 1: Lesson 1'))
+
+    expect(lessonLink).not.toBeUndefined()
+    expect(lessonLink?.className).toContain('active')
+
+    // Check if it has aria-current="page"
+    expect(lessonLink?.getAttribute('aria-current')).toBe('page')
+  })
+
+  it('Navbar renders correctly and highlights the active link with aria-current="page"', async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={['/curriculum']}>
+          <Navbar onToggleSidebar={() => {}} />
+        </MemoryRouter>
+      )
+    })
+
+    const links = Array.from(container.querySelectorAll('a'))
+    // Find link with text "Curriculum"
+    const curriculumLink = links.find(l => l.textContent === 'Curriculum')
+
+    expect(curriculumLink).not.toBeUndefined()
+    expect(curriculumLink?.className).toContain('active')
+    expect(curriculumLink?.getAttribute('aria-current')).toBe('page')
+  })
+})

--- a/src/components/__tests__/Navigation.test.tsx
+++ b/src/components/__tests__/Navigation.test.tsx
@@ -43,7 +43,7 @@ Element.prototype.scrollIntoView = vi.fn()
 
 describe('Navigation Accessibility', () => {
   let container: HTMLDivElement
-  let root: any
+  let root: ReturnType<typeof createRoot>
 
   beforeEach(() => {
     container = document.createElement('div')

--- a/src/components/__tests__/Navigation.test.tsx
+++ b/src/components/__tests__/Navigation.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { act } from 'react'
 import { MemoryRouter } from 'react-router-dom'


### PR DESCRIPTION
💡 **What:** Added `aria-current="page"` to active navigation links in the Sidebar and Navbar.
🎯 **Why:** Screen reader users rely on this attribute to know which link in a navigation menu corresponds to the current page. Visual indicators (like bold text or background color) are not sufficient for non-visual users.
♿ **Accessibility:**
  - Sidebar links (Home, Curriculum, Progress, Exercises, Review) now have `aria-current="page"` when active.
  - Sidebar accordion links (Phase Overview, Lessons) now have `aria-current="page"` when active.
  - Navbar links (Home, Curriculum, Search) now have `aria-current="page"` when active.
✅ **Verification:**
  - Added unit tests in `src/components/__tests__/Navigation.test.tsx` which verify the presence of the attribute.
  - Verified with Playwright script (screenshot confirmed active state visually, script confirmed attribute presence).

---
*PR created automatically by Jules for task [3684024909551988662](https://jules.google.com/task/3684024909551988662) started by @saint2706*