### PR TITLE
UI polish: glass cards, hero gradient mesh, shimmer skeleton, and empty-state SVGs

### DIFF
--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -97,7 +97,7 @@ export default function Curriculum() {
 
           return (
             <motion.div
-              className="curriculum-phase"
+              className="curriculum-phase glass-card"
               key={phase.phase}
               variants={phaseVariants}
               transition={{ duration: prefersReducedMotion ? 0 : 0.28 }}

--- a/src/pages/Exercises.tsx
+++ b/src/pages/Exercises.tsx
@@ -10,7 +10,7 @@
 
 import { useState, useMemo } from 'react'
 import { Link } from 'react-router-dom'
-import { motion } from 'motion/react'
+import { motion, useReducedMotion } from 'motion/react'
 import SEOHead from '../components/SEOHead'
 import {
   getAllExercises,
@@ -35,6 +35,68 @@ import { useQuizStore } from '../stores/quizStore'
  *
  * @returns The rendered exercises page
  */
+
+function ExercisesEmptyIllustration({ reducedMotion }: { reducedMotion: boolean }) {
+  return (
+    <svg
+      className="empty-state-illustration"
+      viewBox="0 0 220 130"
+      role="img"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <defs>
+        <linearGradient id="exerciseEmptyGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="rgba(99,102,241,0.85)" />
+          <stop offset="100%" stopColor="rgba(14,165,233,0.75)" />
+        </linearGradient>
+      </defs>
+      <rect x="30" y="20" width="162" height="88" rx="12" fill="rgba(148,163,184,0.1)" />
+      <path
+        d="M56 49h110"
+        stroke="url(#exerciseEmptyGradient)"
+        strokeWidth="6"
+        strokeLinecap="round"
+      />
+      <path
+        d="M56 68h72"
+        stroke="url(#exerciseEmptyGradient)"
+        strokeWidth="6"
+        strokeLinecap="round"
+      />
+      <path
+        d="M56 87h92"
+        stroke="url(#exerciseEmptyGradient)"
+        strokeWidth="6"
+        strokeLinecap="round"
+      />
+      <circle
+        cx="164"
+        cy="78"
+        r="11"
+        fill="none"
+        stroke="url(#exerciseEmptyGradient)"
+        strokeWidth="4"
+      />
+      <path
+        d="M160 78l4 4 8-9"
+        fill="none"
+        stroke="url(#exerciseEmptyGradient)"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle
+        cx="44"
+        cy="34"
+        r="4"
+        fill="rgba(14,165,233,0.75)"
+        className={reducedMotion ? '' : 'empty-state-dot'}
+      />
+    </svg>
+  )
+}
+
 export default function Exercises() {
   const exercises = getAllExercises()
   const notebooks = getAllNotebooks()
@@ -42,6 +104,7 @@ export default function Exercises() {
   const [difficultyFilter, setDifficultyFilter] = useState('')
   const [searchQuery, setSearchQuery] = useState('')
   const [sortOrder, setSortOrder] = useState<'phase-asc' | 'phase-desc' | 'title-asc'>('phase-asc')
+  const prefersReducedMotion = !!useReducedMotion()
 
   const lowScoringTopics = useQuizStore((state) => state.getLowScoringTopics(60, 2).slice(0, 5))
 
@@ -237,7 +300,8 @@ export default function Exercises() {
       </motion.div>
 
       {filtered.length === 0 && (
-        <div className="exercises-empty">
+        <div className="exercises-empty glass-card">
+          <ExercisesEmptyIllustration reducedMotion={prefersReducedMotion} />
           <p>No exercises match your filters. Try adjusting your search.</p>
         </div>
       )}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -58,10 +58,10 @@ export default function Home() {
         breadcrumbs={[{ name: 'Home', url: '/' }]}
       />
       {/* Hero */}
-      <motion.section className="hero" style={{ y: heroY }}>
+      <motion.section className="hero glass-card" style={{ y: heroY }}>
         <div className="hero-badge">📚 Self-Study Curriculum</div>
         {lastVisitedLesson && (
-          <article className="continue-banner" aria-label="Continue learning">
+          <article className="continue-banner glass-card" aria-label="Continue learning">
             <p className="continue-banner-title">Continue learning</p>
             <p className="continue-banner-subtitle">
               {lastVisitedLesson.title}
@@ -142,7 +142,11 @@ export default function Home() {
             const completedInPhase = getCompletedForPhase(lessonDays)
 
             return (
-              <Link to={`/phase/${phase.phase}`} className="phase-card" key={phase.phase}>
+              <Link
+                to={`/phase/${phase.phase}`}
+                className="phase-card glass-card"
+                key={phase.phase}
+              >
                 <div className="phase-card-header">
                   <div className="phase-card-icon">{icon}</div>
                   <div className="phase-card-title">

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { useReducedMotion } from 'motion/react'
 import SEOHead from '../components/SEOHead'
 import { difficultyConfig } from '../utils/contentLoader'
 import Breadcrumb from '../components/Breadcrumb'
@@ -11,12 +12,59 @@ import {
   type SearchResult,
 } from '../utils/searchIndex'
 
+function SearchEmptyIllustration({ reducedMotion }: { reducedMotion: boolean }) {
+  return (
+    <svg
+      className="empty-state-illustration"
+      viewBox="0 0 220 130"
+      role="img"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <defs>
+        <linearGradient id="searchEmptyGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="rgba(99,102,241,0.9)" />
+          <stop offset="100%" stopColor="rgba(167,139,250,0.75)" />
+        </linearGradient>
+      </defs>
+      <rect x="34" y="36" width="150" height="58" rx="12" fill="rgba(148,163,184,0.12)" />
+      <circle
+        cx="88"
+        cy="65"
+        r="15"
+        fill="none"
+        stroke="url(#searchEmptyGradient)"
+        strokeWidth="5"
+      />
+      <line
+        x1="99"
+        y1="76"
+        x2="118"
+        y2="95"
+        stroke="url(#searchEmptyGradient)"
+        strokeWidth="5"
+        strokeLinecap="round"
+      />
+      <line x1="129" y1="58" x2="170" y2="58" className={reducedMotion ? '' : 'empty-state-line'} />
+      <line x1="129" y1="72" x2="162" y2="72" className={reducedMotion ? '' : 'empty-state-line'} />
+      <circle
+        cx="174"
+        cy="34"
+        r="4"
+        fill="rgba(99,102,241,0.65)"
+        className={reducedMotion ? '' : 'empty-state-dot'}
+      />
+    </svg>
+  )
+}
+
 export default function SearchResults() {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
   const queryFromUrl = searchParams.get('q') ?? ''
   const [query, setQuery] = useState(queryFromUrl)
   const inputRef = useRef<HTMLInputElement>(null)
+  const prefersReducedMotion = !!useReducedMotion()
 
   useEffect(() => {
     setQuery(queryFromUrl)
@@ -141,12 +189,14 @@ export default function SearchResults() {
           })}
         </div>
       ) : query.trim().length >= 2 ? (
-        <div className="search-empty-page">
+        <div className="search-empty-page glass-card">
+          <SearchEmptyIllustration reducedMotion={prefersReducedMotion} />
           <p>No lessons matched your search.</p>
           <p>Try broader or different keywords.</p>
         </div>
       ) : (
-        <div className="search-empty-page">
+        <div className="search-empty-page glass-card">
+          <SearchEmptyIllustration reducedMotion={prefersReducedMotion} />
           <p>Type at least 2 characters to search.</p>
           <p>Shortcut: press "/" to focus this box and Esc to clear.</p>
         </div>

--- a/src/styles/curriculum.css
+++ b/src/styles/curriculum.css
@@ -27,6 +27,8 @@
 .curriculum-phase {
   position: relative;
   margin-bottom: 2.5rem;
+  border-radius: var(--radius-lg);
+  padding: 1rem 1rem 0.875rem;
 }
 
 .curriculum-phase::before {

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -3,12 +3,54 @@
 /* Hero Section */
 .hero {
   position: relative;
+  overflow: hidden;
+  isolation: isolate;
   padding: 4rem 2rem 3rem;
   text-align: center;
   margin-bottom: 3rem;
   background: var(--gradient-glow);
   border-radius: var(--radius-xl);
   border: 1px solid var(--border-subtle);
+}
+
+.hero::before,
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: -35% -15%;
+  pointer-events: none;
+  z-index: -1;
+  opacity: 0.4;
+  background-image:
+    radial-gradient(circle at 20% 25%, rgba(99, 102, 241, 0.35), transparent 45%),
+    radial-gradient(circle at 78% 20%, rgba(139, 92, 246, 0.3), transparent 42%),
+    radial-gradient(circle at 65% 80%, rgba(59, 130, 246, 0.28), transparent 46%);
+  animation: heroMeshFloat 16s ease-in-out infinite alternate;
+}
+
+.hero::after {
+  opacity: 0.28;
+  filter: blur(38px);
+  animation-duration: 23s;
+  animation-direction: alternate-reverse;
+}
+
+@keyframes heroMeshFloat {
+  from {
+    transform: translate3d(-2%, 0, 0) scale(1);
+  }
+
+  to {
+    transform: translate3d(2%, -3%, 0) scale(1.06);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero::before,
+  .hero::after {
+    animation: none;
+    transform: none;
+  }
 }
 
 .hero-badge {

--- a/src/styles/ux-features.css
+++ b/src/styles/ux-features.css
@@ -64,15 +64,25 @@
 
 /* ---------- Skeleton Shimmer ---------- */
 .skeleton {
-  background: linear-gradient(
-    90deg,
-    var(--bg-card) 25%,
-    var(--bg-card-hover) 50%,
-    var(--bg-card) 75%
-  );
-  background-size: 200% 100%;
-  animation: shimmer 1.5s infinite ease-in-out;
+  position: relative;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--bg-card) 78%, white 22%);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
+}
+
+.skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    110deg,
+    transparent 20%,
+    color-mix(in srgb, var(--bg-card-hover) 45%, white 55%) 45%,
+    transparent 72%
+  );
+  transform: translateX(-130%);
+  animation: skeletonShimmer 1.4s infinite;
 }
 
 .skeleton-text {
@@ -105,13 +115,58 @@
   padding: 0 var(--page-padding);
 }
 
-@keyframes shimmer {
+@keyframes skeletonShimmer {
   0% {
-    background-position: 200% 0;
+    transform: translateX(-130%);
   }
 
   100% {
-    background-position: -200% 0;
+    transform: translateX(130%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton::after {
+    animation: none;
+  }
+}
+
+/* ---------- Glassmorphism Utility ---------- */
+.glass-card {
+  position: relative;
+  background: color-mix(in srgb, var(--bg-card) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-card) 80%, white 20%);
+  box-shadow: var(--shadow-card);
+}
+
+@media (prefers-reduced-transparency: no-preference) {
+  :root:not([data-theme='light']) .glass-card {
+    background: color-mix(in srgb, var(--bg-card) 72%, transparent);
+    backdrop-filter: blur(12px) saturate(120%);
+    -webkit-backdrop-filter: blur(12px) saturate(120%);
+  }
+}
+
+/* ---------- Desktop Pointer Hover Glow ---------- */
+@media (hover: hover) and (pointer: fine) {
+  a,
+  button,
+  .interactive {
+    transition:
+      box-shadow var(--transition-fast),
+      transform var(--transition-fast);
+  }
+
+  a:hover,
+  button:hover,
+  .interactive:hover {
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-primary) 24%, transparent);
+  }
+
+  a:focus-visible,
+  button:focus-visible,
+  .interactive:focus-visible {
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-primary) 28%, transparent);
   }
 }
 
@@ -540,4 +595,53 @@
   padding: 0.2rem 0.45rem;
   font-family: inherit;
   font-size: 0.82rem;
+}
+
+/* ---------- Empty-state Illustrations ---------- */
+
+.empty-state-illustration {
+  width: min(220px, 100%);
+  height: auto;
+  margin: 0 auto 0.75rem;
+  display: block;
+}
+
+.empty-state-line {
+  stroke: rgba(148, 163, 184, 0.65);
+  stroke-width: 5;
+  stroke-linecap: round;
+  animation: emptyStatePulse 1.9s ease-in-out infinite;
+}
+
+.empty-state-dot {
+  animation: emptyStateFloat 2.4s ease-in-out infinite;
+}
+
+@keyframes emptyStatePulse {
+  0%,
+  100% {
+    opacity: 0.42;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes emptyStateFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-4px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .empty-state-line,
+  .empty-state-dot {
+    animation: none;
+  }
 }


### PR DESCRIPTION
### Motivation
- Add a subtle, modern visual polish (glassmorphism, gradient mesh, shimmer) to key surfaces while preserving accessibility and performance.
- Ensure new effects respect `prefers-reduced-motion` and users who request reduced transparency, and only enable heavier visual effects on desktop / dark theme where appropriate.

### Description
- Introduced a reusable `.glass-card` utility and pointer-only hover/focus glow in `src/styles/ux-features.css` with guards for `prefers-reduced-transparency` and theme scope to enable `backdrop-filter` only when safe.
- Replaced previous skeleton fill with a pseudo-element shimmer sweep in `src/styles/ux-features.css` while preserving the `Skeleton` component API in `src/components/Skeleton.tsx` and disabling animation for `prefers-reduced-motion` users.
- Added an animated gradient mesh background to the Home hero in `src/styles/home.css` with `prefers-reduced-motion` fallback off; applied `.glass-card` to the Home hero and continue-banner in `src/pages/Home.tsx`.
- Applied `.glass-card` styling to curriculum phase containers and adjusted `src/styles/curriculum.css` padding and radius for better card visuals; updated `src/pages/Curriculum.tsx` to use the utility.
- Added small inline SVG empty-state illustrations for Search Results and Exercises (components embedded in `src/pages/SearchResults.tsx` and `src/pages/Exercises.tsx`) with motion-safe CSS classes in `src/styles/ux-features.css` and reduced-motion fallbacks.

### Testing
- Ran static type checks with `npm run typecheck` which completed successfully after code changes.
- Ran unit tests `npm run test -- src/pages/__tests__/SearchResults.test.tsx src/pages/__tests__/Home.test.tsx` and all tests passed.
- Launched the dev server and captured a full-page screenshot of the Home page to validate visual changes (artifact: `artifacts/ui-polish-home.png`).
- Note: pre-commit hooks in the repository can run `typecheck` with staged file paths and may surface different execution behavior during a commit; the changes were validated by running `npm run typecheck` and the test suite directly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699804145a488330b7b199b5c265be5f)