### PR TITLE
🎨 Palette: Improved Sidebar Accessibility & Visuals

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Semantic Progress Indicators
+**Learning:** Visual shorthand like "5/10 · 🧠 2" is concise for sighted users but meaningless for screen readers ("five slash ten bullet brain two").
+**Action:** Always wrap visual shorthand in `aria-hidden="true"` and provide a robust `sr-only` description (e.g., "5 of 10 lessons completed, 2 reviews due").

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -195,9 +195,29 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                     Phase {phase.phase}: {phase.title}
                   </span>
                   <span className="phase-toggle-progress">
-                    {completedInPhase.length}/{lessons.length} · 🧠 {dueByPhase[phase.phase] || 0}
+                    <span aria-hidden="true">
+                      {completedInPhase.length}/{lessons.length} · 🧠 {dueByPhase[phase.phase] || 0}
+                    </span>
+                    <span className="sr-only">
+                      {completedInPhase.length} of {lessons.length} completed,{' '}
+                      {dueByPhase[phase.phase] || 0} reviews due
+                    </span>
                   </span>
-                  <span className="phase-toggle-arrow">▶</span>
+                  <span className="phase-toggle-arrow">
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="M9 18l6-6-6-6" />
+                    </svg>
+                  </span>
                 </button>
 
                 <div

--- a/src/components/__tests__/ExerciseWidget.test.tsx
+++ b/src/components/__tests__/ExerciseWidget.test.tsx
@@ -55,7 +55,9 @@ describe('ExerciseWidget', () => {
     })
 
     // 1. Initial state: Solution button exists
-    const showButton = container.querySelector('.exercise-widget__solution-btn') as HTMLButtonElement
+    const showButton = container.querySelector(
+      '.exercise-widget__solution-btn',
+    ) as HTMLButtonElement
     expect(showButton).not.toBeNull()
     expect(showButton.textContent).toContain('Show Solution')
 
@@ -89,7 +91,9 @@ describe('ExerciseWidget', () => {
     expect(solutionCodeHidden).not.toBeNull()
 
     // Check if the container is hidden
-    const solutionPanel = container.querySelector('.exercise-widget__solution-panel') as HTMLDivElement
+    const solutionPanel = container.querySelector(
+      '.exercise-widget__solution-panel',
+    ) as HTMLDivElement
     expect(solutionPanel.hidden).toBe(true)
   })
 })

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import Sidebar from '../Sidebar'
+import { MemoryRouter } from 'react-router-dom'
+import * as contentLoader from '../../utils/contentLoader'
+import * as progressTracker from '../../utils/progressTracker'
+import * as reviewTracker from '../../utils/reviewTracker'
+
+// Mock dependencies
+vi.mock('../../utils/contentLoader', () => ({
+  getAllPhases: vi.fn(),
+  getLessonsByPhase: vi.fn(),
+  phaseIcons: ['A', 'B'],
+}))
+
+vi.mock('../../utils/progressTracker', () => ({
+  isLessonComplete: vi.fn(),
+  getCompletedForPhase: vi.fn(),
+}))
+
+vi.mock('../../utils/reviewTracker', () => ({
+  getReviewDueCountByPhase: vi.fn(),
+  getReviewStreak: () => 0,
+}))
+
+describe('Sidebar Accessibility', () => {
+  let container: HTMLDivElement
+  let root: ReturnType<typeof createRoot>
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    document.body.removeChild(container)
+  })
+
+  const phases = [{ phase: 1, title: 'Phase 1', days: [1, 2, 3] }]
+  const lessonsPhase1 = [
+    { day: 1, title: 'Lesson 1', phase: 1 },
+    { day: 2, title: 'Lesson 2', phase: 1 },
+    { day: 3, title: 'Lesson 3', phase: 1 },
+  ]
+
+  it('renders accessible progress information', async () => {
+    vi.mocked(contentLoader.getAllPhases).mockReturnValue(
+      phases as unknown as ReturnType<typeof contentLoader.getAllPhases>,
+    )
+    vi.mocked(contentLoader.getLessonsByPhase).mockReturnValue(
+      lessonsPhase1 as unknown as ReturnType<typeof contentLoader.getLessonsByPhase>,
+    )
+    vi.mocked(progressTracker.getCompletedForPhase).mockReturnValue([1] as unknown as ReturnType<
+      typeof progressTracker.getCompletedForPhase
+    >) // 1 completed
+    vi.mocked(reviewTracker.getReviewDueCountByPhase).mockReturnValue({
+      1: 5,
+    } as unknown as ReturnType<typeof reviewTracker.getReviewDueCountByPhase>) // 5 reviews due
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={['/']}>
+          <Sidebar isOpen={true} onClose={() => {}} />
+        </MemoryRouter>,
+      )
+    })
+
+    const toggleButton = container.querySelector('.phase-toggle')
+    expect(toggleButton).toBeDefined()
+
+    const progressContainer = toggleButton?.querySelector('.phase-toggle-progress')
+    expect(progressContainer).toBeDefined()
+
+    // Check for sr-only description
+    const srOnly = progressContainer?.querySelector('.sr-only')
+    expect(srOnly).not.toBeNull()
+    expect(srOnly?.textContent).toContain('1 of 3')
+
+    // Check that visual parts are hidden
+    const visualText = progressContainer?.querySelector('[aria-hidden="true"]')
+    expect(visualText).not.toBeNull()
+
+    // Check for arrow SVG
+    const arrow = toggleButton?.querySelector('.phase-toggle-arrow svg')
+    expect(arrow).not.toBeNull()
+    expect(arrow?.getAttribute('aria-hidden')).toBe('true')
+  })
+})

--- a/src/components/__tests__/SidebarPerf.test.tsx
+++ b/src/components/__tests__/SidebarPerf.test.tsx
@@ -54,10 +54,14 @@ describe('Sidebar Performance', () => {
 
   it('does not render lesson links for closed phases', async () => {
     // Cast to unknown first to bypass lint rules about direct casting to incompatible types if any
-    vi.mocked(contentLoader.getAllPhases).mockReturnValue(phases as unknown as ReturnType<typeof contentLoader.getAllPhases>)
+    vi.mocked(contentLoader.getAllPhases).mockReturnValue(
+      phases as unknown as ReturnType<typeof contentLoader.getAllPhases>,
+    )
     vi.mocked(contentLoader.getLessonsByPhase).mockImplementation((phase) => {
-      if (phase === 1) return lessonsPhase1 as unknown as ReturnType<typeof contentLoader.getLessonsByPhase>
-      if (phase === 2) return lessonsPhase2 as unknown as ReturnType<typeof contentLoader.getLessonsByPhase>
+      if (phase === 1)
+        return lessonsPhase1 as unknown as ReturnType<typeof contentLoader.getLessonsByPhase>
+      if (phase === 2)
+        return lessonsPhase2 as unknown as ReturnType<typeof contentLoader.getLessonsByPhase>
       return []
     })
 
@@ -66,7 +70,7 @@ describe('Sidebar Performance', () => {
       root.render(
         <MemoryRouter initialEntries={['/']}>
           <Sidebar isOpen={true} onClose={() => {}} />
-        </MemoryRouter>
+        </MemoryRouter>,
       )
     })
 
@@ -75,15 +79,21 @@ describe('Sidebar Performance', () => {
     expect(container.textContent).toContain('Phase 2: Phase 2')
 
     // Lesson links should NOT be in the DOM
-    const lesson1 = Array.from(container.querySelectorAll('a')).find(el => el.textContent?.includes('Day 1: Lesson 1'))
+    const lesson1 = Array.from(container.querySelectorAll('a')).find((el) =>
+      el.textContent?.includes('Day 1: Lesson 1'),
+    )
     expect(lesson1).toBeUndefined()
   })
 
   it('renders lesson links when phase is opened', async () => {
-    vi.mocked(contentLoader.getAllPhases).mockReturnValue(phases as unknown as ReturnType<typeof contentLoader.getAllPhases>)
+    vi.mocked(contentLoader.getAllPhases).mockReturnValue(
+      phases as unknown as ReturnType<typeof contentLoader.getAllPhases>,
+    )
     vi.mocked(contentLoader.getLessonsByPhase).mockImplementation((phase) => {
-      if (phase === 1) return lessonsPhase1 as unknown as ReturnType<typeof contentLoader.getLessonsByPhase>
-      if (phase === 2) return lessonsPhase2 as unknown as ReturnType<typeof contentLoader.getLessonsByPhase>
+      if (phase === 1)
+        return lessonsPhase1 as unknown as ReturnType<typeof contentLoader.getLessonsByPhase>
+      if (phase === 2)
+        return lessonsPhase2 as unknown as ReturnType<typeof contentLoader.getLessonsByPhase>
       return []
     })
 
@@ -91,17 +101,19 @@ describe('Sidebar Performance', () => {
       root.render(
         <MemoryRouter initialEntries={['/']}>
           <Sidebar isOpen={true} onClose={() => {}} />
-        </MemoryRouter>
+        </MemoryRouter>,
       )
     })
 
     // Initially lesson 1 is not visible
-    let lesson1 = Array.from(container.querySelectorAll('a')).find(el => el.textContent?.includes('Day 1: Lesson 1'))
+    let lesson1 = Array.from(container.querySelectorAll('a')).find((el) =>
+      el.textContent?.includes('Day 1: Lesson 1'),
+    )
     expect(lesson1).toBeUndefined()
 
     // Find and click the toggle for Phase 1
     const buttons = Array.from(container.querySelectorAll('button'))
-    const phase1Button = buttons.find(b => b.textContent?.includes('Phase 1: Phase 1'))
+    const phase1Button = buttons.find((b) => b.textContent?.includes('Phase 1: Phase 1'))
 
     expect(phase1Button).toBeDefined()
 
@@ -110,7 +122,9 @@ describe('Sidebar Performance', () => {
     })
 
     // Now lesson 1 should be visible
-    lesson1 = Array.from(container.querySelectorAll('a')).find(el => el.textContent?.includes('Day 1: Lesson 1'))
+    lesson1 = Array.from(container.querySelectorAll('a')).find((el) =>
+      el.textContent?.includes('Day 1: Lesson 1'),
+    )
     expect(lesson1).toBeDefined()
     expect(lesson1?.textContent).toContain('Day 1: Lesson 1')
   })

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { validatePythonCode } from './codeSecurity'
+import { validatePythonCode } from '../codeSecurity'
 
 describe('validatePythonCode', () => {
   it('should allow safe code', () => {

--- a/src/utils/__tests__/searchIndex-functions.test.ts
+++ b/src/utils/__tests__/searchIndex-functions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { createSearchDocuments, createSearchEngine, computeRankingBoost } from './searchIndex'
-import type { Lesson } from './contentLoader'
+import { createSearchDocuments, createSearchEngine, computeRankingBoost } from '../searchIndex'
+import type { Lesson } from '../contentLoader'
 
 const lessons: Lesson[] = [
   {

--- a/tsconfig.json.bak
+++ b/tsconfig.json.bak
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+}


### PR DESCRIPTION
Improved the accessibility and visual polish of the Sidebar phase toggle.
Screen readers now announce "X of Y completed" instead of "X slash Y".
The arrow icon is now a crisp SVG chevron instead of a text character.

---
*PR created automatically by Jules for task [13003566722398367054](https://jules.google.com/task/13003566722398367054) started by @saint2706*