### PR TITLE
Add global Toaster and shared toast utilities (with entrypoint smoke test)

### DIFF
--- a/src/__tests__/main.test.tsx
+++ b/src/__tests__/main.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const renderMock = vi.fn()
+const toasterMarker = vi.fn(() => null)
+const appMarker = vi.fn(() => null)
+
+vi.mock('react-dom/client', () => ({
+  default: {
+    createRoot: vi.fn(() => ({
+      render: renderMock,
+    })),
+  },
+  createRoot: vi.fn(() => ({
+    render: renderMock,
+  })),
+}))
+
+vi.mock('react-hot-toast', () => ({
+  Toaster: toasterMarker,
+}))
+
+vi.mock('../App', () => ({
+  default: appMarker,
+}))
+
+const elementTreeContainsType = (node: unknown, type: unknown): boolean => {
+  if (!node || typeof node !== 'object') {
+    return false
+  }
+
+  if ('type' in node && node.type === type) {
+    return true
+  }
+
+  if (!('props' in node) || !node.props || typeof node.props !== 'object') {
+    return false
+  }
+
+  if (!('children' in node.props)) {
+    return false
+  }
+
+  const children = node.props.children
+  if (Array.isArray(children)) {
+    return children.some((child) => elementTreeContainsType(child, type))
+  }
+
+  return elementTreeContainsType(children, type)
+}
+
+describe('main entrypoint', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  it('renders app shell with Toaster mounted inside providers', async () => {
+    document.body.innerHTML = '<div id="root"></div>'
+
+    await import('../main')
+
+    expect(renderMock).toHaveBeenCalledTimes(1)
+
+    const renderedTree = renderMock.mock.calls[0]?.[0]
+    expect(elementTreeContainsType(renderedTree, appMarker)).toBe(true)
+    expect(elementTreeContainsType(renderedTree, toasterMarker)).toBe(true)
+  })
+})

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,7 +15,9 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { HashRouter } from 'react-router-dom'
 import { HelmetProvider } from '@dr.pogodin/react-helmet'
+import { Toaster } from 'react-hot-toast'
 import App from './App'
+import { TOAST_DEFAULT_OPTIONS } from './utils/toast'
 import './styles/index.css'
 
 /**
@@ -27,6 +29,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <HelmetProvider>
       <HashRouter>
         <App />
+        <Toaster position="top-right" toastOptions={TOAST_DEFAULT_OPTIONS} />
       </HashRouter>
     </HelmetProvider>
   </React.StrictMode>,

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,0 +1,31 @@
+import { toast, type ToastOptions } from 'react-hot-toast'
+
+export const TOAST_DEFAULT_OPTIONS: ToastOptions = {
+  duration: 3500,
+  style: {
+    background: 'var(--bg-elevated, #1f2937)',
+    color: 'var(--text-primary, #f9fafb)',
+    border: '1px solid var(--border-color, #374151)',
+  },
+  success: {
+    iconTheme: {
+      primary: '#22c55e',
+      secondary: '#f9fafb',
+    },
+  },
+  error: {
+    iconTheme: {
+      primary: '#ef4444',
+      secondary: '#f9fafb',
+    },
+  },
+}
+
+export const toastSuccess = (message: string, options?: ToastOptions): string =>
+  toast.success(message, options)
+
+export const toastError = (message: string, options?: ToastOptions): string =>
+  toast.error(message, options)
+
+export const toastInfo = (message: string, options?: ToastOptions): string =>
+  toast(message, options)


### PR DESCRIPTION
### Motivation
- Ensure toast UI is mounted once at the app root so notifications behave consistently across the app.
- Centralize default toast styling and duration to avoid repeated options at call sites and to keep dark/light themes friendly.
- Provide thin wrapper helpers so call sites can use `toastSuccess`, `toastError`, and `toastInfo` without repeating options.

### Description
- Updated `src/main.tsx` to import `Toaster` from `react-hot-toast` and render `<Toaster position="top-right" toastOptions={TOAST_DEFAULT_OPTIONS} />` alongside `<App />` inside the existing providers.
- Added `src/utils/toast.ts` which exports `TOAST_DEFAULT_OPTIONS` (duration + theme-friendly styling + icon themes) and wrapper helpers `toastSuccess`, `toastError`, and `toastInfo` that delegate to `react-hot-toast`.
- Added a smoke test `src/__tests__/main.test.tsx` that mocks the entrypoint render and asserts both `App` and `Toaster` are present in the rendered tree.

### Testing
- Ran `npm run test -- src/__tests__/main.test.tsx`, and the test passed.
- Ran `npx eslint src/main.tsx src/utils/toast.ts src/__tests__/main.test.tsx`, and linting completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996bec4c6888330a7a9f2039c98a1d3)