### PR TITLE
🛡️ Sentinel: [HIGH] Fix Python Line Continuation Bypass

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Regex-based sanitization of Python code (`import js`) was bypassed using `importlib.import_module('js')` and `sys.modules['js']` because `importlib` and `sys` were allowed.
 **Learning:** In a browser-based Python environment like Pyodide, restricting `import js` is insufficient if the environment provides mechanisms to dynamically load modules (`importlib`) or access pre-loaded modules (`sys.modules`).
 **Prevention:** Explicitly block `importlib`, `sys.modules`, and other dynamic loading mechanisms in the sanitization layer, or use a more robust sandboxing method (e.g., AST analysis or restricting the Pyodide environment itself).
+
+## 2025-02-27 - Python Line Continuation Bypass
+**Vulnerability:** Regex-based sanitization of Python code was bypassed using line continuations (e.g., `import \\\njs`), which split keywords across lines while remaining valid Python syntax.
+**Learning:** Regex patterns like `\bimport\s+js\b` often fail to account for language-specific syntax features like line continuations that can fragment tokens.
+**Prevention:** Normalize input code by removing line continuations or other formatting artifacts before applying regex-based security checks, or use an AST-based parser that understands the language structure.

--- a/src/utils/codeSecurity.test.ts
+++ b/src/utils/codeSecurity.test.ts
@@ -177,4 +177,13 @@ print("bad")
     expect(validatePythonCode('getattr(f, "__globals__")').valid).toBe(false)
     // And also because __globals__ pattern matches
   })
+
+  it('should block line continuations bypassing checks', () => {
+    // These would bypass regexes if line continuations weren't handled
+    expect(validatePythonCode('import \\\njs').valid).toBe(false)
+    expect(validatePythonCode('from \\\njs import window').valid).toBe(false)
+    expect(validatePythonCode('import \\\n  js').valid).toBe(false)
+    expect(validatePythonCode('import \\\n\tjs').valid).toBe(false)
+    expect(validatePythonCode('import \\\r\njs').valid).toBe(false)
+  })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -32,6 +32,11 @@ export interface ValidationResult {
 export function validatePythonCode(code: string): ValidationResult {
   if (!code) return { valid: true }
 
+  // Normalize code to handle line continuations
+  // Replace backslash + newline with an empty string to mimic Python's line continuation behavior
+  // This prevents bypassing regex checks by splitting keywords (e.g., "import \n js")
+  const normalizedCode = code.replace(/\\(\r\n|\r|\n)/g, '')
+
   // Regex patterns to detect 'js' module imports and bypass attempts
   // We use \b to ensure we don't match 'json' or 'jsp' etc.
   const patterns = [
@@ -72,7 +77,7 @@ export function validatePythonCode(code: string): ValidationResult {
   ]
 
   for (const pattern of patterns) {
-    if (pattern.test(code)) {
+    if (pattern.test(normalizedCode)) {
       return {
         valid: false,
         error: "Security Error: Direct access to browser APIs via 'js' module is restricted.",


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Regex-based security checks in `validatePythonCode` could be bypassed using Python line continuations (e.g., `import \\\njs`).
🎯 Impact: Malicious code could bypass restrictions and access browser APIs via Pyodide.
🔧 Fix: Normalized input code by removing line continuations before applying regex checks.
✅ Verification: Added unit tests covering various line continuation patterns.

---
*PR created automatically by Jules for task [17851549834739833022](https://jules.google.com/task/17851549834739833022) started by @saint2706*