### PR TITLE
Add "Continue learning" banner to Home linking to last visited lesson

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -39,6 +39,9 @@ export default function Home() {
   const phases = getAllPhases()
   const lastVisitedDay = getLastVisited()
   const lastVisitedLesson = lastVisitedDay ? (getLesson(lastVisitedDay) ?? null) : null
+  const lastVisitedPhase = lastVisitedLesson
+    ? phases.find((phase) => phase.phase === lastVisitedLesson.phase)
+    : null
   const completedCount = getCompletedCount()
   const totalLessons = phases.reduce((sum, p) => sum + getLessonsByPhase(p.phase).length, 0)
   const prefersReducedMotion = useReducedMotion()
@@ -57,6 +60,20 @@ export default function Home() {
       {/* Hero */}
       <motion.section className="hero" style={{ y: heroY }}>
         <div className="hero-badge">📚 Self-Study Curriculum</div>
+        {lastVisitedLesson && (
+          <article className="continue-banner" aria-label="Continue learning">
+            <p className="continue-banner-title">Continue learning</p>
+            <p className="continue-banner-subtitle">
+              {lastVisitedLesson.title}
+              {lastVisitedPhase
+                ? ` • Phase ${lastVisitedPhase.phase}: ${lastVisitedPhase.title}`
+                : ''}
+            </p>
+            <Link className="continue-banner-cta" to={`/lesson/${lastVisitedLesson.day}`}>
+              Resume Day {lastVisitedLesson.day}
+            </Link>
+          </article>
+        )}
         <h1>
           Master <span className="gradient-text">Technical Skills</span>
           <br />
@@ -95,18 +112,11 @@ export default function Home() {
         <div className="hero-cta">
           <Link to="/lesson/1">Start Learning →</Link>
         </div>
-        {(lastVisitedLesson || completedCount > 0) && (
+        {completedCount > 0 && (
           <div className="hero-continue">
-            {lastVisitedLesson && (
-              <Link to={`/lesson/${lastVisitedLesson.day}`}>
-                ▶ Continue: Day {lastVisitedLesson.day}
-              </Link>
-            )}
-            {completedCount > 0 && (
-              <Link to="/progress">
-                📊 {completedCount}/{totalLessons} Complete
-              </Link>
-            )}
+            <Link to="/progress">
+              📊 {completedCount}/{totalLessons} Complete
+            </Link>
           </div>
         )}
       </motion.section>

--- a/src/pages/__tests__/Home.test.tsx
+++ b/src/pages/__tests__/Home.test.tsx
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import Home from '../Home'
+
+const { mockGetLastVisited, mockGetCompletedCount } = vi.hoisted(() => ({
+  mockGetLastVisited: vi.fn(),
+  mockGetCompletedCount: vi.fn(() => 0),
+}))
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('motion/react', () => ({
+  motion: {
+    section: ({ children, ...props }: React.HTMLAttributes<HTMLElement>) => (
+      <section {...props}>{children}</section>
+    ),
+  },
+  useReducedMotion: () => true,
+  useScroll: () => ({ scrollYProgress: 0 }),
+  useTransform: () => 0,
+}))
+
+vi.mock('../../utils/seoSchemas', () => ({
+  buildWebSiteSchema: () => ({}),
+  buildCourseSchema: () => ({}),
+}))
+
+vi.mock('../../components/SEOHead', () => ({ default: () => null }))
+vi.mock('../../components/AnimatedCounter', () => ({
+  default: ({ value }: { value: number }) => <>{value}</>,
+}))
+vi.mock('../../components/ProgressBar', () => ({ default: () => null }))
+
+vi.mock('../../utils/progressTracker', () => ({
+  getLastVisited: mockGetLastVisited,
+  getCompletedCount: mockGetCompletedCount,
+  getCompletedForPhase: () => [],
+}))
+
+vi.mock('../../utils/contentLoader', () => ({
+  getAllPhases: () => [
+    {
+      phase: 2,
+      title: 'Data Foundations',
+      totalDuration: 120,
+      difficulty: 'beginner',
+    },
+  ],
+  getLessonsByPhase: () => [{ day: 12 }],
+  getLesson: (day: number) =>
+    day === 12
+      ? {
+          day: 12,
+          title: 'SQL Basics',
+          phase: 2,
+        }
+      : null,
+  difficultyConfig: {
+    beginner: { label: 'Beginner', color: '#000', bg: '#fff' },
+  },
+  phaseIcons: ['📘'],
+}))
+
+describe('Home continue banner', () => {
+  let container: HTMLDivElement | null = null
+  let root: Root | null = null
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root!.unmount()
+      })
+    }
+    if (container) {
+      document.body.removeChild(container)
+    }
+    vi.clearAllMocks()
+  })
+
+  it('renders resume banner when a last visited lesson exists', async () => {
+    mockGetLastVisited.mockReturnValue(12)
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    const mountedRoot = root
+
+    await act(async () => {
+      mountedRoot.render(<Home />)
+    })
+
+    expect(container.textContent).toContain('Continue learning')
+    expect(container.textContent).toContain('SQL Basics')
+    expect(container.textContent).toContain('Phase 2: Data Foundations')
+
+    const resumeLink = container.querySelector('.continue-banner-cta') as HTMLAnchorElement
+    expect(resumeLink).not.toBeNull()
+    expect(resumeLink.getAttribute('href')).toBe('/lesson/12')
+    expect(resumeLink.textContent).toContain('Resume Day 12')
+  })
+})

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -51,6 +51,55 @@
   line-height: 1.7;
 }
 
+.continue-banner {
+  margin: 0 auto 1.5rem;
+  max-width: 640px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-active);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+  text-align: left;
+}
+
+.continue-banner-title {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--accent-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.continue-banner-subtitle {
+  margin: 0.5rem 0 0.875rem;
+  color: var(--text-secondary);
+  font-size: 0.9375rem;
+  line-height: 1.5;
+}
+
+.continue-banner-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background: var(--gradient-hero);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.875rem;
+  text-decoration: none;
+}
+
+.continue-banner-cta:hover {
+  color: #fff;
+}
+
+.continue-banner-cta:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
 .hero-stats {
   display: flex;
   justify-content: center;
@@ -230,4 +279,18 @@
 .section-header p {
   color: var(--text-secondary);
   font-size: 0.9375rem;
+}
+
+@media (max-width: 640px) {
+  .continue-banner {
+    padding: 0.875rem;
+  }
+
+  .continue-banner-subtitle {
+    font-size: 0.875rem;
+  }
+
+  .continue-banner-cta {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
### Motivation
- Surface a "Continue where you left off" affordance on the Home page by showing the last visited lesson and a direct resume CTA when progress exists.
- Provide contextual info (lesson title and phase) using the existing `contentLoader` so users know what they will resume.
- Keep the existing progress summary separate so users can still open the Progress dashboard.

### Description
- Render a new banner in `src/pages/Home.tsx` when `getLastVisited()` returns a lesson, computing the lesson and its phase and exposing a CTA `Resume Day X` that links to `/lesson/{day}` and includes `aria-label="Continue learning"` for accessibility.
- Add responsive and accessible styles in `src/styles/home.css` for the banner, including touch-friendly sizing, focus-visible ring for keyboard users, and a full-width CTA on small screens.
- Simplify the hero's continue area to keep the progress pill (`📊 x/y Complete`) separate from the resume banner.
- Add a unit test `src/pages/__tests__/Home.test.tsx` that mocks `getLastVisited()`/`contentLoader` and verifies the banner title, subtitle and link render correctly.

### Testing
- Ran `npm run test -- src/pages/__tests__/Home.test.tsx` and the new test passed (1 test passed).
- Ran `npm run typecheck` and the TypeScript build completed without errors.
- Attempted a Playwright screenshot to verify mobile layout but Chromium crashed in this environment (SIGSEGV), so no visual artifact was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998017bc6d48330a677ec3173d3d488)