### PR TITLE
Add local gamification store and fix pre-commit typecheck invocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
-      "npm run typecheck"
+      "sh -c 'npm run typecheck'"
     ],
     "*.{ts,tsx,js,jsx,css,md,json}": [
       "prettier --check"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { hydrateProgressStore } from './utils/progressTracker'
 import { hydrateQuizStore } from './stores/quizStore'
 import { useUserPreferencesStore } from './stores/userPreferencesStore'
 import { useLearningAnalytics } from './hooks/useLearningAnalytics'
+import { hydrateGamificationStore } from './stores/gamificationStore'
 
 const Home = lazy(() => import('./pages/Home'))
 const Lesson = lazy(() => import('./pages/Lesson'))
@@ -40,6 +41,7 @@ export default function App() {
     preloadSearchIndex()
     hydrateProgressStore()
     hydrateQuizStore()
+    hydrateGamificationStore()
   }, [])
 
   useEffect(() => {

--- a/src/components/ExerciseWidget.tsx
+++ b/src/components/ExerciseWidget.tsx
@@ -19,6 +19,7 @@ import { markExerciseComplete } from '../utils/exerciseProgress'
 import { triggerDayExercisesCompleteConfetti } from '../utils/confetti'
 import { toastSuccess } from '../utils/toast'
 import { useQuizStore } from '../stores/quizStore'
+import { useGamificationStore } from '../stores/gamificationStore'
 
 /**
  * Custom syntax highlighting theme for solution code display.
@@ -110,6 +111,7 @@ export default function ExerciseWidget({
 
   const handleExerciseMatch = useCallback(() => {
     if (!lessonDay) return
+    useGamificationStore.getState().awardExerciseCompletion(lessonDay, exerciseId)
     const completedAll = markExerciseComplete(lessonDay, exerciseId, totalExercisesForDay)
     if (completedAll) {
       triggerDayExercisesCompleteConfetti()
@@ -135,7 +137,8 @@ export default function ExerciseWidget({
       attemptedAt: Date
     }) => {
       setHasSubmitted(true)
-      useQuizStore.getState().recordAttempt({
+      const quizStore = useQuizStore.getState()
+      quizStore.recordAttempt({
         quizId,
         topic: quizTopic,
         correct: result.correct,
@@ -143,6 +146,11 @@ export default function ExerciseWidget({
         ...(result.output ? { output: result.output } : {}),
         ...(result.error ? { error: result.error } : {}),
       })
+
+      const stats = quizStore.getQuizStats(quizId)
+      if (result.correct && stats && stats.accuracy === 100 && stats.attempts >= 1) {
+        useGamificationStore.getState().awardPerfectQuiz(quizId)
+      }
     },
     [quizId, quizTopic],
   )

--- a/src/hooks/__tests__/usePyodide.test.tsx
+++ b/src/hooks/__tests__/usePyodide.test.tsx
@@ -50,7 +50,7 @@ describe('usePyodide Output Limit', () => {
                 }
                 return undefined
               }
-              return "result"
+              return 'result'
             }),
             setStdout: vi.fn().mockImplementation(({ batched }) => {
               window.__stdoutCallback = batched

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,6 +9,7 @@
  * @module pages/Home
  */
 
+import { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { motion, useReducedMotion, useScroll, useTransform } from 'motion/react'
 import SEOHead from '../components/SEOHead'
@@ -23,6 +24,7 @@ import {
 import { getLastVisited, getCompletedForPhase, getCompletedCount } from '../utils/progressTracker'
 import ProgressBar from '../components/ProgressBar'
 import AnimatedCounter from '../components/AnimatedCounter'
+import { useGamificationStore } from '../stores/gamificationStore'
 
 /**
  * Home page component displaying the curriculum landing page.
@@ -48,6 +50,15 @@ export default function Home() {
   const { scrollYProgress } = useScroll()
   const heroY = useTransform(scrollYProgress, [0, 0.35], [0, prefersReducedMotion ? 0 : -50])
 
+  const dailyChallenge = useGamificationStore((state) => state.dailyChallenge)
+  const refreshDailyChallenge = useGamificationStore((state) => state.refreshDailyChallenge)
+
+  useEffect(() => {
+    refreshDailyChallenge()
+  }, [refreshDailyChallenge])
+
+  const challengeLesson = getLesson(dailyChallenge.day)
+
   return (
     <div className="page-container">
       <SEOHead
@@ -71,6 +82,18 @@ export default function Home() {
             </p>
             <Link className="continue-banner-cta" to={`/lesson/${lastVisitedLesson.day}`}>
               Resume Day {lastVisitedLesson.day}
+            </Link>
+          </article>
+        )}
+
+        {challengeLesson && (
+          <article className="continue-banner glass-card" aria-label="Daily challenge">
+            <p className="continue-banner-title">Daily Challenge</p>
+            <p className="continue-banner-subtitle">
+              Day {challengeLesson.day}: {challengeLesson.title}
+            </p>
+            <Link className="continue-banner-cta" to={`/lesson/${challengeLesson.day}`}>
+              Take today&apos;s challenge
             </Link>
           </article>
         )}

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -36,6 +36,7 @@ import RelatedLessons from '../components/RelatedLessons'
 import { useSwipe } from '../hooks/useSwipe'
 import { toastInfo, toastSuccess } from '../utils/toast'
 import { isTypingInEditableElement } from '../utils/shortcuts'
+import { useGamificationStore } from '../stores/gamificationStore'
 import {
   triggerSparkle,
   triggerPhaseUnlockConfetti,
@@ -94,6 +95,9 @@ export default function Lesson() {
     if (nowComplete) {
       triggerSparkle()
       toastSuccess('Progress saved ✓')
+      if (!beforeCompleted.has(day)) {
+        useGamificationStore.getState().awardLessonCompletion(day)
+      }
 
       const afterCompleted = getCompletedLessons()
       const wasPhaseCompleted = lesson

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -8,12 +8,13 @@
  * @module pages/ProgressDashboard
  */
 
-import { useMemo, useState, useCallback } from 'react'
+import { useEffect, useMemo, useState, useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import SEOHead from '../components/SEOHead'
 import {
   getAllPhases,
   getLessonsByPhase,
+  getLesson,
   phaseIcons,
   difficultyConfig,
 } from '../utils/contentLoader'
@@ -29,6 +30,7 @@ import Breadcrumb from '../components/Breadcrumb'
 import AnimatedCounter from '../components/AnimatedCounter'
 import { useUserPreferencesStore } from '../stores/userPreferencesStore'
 import { formatDuration, useLearningAnalyticsStore } from '../stores/learningAnalyticsStore'
+import { ACHIEVEMENTS, useGamificationStore } from '../stores/gamificationStore'
 
 /**
  * Progress dashboard page component.
@@ -67,6 +69,19 @@ export default function ProgressDashboard() {
   const last7Days = useLearningAnalyticsStore((state) => state.getLast7Days())
 
   const chartMax = Math.max(1, ...last7Days.map((item) => item.ms))
+
+  const xpTotal = useGamificationStore((state) => state.xpTotal)
+  const achievementsUnlocked = useGamificationStore((state) => state.achievementsUnlocked)
+  const dailyChallenge = useGamificationStore((state) => state.dailyChallenge)
+  const refreshDailyChallenge = useGamificationStore((state) => state.refreshDailyChallenge)
+  const xpToNextMilestone = useGamificationStore((state) => state.xpToNextMilestone)
+  const milestoneProgress = xpToNextMilestone()
+  const earnedBadges = ACHIEVEMENTS.filter((badge) => achievementsUnlocked.includes(badge.id))
+  const challengeLesson = getLesson(dailyChallenge.day)
+
+  useEffect(() => {
+    refreshDailyChallenge()
+  }, [refreshDailyChallenge])
 
   const {
     theme,
@@ -123,6 +138,61 @@ export default function ProgressDashboard() {
       </div>
 
       <ProgressBar completed={completedLessons.length} total={totalLessons} />
+
+      <section className="gamification-card" aria-labelledby="gamification-heading">
+        <div className="section-header" style={{ marginTop: '2.5rem', marginBottom: '1rem' }}>
+          <h2 id="gamification-heading">Gamification</h2>
+          <p>XP, badges, and your daily challenge — saved only on this device.</p>
+        </div>
+
+        <div className="gamification-summary-grid">
+          <div className="progress-stat-big">
+            <span className="progress-stat-value">{xpTotal}</span>
+            <span className="progress-stat-label">XP Total</span>
+          </div>
+          <div className="progress-stat-big">
+            <span className="progress-stat-value">{earnedBadges.length}</span>
+            <span className="progress-stat-label">Badges Earned</span>
+          </div>
+          <div className="progress-stat-big">
+            <span className="progress-stat-value">{milestoneProgress.next ?? 'MAX'}</span>
+            <span className="progress-stat-label">Next XP Milestone</span>
+          </div>
+        </div>
+
+        <div className="xp-milestone-track" aria-label="XP progress to next badge">
+          <div className="xp-milestone-fill" style={{ width: `${milestoneProgress.percent}%` }} />
+        </div>
+
+        {challengeLesson && (
+          <div className="daily-challenge-card">
+            <div>
+              <h3>Daily Challenge</h3>
+              <p>
+                Day {challengeLesson.day}: {challengeLesson.title}
+              </p>
+            </div>
+            <Link className="continue-banner-cta" to={`/lesson/${challengeLesson.day}`}>
+              Start challenge
+            </Link>
+          </div>
+        )}
+
+        <div className="badge-grid">
+          {earnedBadges.length === 0 ? (
+            <p className="progress-stat-label">
+              No badges yet — complete your first lesson to begin.
+            </p>
+          ) : (
+            earnedBadges.map((badge) => (
+              <div className="badge-chip" key={badge.id} title={badge.description}>
+                <span aria-hidden="true">{badge.icon}</span>
+                <span>{badge.label}</span>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
 
       <section className="learning-analytics-card" aria-labelledby="learning-analytics-heading">
         <div className="section-header" style={{ marginTop: '2.5rem', marginBottom: '1rem' }}>

--- a/src/stores/__tests__/gamificationStore.test.ts
+++ b/src/stores/__tests__/gamificationStore.test.ts
@@ -1,0 +1,93 @@
+import { useGamificationStore } from '../gamificationStore'
+import { useProgressStore } from '../progressStore'
+
+vi.mock('../../utils/confetti', () => ({
+  triggerSparkle: vi.fn(),
+}))
+
+vi.mock('../../utils/toast', () => ({
+  toastSuccess: vi.fn(),
+}))
+
+describe('gamificationStore', () => {
+  beforeEach(() => {
+    useProgressStore.setState({
+      completedLessons: [],
+      completionDates: {},
+      lastVisitedLesson: null,
+      hasHydrated: true,
+    })
+
+    useGamificationStore.setState({
+      xpTotal: 0,
+      xpByDay: {},
+      achievementsUnlocked: [],
+      dailyChallenge: { day: 1, dateKey: '' },
+      leaderboard: [{ name: 'You', xp: 0, updatedAt: new Date(0).toISOString() }],
+      perfectQuizIds: [],
+      lessonXpAwardedDays: [],
+      completedExerciseIds: [],
+      lessonsCompletedByDate: {},
+      hasHydrated: true,
+    })
+  })
+
+  it('awards lesson XP only once per lesson day', () => {
+    useProgressStore.getState().markLessonComplete(5)
+    useGamificationStore.getState().awardLessonCompletion(5, new Date('2026-04-01T11:00:00'))
+    useGamificationStore.getState().awardLessonCompletion(5, new Date('2026-04-01T12:00:00'))
+
+    const state = useGamificationStore.getState()
+    expect(state.xpTotal).toBe(10)
+    expect(state.xpByDay[5]).toBe(10)
+  })
+
+  it('awards exercise and perfect-quiz XP once', () => {
+    const store = useGamificationStore.getState()
+    store.awardExerciseCompletion(3, '3-loop-exercise')
+    store.awardExerciseCompletion(3, '3-loop-exercise')
+    store.awardPerfectQuiz('quiz-day-3')
+    store.awardPerfectQuiz('quiz-day-3')
+
+    const state = useGamificationStore.getState()
+    expect(state.xpTotal).toBe(25)
+    expect(state.xpByDay[3]).toBe(5)
+    expect(state.perfectQuizIds).toEqual(['quiz-day-3'])
+  })
+
+  it('unlocks achievements for streak, night owl, speed runner, and quiz master', () => {
+    const now = new Date('2026-05-07T22:30:00')
+
+    useProgressStore.setState({
+      completionDates: {
+        1: '2026-05-01',
+        2: '2026-05-02',
+        3: '2026-05-03',
+        4: '2026-05-04',
+        5: '2026-05-05',
+        6: '2026-05-06',
+      },
+      completedLessons: [1, 2, 3, 4, 5, 6],
+    })
+
+    useProgressStore.getState().markLessonComplete(7, now)
+    useGamificationStore.getState().awardLessonCompletion(7, now)
+    useGamificationStore.getState().awardLessonCompletion(8, now)
+    useGamificationStore.getState().awardLessonCompletion(9, now)
+
+    useGamificationStore.getState().awardPerfectQuiz('q-1')
+    useGamificationStore.getState().awardPerfectQuiz('q-2')
+    useGamificationStore.getState().awardPerfectQuiz('q-3')
+
+    const unlocked = useGamificationStore.getState().achievementsUnlocked
+    expect(unlocked).toEqual(
+      expect.arrayContaining([
+        'first-lesson',
+        'streak-7',
+        'night-owl',
+        'speed-runner',
+        'quiz-master',
+      ]),
+    )
+  })
+})

--- a/src/stores/gamificationStore.ts
+++ b/src/stores/gamificationStore.ts
@@ -1,0 +1,330 @@
+import { create } from 'zustand'
+import { StateStorage, createJSONStorage, persist } from 'zustand/middleware'
+import { getAllPhases, getLessonsByPhase } from '../utils/contentLoader'
+import { useProgressStore } from './progressStore'
+import { triggerSparkle } from '../utils/confetti'
+import { toastSuccess } from '../utils/toast'
+
+const STORAGE_KEY = 'coding-for-mba-gamification'
+
+export type AchievementId =
+  | 'first-lesson'
+  | 'streak-7'
+  | 'night-owl'
+  | 'speed-runner'
+  | 'quiz-master'
+  | 'xp-50'
+  | 'xp-150'
+  | 'xp-300'
+
+export type AchievementMeta = {
+  id: AchievementId
+  label: string
+  description: string
+  icon: string
+}
+
+export const ACHIEVEMENTS: AchievementMeta[] = [
+  {
+    id: 'first-lesson',
+    label: 'First Lesson',
+    description: 'Complete your first lesson.',
+    icon: '🎯',
+  },
+  {
+    id: 'streak-7',
+    label: '7-Day Streak',
+    description: 'Keep a 7-day lesson completion streak.',
+    icon: '🔥',
+  },
+  {
+    id: 'night-owl',
+    label: 'Night Owl',
+    description: 'Study after 10pm local time.',
+    icon: '🦉',
+  },
+  {
+    id: 'speed-runner',
+    label: 'Speed Runner',
+    description: 'Complete 3 lessons in one calendar day.',
+    icon: '⚡',
+  },
+  {
+    id: 'quiz-master',
+    label: 'Quiz Master',
+    description: 'Ace 3 unique quizzes with 100% accuracy.',
+    icon: '🧠',
+  },
+  {
+    id: 'xp-50',
+    label: 'Bronze Learner',
+    description: 'Reach 50 XP.',
+    icon: '🥉',
+  },
+  {
+    id: 'xp-150',
+    label: 'Silver Learner',
+    description: 'Reach 150 XP.',
+    icon: '🥈',
+  },
+  {
+    id: 'xp-300',
+    label: 'Gold Learner',
+    description: 'Reach 300 XP.',
+    icon: '🥇',
+  },
+]
+
+const XP_MILESTONES = [50, 150, 300, 500, 750, 1000]
+
+const safeStorage: StateStorage = {
+  getItem: (name) => {
+    try {
+      return typeof window === 'undefined' ? null : window.localStorage.getItem(name)
+    } catch {
+      return null
+    }
+  },
+  setItem: (name, value) => {
+    try {
+      if (typeof window !== 'undefined') window.localStorage.setItem(name, value)
+    } catch {
+      // Ignore localStorage write failures.
+    }
+  },
+  removeItem: (name) => {
+    try {
+      if (typeof window !== 'undefined') window.localStorage.removeItem(name)
+    } catch {
+      // Ignore localStorage delete failures.
+    }
+  },
+}
+
+type LeaderboardEntry = {
+  name: string
+  xp: number
+  updatedAt: string
+}
+
+type DailyChallenge = {
+  day: number
+  dateKey: string
+}
+
+type GamificationStore = {
+  xpTotal: number
+  xpByDay: Record<number, number>
+  achievementsUnlocked: string[]
+  dailyChallenge: DailyChallenge
+  leaderboard: LeaderboardEntry[]
+  perfectQuizIds: string[]
+  lessonXpAwardedDays: number[]
+  completedExerciseIds: string[]
+  lessonsCompletedByDate: Record<string, number>
+  hasHydrated: boolean
+  hydrate: () => void
+  awardLessonCompletion: (day: number, completedAt?: Date) => void
+  awardExerciseCompletion: (day: number, exerciseId: string) => void
+  awardPerfectQuiz: (quizId: string) => void
+  refreshDailyChallenge: () => void
+  xpToNextMilestone: () => { current: number; next: number | null; percent: number }
+  getAchievementMeta: (id: string) => AchievementMeta | null
+}
+
+function toDayKey(input: Date): string {
+  const year = input.getFullYear()
+  const month = `${input.getMonth() + 1}`.padStart(2, '0')
+  const day = `${input.getDate()}`.padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function randomFrom<T>(items: T[]): T | null {
+  if (!items.length) return null
+  const index = Math.floor(Math.random() * items.length)
+  return items[index] ?? null
+}
+
+function resolveChallengeCandidates(): number[] {
+  const progress = useProgressStore.getState()
+  const completed = progress.completedLessons
+  if (completed.length) return completed
+
+  const lastVisited = progress.lastVisitedLesson
+  if (lastVisited && lastVisited > 0) {
+    return Array.from({ length: lastVisited }, (_, i) => i + 1)
+  }
+
+  return getAllPhases().flatMap((phase) =>
+    getLessonsByPhase(phase.phase).map((lesson) => lesson.day),
+  )
+}
+
+function maybeCelebrateAchievement(id: AchievementId): void {
+  const meta = ACHIEVEMENTS.find((item) => item.id === id)
+  if (!meta) return
+
+  triggerSparkle()
+  toastSuccess(`${meta.icon} Badge unlocked: ${meta.label}`)
+}
+
+export const useGamificationStore = create<GamificationStore>()(
+  persist(
+    (set, get) => ({
+      xpTotal: 0,
+      xpByDay: {},
+      achievementsUnlocked: [],
+      dailyChallenge: { day: 1, dateKey: '' },
+      leaderboard: [{ name: 'You', xp: 0, updatedAt: new Date(0).toISOString() }],
+      perfectQuizIds: [],
+      lessonXpAwardedDays: [],
+      completedExerciseIds: [],
+      lessonsCompletedByDate: {},
+      hasHydrated: false,
+      hydrate: () => {
+        if (get().hasHydrated) return
+        useGamificationStore.persist.rehydrate()
+      },
+      awardLessonCompletion: (day, completedAt = new Date()) => {
+        if (!Number.isInteger(day) || day < 1) return
+
+        set((state) => {
+          if (state.lessonXpAwardedDays.includes(day)) return state
+
+          const nextXpTotal = state.xpTotal + 10
+          const nextXpByDay = { ...state.xpByDay, [day]: (state.xpByDay[day] ?? 0) + 10 }
+          const dateKey = toDayKey(completedAt)
+          const nextLessonsByDate = {
+            ...state.lessonsCompletedByDate,
+            [dateKey]: (state.lessonsCompletedByDate[dateKey] ?? 0) + 1,
+          }
+          const unlocked = new Set(state.achievementsUnlocked as AchievementId[])
+
+          if (useProgressStore.getState().completedLessonsCount() >= 1) unlocked.add('first-lesson')
+          if (useProgressStore.getState().streakDays(completedAt) >= 7) unlocked.add('streak-7')
+          if (completedAt.getHours() >= 22) unlocked.add('night-owl')
+          if ((nextLessonsByDate[dateKey] ?? 0) >= 3) unlocked.add('speed-runner')
+          if (nextXpTotal >= 50) unlocked.add('xp-50')
+          if (nextXpTotal >= 150) unlocked.add('xp-150')
+          if (nextXpTotal >= 300) unlocked.add('xp-300')
+
+          const previous = new Set(state.achievementsUnlocked as AchievementId[])
+          for (const id of unlocked) {
+            if (!previous.has(id)) maybeCelebrateAchievement(id)
+          }
+
+          return {
+            xpTotal: nextXpTotal,
+            xpByDay: nextXpByDay,
+            lessonsCompletedByDate: nextLessonsByDate,
+            achievementsUnlocked: [...unlocked],
+            leaderboard: [{ name: 'You', xp: nextXpTotal, updatedAt: new Date().toISOString() }],
+            lessonXpAwardedDays: [...state.lessonXpAwardedDays, day],
+          }
+        })
+      },
+      awardExerciseCompletion: (day, exerciseId) => {
+        if (!Number.isInteger(day) || day < 1 || !exerciseId.trim()) return
+
+        set((state) => {
+          if (state.completedExerciseIds.includes(exerciseId)) return state
+          const nextXpTotal = state.xpTotal + 5
+          const unlocked = new Set(state.achievementsUnlocked as AchievementId[])
+          if (nextXpTotal >= 50) unlocked.add('xp-50')
+          if (nextXpTotal >= 150) unlocked.add('xp-150')
+          if (nextXpTotal >= 300) unlocked.add('xp-300')
+
+          const previous = new Set(state.achievementsUnlocked as AchievementId[])
+          for (const id of unlocked) {
+            if (!previous.has(id)) maybeCelebrateAchievement(id)
+          }
+
+          return {
+            xpTotal: nextXpTotal,
+            xpByDay: { ...state.xpByDay, [day]: (state.xpByDay[day] ?? 0) + 5 },
+            completedExerciseIds: [...state.completedExerciseIds, exerciseId],
+            achievementsUnlocked: [...unlocked],
+            leaderboard: [{ name: 'You', xp: nextXpTotal, updatedAt: new Date().toISOString() }],
+          }
+        })
+      },
+      awardPerfectQuiz: (quizId) => {
+        if (!quizId.trim()) return
+
+        set((state) => {
+          if (state.perfectQuizIds.includes(quizId)) return state
+          const nextPerfect = [...state.perfectQuizIds, quizId]
+          const nextXpTotal = state.xpTotal + 20
+          const unlocked = new Set(state.achievementsUnlocked as AchievementId[])
+          if (nextPerfect.length >= 3) unlocked.add('quiz-master')
+          if (nextXpTotal >= 50) unlocked.add('xp-50')
+          if (nextXpTotal >= 150) unlocked.add('xp-150')
+          if (nextXpTotal >= 300) unlocked.add('xp-300')
+
+          const previous = new Set(state.achievementsUnlocked as AchievementId[])
+          for (const id of unlocked) {
+            if (!previous.has(id)) maybeCelebrateAchievement(id)
+          }
+
+          return {
+            perfectQuizIds: nextPerfect,
+            xpTotal: nextXpTotal,
+            achievementsUnlocked: [...unlocked],
+            leaderboard: [{ name: 'You', xp: nextXpTotal, updatedAt: new Date().toISOString() }],
+          }
+        })
+      },
+      refreshDailyChallenge: () => {
+        const todayKey = toDayKey(new Date())
+        const existing = get().dailyChallenge
+        if (existing.dateKey === todayKey) return
+
+        const candidates = resolveChallengeCandidates()
+        const picked = randomFrom(candidates)
+        if (!picked) return
+
+        set({ dailyChallenge: { day: picked, dateKey: todayKey } })
+      },
+      xpToNextMilestone: () => {
+        const current = get().xpTotal
+        const next = XP_MILESTONES.find((value) => value > current) ?? null
+        if (!next) return { current, next: null, percent: 100 }
+
+        const previous = [...XP_MILESTONES].reverse().find((value) => value <= current) ?? 0
+        const percent = Math.max(
+          0,
+          Math.min(100, Math.round(((current - previous) / (next - previous)) * 100)),
+        )
+
+        return { current, next, percent }
+      },
+      getAchievementMeta: (id) => ACHIEVEMENTS.find((item) => item.id === id) ?? null,
+    }),
+    {
+      name: STORAGE_KEY,
+      version: 1,
+      storage: createJSONStorage(() => safeStorage),
+      partialize: (state) => ({
+        xpTotal: state.xpTotal,
+        xpByDay: state.xpByDay,
+        achievementsUnlocked: state.achievementsUnlocked,
+        dailyChallenge: state.dailyChallenge,
+        leaderboard: state.leaderboard,
+        perfectQuizIds: state.perfectQuizIds,
+        lessonXpAwardedDays: state.lessonXpAwardedDays,
+        completedExerciseIds: state.completedExerciseIds,
+        lessonsCompletedByDate: state.lessonsCompletedByDate,
+      }),
+      skipHydration: true,
+      onRehydrateStorage: () => (state) => {
+        if (!state) return
+        useGamificationStore.setState({ hasHydrated: true })
+        useGamificationStore.getState().refreshDailyChallenge()
+      },
+    },
+  ),
+)
+
+export function hydrateGamificationStore(): void {
+  useGamificationStore.getState().hydrate()
+}

--- a/src/styles/progress.css
+++ b/src/styles/progress.css
@@ -365,3 +365,63 @@
   font-size: 0.625rem;
   fill: var(--text-muted);
 }
+
+.gamification-card {
+  margin-top: 2rem;
+  padding: 1.25rem;
+  border: 1px solid var(--border-card);
+  border-radius: var(--radius-lg);
+  background: var(--bg-card);
+}
+
+.gamification-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.xp-milestone-track {
+  width: 100%;
+  margin: 1rem 0;
+  height: 10px;
+  border-radius: 100px;
+  background: rgba(148, 163, 184, 0.15);
+  overflow: hidden;
+}
+
+.xp-milestone-fill {
+  height: 100%;
+  background: var(--gradient-hero);
+  border-radius: inherit;
+  transition: width var(--transition-base);
+}
+
+.daily-challenge-card {
+  margin-top: 1rem;
+  padding: 0.875rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-card);
+  background: var(--bg-elevated);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.badge-grid {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.badge-chip {
+  border: 1px solid var(--border-card);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  padding: 0.6rem 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, local-only gamification layer to reward lesson/exercise/quiz activity and surface XP, badges and a daily challenge in the UI without server changes. 
- Ensure pre-commit hooks are reliable by preventing `tsc -b` from being invoked with staged file arguments and resolve formatting issues that caused hook failures.

### Description
- Added a persisted zustand store `src/stores/gamificationStore.ts` implementing XP tracking, achievements, daily challenge selection, leaderboard state and helper `hydrateGamificationStore`.
- Wired the store into the app by calling `hydrateGamificationStore` from `src/App.tsx`, awarding XP on lesson complete in `src/pages/Lesson.tsx`, and awarding exercise/quiz XP in `src/components/ExerciseWidget.tsx`, plus exposing daily challenge and a Gamification section in `src/pages/Home.tsx` and `src/pages/ProgressDashboard.tsx` with related styles in `src/styles/progress.css`.
- Added unit tests at `src/stores/__tests__/gamificationStore.test.ts` to validate XP awarding, deduping and achievement unlocks, and applied Prettier cleanup to impacted files for style consistency.
- Updated `package.json` `lint-staged` config to run typechecking via `sh -c 'npm run typecheck'` to avoid passing staged file paths to `tsc -b`.

### Testing
- Ran `npm run typecheck` and it succeeded.
- Ran `npm run format:check` (Prettier) and it succeeded after formatting fixes.
- Ran the full test suite with `npm test` (Vitest) and all tests passed (117 tests across 32 files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699807e2b9b48330a64e88b5c08b4c47)