### PR TITLE
Add local learning analytics (time-on-page) with dashboard summary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { preloadSearchIndex } from './utils/searchIndex'
 import { hydrateProgressStore } from './utils/progressTracker'
 import { hydrateQuizStore } from './stores/quizStore'
 import { useUserPreferencesStore } from './stores/userPreferencesStore'
+import { useLearningAnalytics } from './hooks/useLearningAnalytics'
 
 const Home = lazy(() => import('./pages/Home'))
 const Lesson = lazy(() => import('./pages/Lesson'))
@@ -31,6 +32,8 @@ export default function App() {
   const [sidebarOpen, setSidebarOpen] = useState(sidebarDefaultOpen)
   const location = useLocation()
   const prefersReducedMotion = useReducedMotion()
+
+  useLearningAnalytics(location.pathname)
 
   useEffect(() => {
     preloadSearchIndex()

--- a/src/hooks/useLearningAnalytics.ts
+++ b/src/hooks/useLearningAnalytics.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react'
+import { useLearningAnalyticsStore } from '../stores/learningAnalyticsStore'
+
+let activeSubscribers = 0
+
+export function useLearningAnalytics(route: string): void {
+  useEffect(() => {
+    useLearningAnalyticsStore.getState().hydrate()
+    useLearningAnalyticsStore.getState().startTrackingRoute(route)
+  }, [route])
+
+  useEffect(() => {
+    activeSubscribers += 1
+
+    const onVisibilityChange = () => {
+      const store = useLearningAnalyticsStore.getState()
+      if (document.hidden) {
+        store.pauseTracking()
+      } else {
+        store.resumeTracking()
+      }
+    }
+
+    const onBeforeUnload = () => {
+      useLearningAnalyticsStore.getState().stopTracking()
+    }
+
+    if (activeSubscribers === 1 && typeof window !== 'undefined') {
+      document.addEventListener('visibilitychange', onVisibilityChange)
+      window.addEventListener('beforeunload', onBeforeUnload)
+    }
+
+    return () => {
+      activeSubscribers = Math.max(0, activeSubscribers - 1)
+      useLearningAnalyticsStore.getState().stopTracking()
+
+      if (activeSubscribers === 0 && typeof window !== 'undefined') {
+        document.removeEventListener('visibilitychange', onVisibilityChange)
+        window.removeEventListener('beforeunload', onBeforeUnload)
+      }
+    }
+  }, [])
+}

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -8,7 +8,7 @@
  * @module pages/ProgressDashboard
  */
 
-import { useState, useCallback } from 'react'
+import { useMemo, useState, useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import SEOHead from '../components/SEOHead'
 import {
@@ -19,6 +19,7 @@ import {
 } from '../utils/contentLoader'
 import {
   getCompletedLessons,
+  getStreakDays,
   isLessonComplete,
   getCompletedForPhase,
   clearAllProgress,
@@ -27,6 +28,7 @@ import ProgressBar from '../components/ProgressBar'
 import Breadcrumb from '../components/Breadcrumb'
 import AnimatedCounter from '../components/AnimatedCounter'
 import { useUserPreferencesStore } from '../stores/userPreferencesStore'
+import { formatDuration, useLearningAnalyticsStore } from '../stores/learningAnalyticsStore'
 
 /**
  * Progress dashboard page component.
@@ -56,6 +58,15 @@ export default function ProgressDashboard() {
       forceUpdate()
     }
   }
+
+  const totalLearningMs = useLearningAnalyticsStore((state) => state.totalLearningMs())
+  const thisWeekLearningMs = useLearningAnalyticsStore((state) => state.weekLearningMs())
+  const todayLearningMs = useLearningAnalyticsStore((state) => state.todayLearningMs())
+  const studyStreak = useLearningAnalyticsStore((state) => state.studyStreakDays(5))
+  const completionStreak = useMemo(() => getStreakDays(), [completedLessons.length])
+  const last7Days = useLearningAnalyticsStore((state) => state.getLast7Days())
+
+  const chartMax = Math.max(1, ...last7Days.map((item) => item.ms))
 
   const {
     theme,
@@ -112,6 +123,73 @@ export default function ProgressDashboard() {
       </div>
 
       <ProgressBar completed={completedLessons.length} total={totalLessons} />
+
+      <section className="learning-analytics-card" aria-labelledby="learning-analytics-heading">
+        <div className="section-header" style={{ marginTop: '2.5rem', marginBottom: '1rem' }}>
+          <h2 id="learning-analytics-heading">Learning Analytics</h2>
+          <p>Local-only study time summaries from your device.</p>
+        </div>
+
+        <div className="learning-analytics-grid">
+          <div className="progress-stat-big">
+            <span className="progress-stat-value">{formatDuration(totalLearningMs)}</span>
+            <span className="progress-stat-label">Total Study Time</span>
+          </div>
+          <div className="progress-stat-big">
+            <span className="progress-stat-value">{formatDuration(thisWeekLearningMs)}</span>
+            <span className="progress-stat-label">This Week</span>
+          </div>
+          <div className="progress-stat-big">
+            <span className="progress-stat-value">{formatDuration(todayLearningMs)}</span>
+            <span className="progress-stat-label">Today</span>
+          </div>
+          <div className="progress-stat-big">
+            <span className="progress-stat-value">{studyStreak}</span>
+            <span className="progress-stat-label">Study Streak (5m+)</span>
+          </div>
+          <div className="progress-stat-big">
+            <span className="progress-stat-value">{completionStreak}</span>
+            <span className="progress-stat-label">Completion Streak</span>
+          </div>
+        </div>
+
+        <svg
+          className="learning-analytics-chart"
+          viewBox="0 0 420 140"
+          role="img"
+          aria-label="Last 7 days time studied"
+        >
+          {last7Days.map((entry, index) => {
+            const barWidth = 48
+            const gap = 10
+            const x = 16 + index * (barWidth + gap)
+            const height = Math.round((entry.ms / chartMax) * 96)
+            const y = 110 - height
+            const dayLabel = entry.date.slice(5)
+            return (
+              <g key={entry.date}>
+                <title>{`${entry.date}: ${formatDuration(entry.ms)}`}</title>
+                <rect
+                  x={x}
+                  y={y}
+                  width={barWidth}
+                  height={Math.max(2, height)}
+                  rx={5}
+                  className="learning-analytics-bar"
+                />
+                <text
+                  x={x + barWidth / 2}
+                  y={128}
+                  textAnchor="middle"
+                  className="learning-analytics-label"
+                >
+                  {dayLabel}
+                </text>
+              </g>
+            )
+          })}
+        </svg>
+      </section>
 
       <section className="preferences-card" aria-labelledby="preferences-heading">
         <div className="section-header" style={{ marginTop: '2.5rem', marginBottom: '1rem' }}>

--- a/src/stores/__tests__/learningAnalyticsStore.test.ts
+++ b/src/stores/__tests__/learningAnalyticsStore.test.ts
@@ -1,0 +1,68 @@
+import { formatDuration, useLearningAnalyticsStore } from '../learningAnalyticsStore'
+
+describe('learningAnalyticsStore', () => {
+  beforeEach(() => {
+    useLearningAnalyticsStore.getState().clearAnalytics()
+    useLearningAnalyticsStore.setState({
+      hasHydrated: false,
+      isPaused: false,
+      sessionStartedAt: null,
+      lastActiveRoute: null,
+      lastLessonDay: null,
+    })
+  })
+
+  it('tracks time by lesson/day and date on route changes', () => {
+    const store = useLearningAnalyticsStore.getState()
+
+    store.startTrackingRoute('/lesson/2', 0)
+    store.startTrackingRoute('/lesson/3', 120_000)
+    store.stopTracking(240_000)
+
+    const state = useLearningAnalyticsStore.getState()
+
+    expect(state.timeByLessonDay[2]).toBe(120_000)
+    expect(state.timeByLessonDay[3]).toBe(120_000)
+    expect(state.totalLearningMs()).toBe(240_000)
+    expect(state.visitsByLessonDay[2]).toBe(1)
+    expect(state.visitsByLessonDay[3]).toBe(1)
+  })
+
+  it('pauses and resumes without double-counting hidden time', () => {
+    const store = useLearningAnalyticsStore.getState()
+
+    store.startTrackingRoute('/lesson/5', 1_000)
+    store.pauseTracking(61_000)
+    store.resumeTracking(120_000)
+    store.stopTracking(180_000)
+
+    const state = useLearningAnalyticsStore.getState()
+    expect(state.timeByLessonDay[5]).toBe(120_000)
+  })
+
+  it('computes weekly points and study streak threshold', () => {
+    useLearningAnalyticsStore.setState({
+      timeByDate: {
+        '2026-03-01': 6 * 60_000,
+        '2026-03-02': 8 * 60_000,
+        '2026-03-03': 5 * 60_000,
+        '2026-03-04': 4 * 60_000,
+      },
+    })
+
+    const state = useLearningAnalyticsStore.getState()
+    const now = new Date('2026-03-04T12:00:00.000Z')
+
+    expect(state.getLast7Days(now)).toHaveLength(7)
+    expect(state.studyStreakDays(5, now)).toBe(0)
+    expect(state.studyStreakDays(4, now)).toBe(4)
+    expect(state.weekLearningMs(now)).toBe(23 * 60_000)
+  })
+
+  it('formats duration labels', () => {
+    expect(formatDuration(0)).toBe('0m')
+    expect(formatDuration(59 * 60_000)).toBe('59m')
+    expect(formatDuration(60 * 60_000)).toBe('1h')
+    expect(formatDuration(72 * 60_000)).toBe('1h 12m')
+  })
+})

--- a/src/stores/learningAnalyticsStore.ts
+++ b/src/stores/learningAnalyticsStore.ts
@@ -1,0 +1,284 @@
+import { create } from 'zustand'
+import { createJSONStorage, persist, StateStorage } from 'zustand/middleware'
+
+const STORAGE_KEY = 'coding-for-mba-learning-analytics'
+const DAY_IN_MS = 24 * 60 * 60 * 1000
+const DEFAULT_STREAK_MINUTES = 5
+
+const safeStorage: StateStorage = {
+  getItem: (name) => {
+    try {
+      return typeof window === 'undefined' ? null : window.localStorage.getItem(name)
+    } catch {
+      return null
+    }
+  },
+  setItem: (name, value) => {
+    try {
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(name, value)
+      }
+    } catch {
+      // Ignore storage write failures.
+    }
+  },
+  removeItem: (name) => {
+    try {
+      if (typeof window !== 'undefined') {
+        window.localStorage.removeItem(name)
+      }
+    } catch {
+      // Ignore storage delete failures.
+    }
+  },
+}
+
+type PersistedLearningAnalytics = {
+  timeByLessonDay?: unknown
+  timeByDate?: unknown
+  visitsByLessonDay?: unknown
+}
+
+export type LearningAnalyticsStore = {
+  timeByLessonDay: Record<number, number>
+  timeByDate: Record<string, number>
+  visitsByLessonDay: Record<number, number>
+  lastActiveRoute: string | null
+  lastLessonDay: number | null
+  sessionStartedAt: number | null
+  isPaused: boolean
+  hasHydrated: boolean
+  hydrate: () => void
+  startTrackingRoute: (route: string, now?: number) => void
+  stopTracking: (now?: number) => void
+  pauseTracking: (now?: number) => void
+  resumeTracking: (now?: number) => void
+  clearAnalytics: () => void
+  totalLearningMs: () => number
+  todayLearningMs: (now?: Date) => number
+  weekLearningMs: (now?: Date) => number
+  getLast7Days: (now?: Date) => Array<{ date: string; ms: number }>
+  studyStreakDays: (minimumMinutes?: number, now?: Date) => number
+}
+
+function asDayKey(date: Date): string {
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, '0')
+  const day = `${date.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function parsePositiveRecord(value: unknown, integerKeys = false): Record<string, number> {
+  if (!value || typeof value !== 'object') return {}
+
+  return Object.entries(value as Record<string, unknown>).reduce<Record<string, number>>(
+    (acc, [key, raw]) => {
+      const numeric = typeof raw === 'number' ? raw : Number(raw)
+      if (!Number.isFinite(numeric) || numeric < 0) return acc
+      if (integerKeys && (!/^\d+$/.test(key) || Number(key) < 1)) return acc
+      acc[key] = Math.floor(numeric)
+      return acc
+    },
+    {},
+  )
+}
+
+function normalizePersistedState(
+  state: unknown,
+): Pick<LearningAnalyticsStore, 'timeByLessonDay' | 'timeByDate' | 'visitsByLessonDay'> {
+  const maybe = (state || {}) as PersistedLearningAnalytics
+
+  return {
+    timeByLessonDay: parsePositiveRecord(maybe.timeByLessonDay, true) as Record<number, number>,
+    timeByDate: parsePositiveRecord(maybe.timeByDate),
+    visitsByLessonDay: parsePositiveRecord(maybe.visitsByLessonDay, true) as Record<number, number>,
+  }
+}
+
+function parseLessonDayFromRoute(route: string): number | null {
+  const match = route.match(/^\/lesson\/(\d+)$/)
+  if (!match) return null
+  const asNumber = Number(match[1])
+  return Number.isInteger(asNumber) && asNumber > 0 ? asNumber : null
+}
+
+function addElapsed(
+  elapsedMs: number,
+  day: number | null,
+  now: Date,
+  state: Pick<LearningAnalyticsStore, 'timeByDate' | 'timeByLessonDay'>,
+): Pick<LearningAnalyticsStore, 'timeByDate' | 'timeByLessonDay'> {
+  if (elapsedMs <= 0) return state
+  const dayKey = asDayKey(now)
+
+  return {
+    timeByDate: {
+      ...state.timeByDate,
+      [dayKey]: (state.timeByDate[dayKey] || 0) + elapsedMs,
+    },
+    timeByLessonDay:
+      day === null
+        ? state.timeByLessonDay
+        : {
+            ...state.timeByLessonDay,
+            [day]: (state.timeByLessonDay[day] || 0) + elapsedMs,
+          },
+  }
+}
+
+function streakDaysForThreshold(
+  timeByDate: Record<string, number>,
+  minimumMinutes: number,
+  now: Date,
+): number {
+  const thresholdMs = minimumMinutes * 60 * 1000
+  const cursor = new Date(now)
+  let streak = 0
+
+  while (true) {
+    const key = asDayKey(cursor)
+    if ((timeByDate[key] || 0) < thresholdMs) {
+      break
+    }
+    streak += 1
+    cursor.setTime(cursor.getTime() - DAY_IN_MS)
+  }
+
+  return streak
+}
+
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '0m'
+
+  const totalMinutes = Math.floor(ms / (60 * 1000))
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+
+  if (hours <= 0) return `${minutes}m`
+  if (minutes <= 0) return `${hours}h`
+  return `${hours}h ${minutes}m`
+}
+
+export const useLearningAnalyticsStore = create<LearningAnalyticsStore>()(
+  persist(
+    (set, get) => ({
+      timeByLessonDay: {},
+      timeByDate: {},
+      visitsByLessonDay: {},
+      lastActiveRoute: null,
+      lastLessonDay: null,
+      sessionStartedAt: null,
+      isPaused: false,
+      hasHydrated: false,
+      hydrate: () => {
+        if (get().hasHydrated) return
+        useLearningAnalyticsStore.persist.rehydrate()
+      },
+      startTrackingRoute: (route, now = Date.now()) => {
+        if (!route) return
+
+        set((state) => {
+          let nextState = state
+
+          if (!state.isPaused && state.lastActiveRoute && state.sessionStartedAt !== null) {
+            const elapsedMs = Math.max(0, now - state.sessionStartedAt)
+            const merged = addElapsed(elapsedMs, state.lastLessonDay, new Date(now), state)
+            nextState = { ...state, ...merged }
+          }
+
+          const lessonDay = parseLessonDayFromRoute(route)
+          return {
+            ...nextState,
+            lastActiveRoute: route,
+            lastLessonDay: lessonDay,
+            sessionStartedAt: now,
+            isPaused: false,
+            visitsByLessonDay:
+              lessonDay === null
+                ? nextState.visitsByLessonDay
+                : {
+                    ...nextState.visitsByLessonDay,
+                    [lessonDay]: (nextState.visitsByLessonDay[lessonDay] || 0) + 1,
+                  },
+          }
+        })
+      },
+      stopTracking: (now = Date.now()) => {
+        set((state) => {
+          if (state.sessionStartedAt === null || state.isPaused) {
+            return {
+              ...state,
+              sessionStartedAt: null,
+            }
+          }
+
+          const elapsedMs = Math.max(0, now - state.sessionStartedAt)
+          const merged = addElapsed(elapsedMs, state.lastLessonDay, new Date(now), state)
+          return {
+            ...state,
+            ...merged,
+            sessionStartedAt: null,
+          }
+        })
+      },
+      pauseTracking: (now = Date.now()) => {
+        get().stopTracking(now)
+        set({ isPaused: true })
+      },
+      resumeTracking: (now = Date.now()) => {
+        const route = get().lastActiveRoute
+        if (!route) return
+        set({
+          isPaused: false,
+          sessionStartedAt: now,
+        })
+      },
+      clearAnalytics: () => {
+        set({
+          timeByLessonDay: {},
+          timeByDate: {},
+          visitsByLessonDay: {},
+          lastActiveRoute: null,
+          lastLessonDay: null,
+          sessionStartedAt: null,
+          isPaused: false,
+        })
+      },
+      totalLearningMs: () => Object.values(get().timeByDate).reduce((sum, value) => sum + value, 0),
+      todayLearningMs: (now = new Date()) => get().timeByDate[asDayKey(now)] || 0,
+      weekLearningMs: (now = new Date()) =>
+        get()
+          .getLast7Days(now)
+          .reduce((sum, item) => sum + item.ms, 0),
+      getLast7Days: (now = new Date()) => {
+        return Array.from({ length: 7 }, (_, index) => {
+          const date = new Date(now)
+          date.setTime(date.getTime() - (6 - index) * DAY_IN_MS)
+          const key = asDayKey(date)
+          return {
+            date: key,
+            ms: get().timeByDate[key] || 0,
+          }
+        })
+      },
+      studyStreakDays: (minimumMinutes = DEFAULT_STREAK_MINUTES, now = new Date()) =>
+        streakDaysForThreshold(get().timeByDate, minimumMinutes, now),
+    }),
+    {
+      name: STORAGE_KEY,
+      version: 1,
+      storage: createJSONStorage(() => safeStorage),
+      partialize: (state) => ({
+        timeByLessonDay: state.timeByLessonDay,
+        timeByDate: state.timeByDate,
+        visitsByLessonDay: state.visitsByLessonDay,
+      }),
+      migrate: (persistedState) => normalizePersistedState(persistedState),
+      skipHydration: true,
+      onRehydrateStorage: () => (state) => {
+        if (!state) return
+        useLearningAnalyticsStore.setState({ hasHydrated: true })
+      },
+    },
+  ),
+)

--- a/src/styles/progress.css
+++ b/src/styles/progress.css
@@ -337,3 +337,31 @@
 .preferences-toggle small {
   color: var(--text-muted);
 }
+
+.learning-analytics-card {
+  margin-top: 2rem;
+  padding: 1.25rem;
+  border: 1px solid var(--border-card);
+  border-radius: var(--radius-lg);
+  background: var(--bg-card);
+}
+
+.learning-analytics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.learning-analytics-chart {
+  width: 100%;
+  margin-top: 1rem;
+}
+
+.learning-analytics-bar {
+  fill: rgba(99, 102, 241, 0.65);
+}
+
+.learning-analytics-label {
+  font-size: 0.625rem;
+  fill: var(--text-muted);
+}

--- a/tests/e2e/learning-analytics.spec.ts
+++ b/tests/e2e/learning-analytics.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test'
+
+const STORAGE_KEY = 'coding-for-mba-learning-analytics'
+
+test('records study time when navigating away from a lesson', async ({ page }) => {
+  await page.goto('/#/lesson/1')
+  await page.waitForTimeout(1100)
+  await page.goto('/#/progress')
+
+  const persisted = await page.evaluate((key) => window.localStorage.getItem(key), STORAGE_KEY)
+  expect(persisted).toBeTruthy()
+
+  const parsed = JSON.parse(persisted || '{}') as {
+    state?: { timeByLessonDay?: Record<string, number> }
+  }
+
+  const lessonMs = parsed.state?.timeByLessonDay?.['1'] || 0
+  expect(lessonMs).toBeGreaterThan(500)
+})


### PR DESCRIPTION
### Motivation

- Provide local-only learning analytics to record time-on-page per lesson and aggregate summaries for user insights while keeping all data on-device.
- Reuse the existing progress tracking surface (`progressStore` / `progressTracker`) and surface a lightweight weekly summary and streak without heavy dependencies.

### Description

- Added a persisted zustand store `src/stores/learningAnalyticsStore.ts` that records `timeByLessonDay`, `timeByDate`, `visitsByLessonDay`, and session state (`lastActiveRoute`, `lastLessonDay`, `sessionStartedAt`, `isPaused`) and exposes selectors like `totalLearningMs`, `todayLearningMs`, `weekLearningMs`, `getLast7Days`, `studyStreakDays`, and `formatDuration`.
- Implemented `src/hooks/useLearningAnalytics.ts` which hydrates the store and starts/stops tracking on route changes, listens to `document.visibilitychange` to pause/resume, flushes on `beforeunload`, and uses a subscriber guard (`activeSubscribers`) to avoid duplicate listeners / double-counting (handling React StrictMode re-mounts).
- Wired the hook into the app by calling `useLearningAnalytics(location.pathname)` in `src/App.tsx` so route transitions are tracked globally.
- Augmented `src/pages/ProgressDashboard.tsx` with a compact Learning Analytics card showing total / this week / today study time, a study streak computed from `timeByDate` (default 5 min threshold), completion streak (via existing `getStreakDays`), and a lightweight 7-day SVG bar chart; added corresponding styles to `src/styles/progress.css`.
- Added tests: unit tests for the store and helpers in `src/stores/__tests__/learningAnalyticsStore.test.ts` and a lightweight Playwright e2e test `tests/e2e/learning-analytics.spec.ts` that navigates to a lesson and verifies persisted time increments.

### Testing

- Ran static typecheck with `npm run typecheck` and it succeeded.
- Ran unit tests with Vitest: `npm run test -- src/stores/__tests__/learningAnalyticsStore.test.ts` and all tests passed.
- Attempted the Playwright e2e test with `npx playwright test tests/e2e/learning-analytics.spec.ts --project=chromium` which failed in this environment because Playwright browser binaries are not installed; running `npx playwright install` locally/CI will resolve this and allow the e2e to run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997fdf7dad48330b9ebe4621ef57482)