### PR TITLE
Add app-wide ErrorBoundary with toast and fallback UI

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,52 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { toastError } from '../utils/toast'
+
+type ErrorBoundaryProps = {
+  children: ReactNode
+}
+
+type ErrorBoundaryState = {
+  hasError: boolean
+}
+
+export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('Unhandled UI error:', error, errorInfo)
+    toastError('Something went wrong. Please try again.')
+  }
+
+  private handleRetry = (): void => {
+    this.setState({ hasError: false })
+  }
+
+  private handleReload = (): void => {
+    window.location.reload()
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <main className="main-content" role="alert" aria-live="assertive">
+          <h1>Something went wrong</h1>
+          <p>We hit an unexpected issue while loading this page.</p>
+          <div>
+            <button type="button" onClick={this.handleRetry}>
+              Try again
+            </button>
+            <button type="button" onClick={this.handleReload}>
+              Reload page
+            </button>
+          </div>
+        </main>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,43 @@
+import { act } from 'react'
+import ReactDOM from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import ErrorBoundary from '../ErrorBoundary'
+import { toastError } from '../../utils/toast'
+
+vi.mock('../../utils/toast', () => ({
+  toastError: vi.fn(),
+}))
+
+const ThrowingComponent = () => {
+  throw new Error('Kaboom')
+}
+
+describe('ErrorBoundary', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  it('renders fallback UI and emits a safe toast message when a child throws', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    document.body.innerHTML = '<div id="root"></div>'
+    const rootElement = document.getElementById('root')
+    expect(rootElement).not.toBeNull()
+
+    const root = ReactDOM.createRoot(rootElement as HTMLElement)
+
+    await act(async () => {
+      root.render(
+        <ErrorBoundary>
+          <ThrowingComponent />
+        </ErrorBoundary>,
+      )
+    })
+
+    expect(document.body.textContent).toContain('Something went wrong')
+    expect(document.body.textContent).toContain('Try again')
+    expect(toastError).toHaveBeenCalledWith('Something went wrong. Please try again.')
+
+    consoleErrorSpy.mockRestore()
+  })
+})

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,6 +18,7 @@ import { HelmetProvider } from '@dr.pogodin/react-helmet'
 import { Toaster } from 'react-hot-toast'
 import App from './App'
 import { TOAST_DEFAULT_OPTIONS } from './utils/toast'
+import ErrorBoundary from './components/ErrorBoundary'
 import './styles/index.css'
 
 /**
@@ -28,7 +29,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <HelmetProvider>
       <HashRouter>
-        <App />
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
         <Toaster position="top-right" toastOptions={TOAST_DEFAULT_OPTIONS} />
       </HashRouter>
     </HelmetProvider>


### PR DESCRIPTION
### Motivation

- Provide a global UI error boundary to catch unexpected render-time exceptions and avoid blank pages.
- Surface a safe, user-friendly notification when a UI error occurs instead of exposing raw errors.
- Allow users to recover via a minimal fallback UI with retry and reload actions.

### Description

- Added `src/components/ErrorBoundary.tsx`, a class component implementing `static getDerivedStateFromError` and `componentDidCatch`, which calls `toastError('Something went wrong. Please try again.')` and logs the error to the console.
- Fallback UI shows a brief message and two actions: `Try again` (resets boundary state) and `Reload page` (calls `window.location.reload()`).
- Wrapped the root `<App />` in `src/main.tsx` with the new `<ErrorBoundary>` while keeping the `Toaster` mounted outside the boundary so toasts can render even when the app subtree fails.
- Added `src/components/__tests__/ErrorBoundary.test.tsx`, a focused test that mounts a throwing child component and asserts the fallback UI is rendered and the toast helper is invoked.

### Testing

- Ran `npm test -- src/components/__tests__/ErrorBoundary.test.tsx src/__tests__/main.test.tsx`, which executed the focused tests under `vitest`.
- Both tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996bf9649108330b79527f958264cde)