### PR TITLE
Add global keyboard shortcuts overlay with centralized registry

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Sidebar from './components/Sidebar'
 import SkipToContent from './components/SkipToContent'
 import ScrollProgress from './components/ScrollProgress'
 import MobileNav from './components/MobileNav'
+import KeyboardShortcutsOverlay from './components/KeyboardShortcutsOverlay'
 import { PageSkeleton } from './components/Skeleton'
 import { ThemeProvider } from './context/ThemeProvider'
 import { preloadSearchIndex } from './utils/searchIndex'
@@ -94,6 +95,7 @@ export default function App() {
           </Suspense>
         </main>
         <MobileNav />
+        <KeyboardShortcutsOverlay />
       </div>
     </ThemeProvider>
   )

--- a/src/components/KeyboardShortcutsOverlay.tsx
+++ b/src/components/KeyboardShortcutsOverlay.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { SHORTCUTS, isTypingInEditableElement, type ShortcutDefinition } from '../utils/shortcuts'
+
+const focusableSelector =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+export default function KeyboardShortcutsOverlay() {
+  const [isOpen, setIsOpen] = useState(false)
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  const shortcutsByScope = useMemo(() => {
+    const grouped = SHORTCUTS.reduce<Record<string, ShortcutDefinition[]>>((acc, shortcut) => {
+      const existing = acc[shortcut.scope] ?? []
+      acc[shortcut.scope] = [...existing, shortcut]
+      return acc
+    }, {})
+
+    return ['Global', 'Search', 'Lesson'].flatMap((scope) =>
+      grouped[scope] ? [[scope, grouped[scope]] as const] : [],
+    )
+  }, [])
+
+  useEffect(() => {
+    const handleGlobalKeyDown = (event: KeyboardEvent) => {
+      if (event.key === '?' && !event.ctrlKey && !event.metaKey && !event.altKey) {
+        if (isTypingInEditableElement(event.target)) {
+          return
+        }
+        event.preventDefault()
+        setIsOpen(true)
+      }
+    }
+
+    window.addEventListener('keydown', handleGlobalKeyDown)
+    return () => window.removeEventListener('keydown', handleGlobalKeyDown)
+  }, [])
+
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+
+    const priorFocus = document.activeElement as HTMLElement | null
+    const closeButton =
+      dialogRef.current?.querySelector<HTMLButtonElement>('[data-shortcuts-close]')
+    closeButton?.focus()
+
+    const handleOpenKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setIsOpen(false)
+        return
+      }
+
+      if (event.key !== 'Tab' || !dialogRef.current) {
+        return
+      }
+
+      const focusables = Array.from(
+        dialogRef.current.querySelectorAll<HTMLElement>(focusableSelector),
+      )
+      if (focusables.length === 0) {
+        event.preventDefault()
+        return
+      }
+
+      const first = focusables[0]!
+      const last = focusables[focusables.length - 1]!
+      const active = document.activeElement
+
+      if (event.shiftKey && active === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    window.addEventListener('keydown', handleOpenKeyDown)
+    return () => {
+      window.removeEventListener('keydown', handleOpenKeyDown)
+      priorFocus?.focus()
+    }
+  }, [isOpen])
+
+  if (!isOpen) {
+    return null
+  }
+
+  return (
+    <div
+      className="shortcut-overlay-backdrop"
+      role="presentation"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          setIsOpen(false)
+        }
+      }}
+    >
+      <div
+        ref={dialogRef}
+        className="shortcut-overlay-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="keyboard-shortcuts-title"
+      >
+        <div className="shortcut-overlay-header">
+          <h2 id="keyboard-shortcuts-title">Keyboard shortcuts</h2>
+          <button
+            type="button"
+            className="shortcut-overlay-close"
+            data-shortcuts-close
+            onClick={() => setIsOpen(false)}
+            aria-label="Close keyboard shortcuts"
+          >
+            Esc
+          </button>
+        </div>
+
+        {shortcutsByScope.map(([scope, shortcuts]) => (
+          <section key={scope} className="shortcut-overlay-group" aria-label={scope}>
+            <h3>{scope}</h3>
+            <ul>
+              {shortcuts.map((shortcut) => (
+                <li key={`${scope}-${shortcut.keys}-${shortcut.description}`}>
+                  <span className="shortcut-overlay-keys">
+                    <kbd>{shortcut.keys}</kbd>
+                  </span>
+                  <span>{shortcut.description}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type FormEvent } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useTheme } from '../context/useTheme'
 import { toastInfo } from '../utils/toast'
+import { isTypingInEditableElement } from '../utils/shortcuts'
 
 interface NavbarProps {
   onToggleSidebar: () => void
@@ -21,13 +22,7 @@ export default function Navbar({ onToggleSidebar }: NavbarProps) {
       if (location.pathname === '/search') return
 
       if (event.key === '/' && !event.metaKey && !event.ctrlKey && !event.altKey) {
-        const target = event.target as HTMLElement | null
-        if (
-          target?.tagName === 'INPUT' ||
-          target?.tagName === 'TEXTAREA' ||
-          target?.isContentEditable
-        )
-          return
+        if (isTypingInEditableElement(event.target)) return
 
         event.preventDefault()
         inputRef.current?.focus()

--- a/src/components/__tests__/KeyboardShortcutsOverlay.test.tsx
+++ b/src/components/__tests__/KeyboardShortcutsOverlay.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import KeyboardShortcutsOverlay from '../KeyboardShortcutsOverlay'
+
+describe('KeyboardShortcutsOverlay', () => {
+  let container: HTMLDivElement
+  let root: ReturnType<typeof createRoot>
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    document.body.removeChild(container)
+  })
+
+  it('opens with ? and renders grouped shortcuts', async () => {
+    await act(async () => {
+      root.render(<KeyboardShortcutsOverlay />)
+    })
+
+    expect(container.querySelector('[role="dialog"]')).toBeNull()
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '?' }))
+    })
+
+    const dialog = container.querySelector('[role="dialog"]')
+    expect(dialog).not.toBeNull()
+    expect(container.textContent).toContain('Keyboard shortcuts')
+    expect(container.textContent).toContain('Global')
+    expect(container.textContent).toContain('Search')
+    expect(container.textContent).toContain('Lesson')
+  })
+
+  it('does not open when typing and closes with Escape', async () => {
+    await act(async () => {
+      root.render(
+        <>
+          <input aria-label="editor" />
+          <KeyboardShortcutsOverlay />
+        </>,
+      )
+    })
+
+    const input = container.querySelector('input') as HTMLInputElement
+    input.focus()
+
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: '?', bubbles: true }))
+    })
+
+    expect(container.querySelector('[role="dialog"]')).toBeNull()
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '?' }))
+    })
+
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull()
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    })
+
+    expect(container.querySelector('[role="dialog"]')).toBeNull()
+  })
+})

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -35,6 +35,7 @@ import PrerequisitePills from '../components/PrerequisitePills'
 import RelatedLessons from '../components/RelatedLessons'
 import { useSwipe } from '../hooks/useSwipe'
 import { toastInfo, toastSuccess } from '../utils/toast'
+import { isTypingInEditableElement } from '../utils/shortcuts'
 import {
   triggerSparkle,
   triggerPhaseUnlockConfetti,
@@ -127,9 +128,7 @@ export default function Lesson() {
   // Keyboard shortcuts: ← prev, → next
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
-        return
+      if (isTypingInEditableElement(e.target)) return
       if (e.key === 'ArrowLeft' && prev) {
         navigate(`/lesson/${prev.day}`)
       } else if (e.key === 'ArrowRight' && next) {

--- a/src/styles/ux-features.css
+++ b/src/styles/ux-features.css
@@ -459,3 +459,85 @@
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+/* ---------- Keyboard Shortcuts Overlay ---------- */
+.shortcut-overlay-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.shortcut-overlay-dialog {
+  width: min(640px, 100%);
+  max-height: min(85vh, 700px);
+  overflow-y: auto;
+  background: var(--bg-card);
+  border: 1px solid var(--border-card);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-elevated);
+  padding: 1.25rem;
+}
+
+.shortcut-overlay-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.shortcut-overlay-header h2 {
+  margin: 0;
+}
+
+.shortcut-overlay-close {
+  border: 1px solid var(--border-card);
+  border-radius: var(--radius-sm);
+  padding: 0.35rem 0.6rem;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.shortcut-overlay-group + .shortcut-overlay-group {
+  margin-top: 1rem;
+}
+
+.shortcut-overlay-group h3 {
+  margin: 0 0 0.4rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.shortcut-overlay-group ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.shortcut-overlay-group li {
+  display: grid;
+  grid-template-columns: 92px 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.4rem 0;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.shortcut-overlay-keys kbd {
+  display: inline-block;
+  min-width: 28px;
+  text-align: center;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-card);
+  border-radius: 6px;
+  padding: 0.2rem 0.45rem;
+  font-family: inherit;
+  font-size: 0.82rem;
+}

--- a/src/utils/shortcuts.ts
+++ b/src/utils/shortcuts.ts
@@ -1,0 +1,53 @@
+export type ShortcutScope = 'Global' | 'Search' | 'Lesson'
+
+export interface ShortcutDefinition {
+  keys: string
+  description: string
+  scope: ShortcutScope
+}
+
+export const SHORTCUTS: ShortcutDefinition[] = [
+  {
+    keys: '?',
+    description: 'Open keyboard shortcuts overlay',
+    scope: 'Global',
+  },
+  {
+    keys: '/',
+    description: 'Focus search input in the navbar',
+    scope: 'Search',
+  },
+  {
+    keys: 'Esc',
+    description: 'Close the search input (when focused)',
+    scope: 'Search',
+  },
+  {
+    keys: 'Esc',
+    description: 'Close keyboard shortcuts overlay',
+    scope: 'Global',
+  },
+  {
+    keys: '←',
+    description: 'Go to previous lesson',
+    scope: 'Lesson',
+  },
+  {
+    keys: '→',
+    description: 'Go to next lesson',
+    scope: 'Lesson',
+  },
+]
+
+export const isTypingInEditableElement = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+
+  return (
+    target.tagName === 'INPUT' ||
+    target.tagName === 'TEXTAREA' ||
+    target.isContentEditable ||
+    target.getAttribute('role') === 'textbox'
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a single source of truth for keyboard shortcuts and a discoverable UI so users can learn available hotkeys quickly. 
- Make shortcut handling consistent across the app and avoid accidental triggers while typing in inputs or contenteditable regions.

### Description
- Add a centralized registry at `src/utils/shortcuts.ts` that exports `SHORTCUTS` (objects with `keys`, `description`, `scope`) and the helper `isTypingInEditableElement`.
- Implement `src/components/KeyboardShortcutsOverlay.tsx`, a modal that opens on `?`, is `aria-modal`, traps Tab focus simply, closes on `Esc` or backdrop click, and renders shortcuts grouped by scope.
- Integrate the overlay globally by mounting `<KeyboardShortcutsOverlay />` in `src/App.tsx` so it works across routes.
- Update `src/components/Navbar.tsx` and `src/pages/Lesson.tsx` to reuse `isTypingInEditableElement` for consistent typing-guard behavior, and add overlay styles in `src/styles/ux-features.css`.
- Add unit tests `src/components/__tests__/KeyboardShortcutsOverlay.test.tsx` covering open via `?`, typing guard, and `Esc` close behavior.

### Testing
- Ran type checking with `npm run typecheck`, which completed successfully.
- Ran the overlay unit tests with `npm test -- src/components/__tests__/KeyboardShortcutsOverlay.test.tsx`, and the test file passed (2 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699802a4cdac8330b693d17c9a2be07d)