### PR TITLE
Add navbar command palette controls and shortcut interaction test

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState, type FormEvent } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useTheme } from '../context/useTheme'
+import SearchPalette from './SearchPalette'
+import { toastInfo } from '../utils/toast'
 
 interface NavbarProps {
   onToggleSidebar: () => void
@@ -11,21 +13,45 @@ export default function Navbar({ onToggleSidebar }: NavbarProps) {
   const navigate = useNavigate()
   const { theme, toggleTheme } = useTheme()
   const [query, setQuery] = useState('')
+  const [isPaletteOpen, setIsPaletteOpen] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
+
+  const openSearchPalette = () => {
+    setIsPaletteOpen(true)
+    toastInfo('Search opened — press ESC to close', { duration: 2000 })
+  }
+
+  const closeSearchPalette = () => {
+    setIsPaletteOpen(false)
+    toastInfo('Search closed', { duration: 1200 })
+  }
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
-      // Skip navbar shortcut when on /search page to avoid conflict
-      if (location.pathname === '/search') return
+      const isTypingTarget = (target: EventTarget | null) => {
+        const element = target as HTMLElement | null
+        return (
+          element?.tagName === 'INPUT' ||
+          element?.tagName === 'TEXTAREA' ||
+          element?.isContentEditable
+        )
+      }
+
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        if (isTypingTarget(event.target)) return
+
+        event.preventDefault()
+        if (!isPaletteOpen) {
+          openSearchPalette()
+        }
+        return
+      }
+
+      // Skip navbar slash shortcut while palette is open or on /search page to avoid conflict
+      if (isPaletteOpen || location.pathname === '/search') return
 
       if (event.key === '/' && !event.metaKey && !event.ctrlKey && !event.altKey) {
-        const target = event.target as HTMLElement | null
-        if (
-          target?.tagName === 'INPUT' ||
-          target?.tagName === 'TEXTAREA' ||
-          target?.isContentEditable
-        )
-          return
+        if (isTypingTarget(event.target)) return
 
         event.preventDefault()
         inputRef.current?.focus()
@@ -40,7 +66,7 @@ export default function Navbar({ onToggleSidebar }: NavbarProps) {
 
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [navigate, location.pathname])
+  }, [isPaletteOpen, navigate, location.pathname])
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -74,6 +100,15 @@ export default function Navbar({ onToggleSidebar }: NavbarProps) {
       </div>
 
       <div className="navbar-links">
+        <button
+          type="button"
+          className="theme-toggle"
+          onClick={openSearchPalette}
+          aria-label="Open command palette search"
+          title="Open command palette search (Ctrl/Cmd+K)"
+        >
+          🔎
+        </button>
         <form onSubmit={handleSubmit} className="navbar-search-form">
           <input
             ref={inputRef}
@@ -111,6 +146,7 @@ export default function Navbar({ onToggleSidebar }: NavbarProps) {
           GitHub ↗
         </a>
       </div>
+      <SearchPalette isOpen={isPaletteOpen} onClose={closeSearchPalette} />
     </nav>
   )
 }

--- a/src/components/__tests__/Navbar.test.tsx
+++ b/src/components/__tests__/Navbar.test.tsx
@@ -1,0 +1,67 @@
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import Navbar from '../Navbar'
+
+const toastInfoMock = vi.fn()
+
+vi.mock('../../context/useTheme', () => ({
+  useTheme: () => ({
+    theme: 'dark',
+    toggleTheme: vi.fn(),
+  }),
+}))
+
+vi.mock('../../utils/toast', () => ({
+  toastInfo: (...args: unknown[]) => toastInfoMock(...args),
+}))
+
+describe('Navbar Search Palette', () => {
+  let container: HTMLDivElement
+  let root: ReturnType<typeof createRoot>
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    toastInfoMock.mockReset()
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    document.body.removeChild(container)
+  })
+
+  it('opens with Cmd/Ctrl+K and closes with ESC', async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={['/']}>
+          <Navbar onToggleSidebar={() => {}} />
+        </MemoryRouter>,
+      )
+    })
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }))
+    })
+
+    const dialog = container.querySelector('[role="dialog"][aria-label="Search lessons"]')
+    expect(dialog).not.toBeNull()
+    expect(toastInfoMock).toHaveBeenCalledWith('Search opened — press ESC to close', {
+      duration: 2000,
+    })
+
+    const paletteInput = container.querySelector('.search-input') as HTMLInputElement | null
+    expect(paletteInput).not.toBeNull()
+
+    await act(async () => {
+      paletteInput?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+
+    expect(container.querySelector('[role="dialog"][aria-label="Search lessons"]')).toBeNull()
+    expect(toastInfoMock).toHaveBeenCalledWith('Search closed', { duration: 1200 })
+  })
+})


### PR DESCRIPTION
### Motivation

- Provide a global command-palette from the main navbar to let users open a fast search UI with a familiar shortcut and button.
- Prevent shortcut conflicts so the existing inline `/` navbar search remains usable while the palette is closed.

### Description

- Add `isPaletteOpen` state to `Navbar` and mount `SearchPalette` as `<SearchPalette isOpen={isPaletteOpen} onClose={closeSearchPalette} />` in `src/components/Navbar.tsx`.
- Wire `Cmd/Ctrl+K` keyboard handling to open the palette (ignoring typing targets) and add a visible search icon/button that calls `openSearchPalette()` when clicked.
- Show informational toasts via `toastInfo` on open (`Search opened — press ESC to close`) and on close (`Search closed`), and guard the inline `/` shortcut while the palette is open or on `/search` to avoid conflicts.
- Add an interaction test `src/components/__tests__/Navbar.test.tsx` that opens the palette with `Ctrl/Cmd+K` and closes it with `Escape`, asserting the palette dialog and toast calls.

### Testing

- Ran `npm test -- src/components/__tests__/Navbar.test.tsx` which passed (`1 test, 1 passed`).
- Ran `npx eslint src/components/Navbar.tsx src/components/__tests__/Navbar.test.tsx` and linting reported no errors.
- Pre-commit checks (`eslint --max-warnings=0` and `prettier --check`) were executed successfully during commit.
- Launched the dev server and ran a Playwright script to open the app and verify the palette visually, capturing a screenshot of the opened palette.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996bf8dd39483309d6dd065d4647d23)