### PR TITLE
Improve Vite perf tooling with bundle analysis, preload tuning, and route prefetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,20 @@ content/lessons/       # 108 lesson markdown files
 | ---------------------- | ----------------------------- |
 | `npm run dev`          | Start Vite dev server         |
 | `npm run build`        | Type-check + production build |
+| `npm run analyze`      | Build + generate `dist/stats.html` bundle report |
 | `npm run lint`         | Run ESLint                    |
 | `npm run typecheck`    | Run TypeScript compiler check |
 | `npm run format`       | Format code with Prettier     |
 | `npm run format:check` | Verify formatting             |
 | `npm run deploy`       | Deploy to GitHub Pages        |
+
+
+## ⚡ Build & Performance Notes
+
+- **Bundle analysis**: run `npm run analyze` to generate a visual treemap report at `dist/stats.html` (powered by `rollup-plugin-visualizer`).
+- **Route prefetching**: key nav links now prefetch lazy route chunks on hover/focus/touch so common transitions feel instant on warm networks.
+- **Module preload tuning**: Vite preload dependencies are filtered/prioritized for JS/CSS runtime chunks to avoid noisy preload graphs.
+- **Critical CSS plan**: we intentionally inline a small, maintainable CSS block in `index.html` for the home above-the-fold shell (`body`, `.page-container`, `.hero`), while leaving the main stylesheets untouched for long-term maintainability.
 
 ## 📄 License
 

--- a/index.html
+++ b/index.html
@@ -20,6 +20,41 @@
     />
     <meta name="theme-color" content="#6366f1" />
 
+    <!-- Minimal critical CSS for first paint of the home route -->
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        margin: 0;
+        font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: #f8fafc;
+      }
+      #root {
+        min-height: 100vh;
+      }
+      .page-container {
+        width: min(1200px, 100% - 2rem);
+        margin: 0 auto;
+        padding: 1rem 0 2rem;
+      }
+      .hero {
+        border-radius: 1rem;
+        padding: 1.5rem;
+        margin-bottom: 1.5rem;
+        background: linear-gradient(135deg, rgba(99, 102, 241, 0.08), rgba(59, 130, 246, 0.08));
+      }
+      .hero h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 3.8vw, 3rem);
+        line-height: 1.15;
+      }
+      .hero p {
+        margin: 0.9rem 0 0;
+        max-width: 65ch;
+      }
+    </style>
+
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Coding for MBA — 108-Day Technical Curriculum" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "jsdom": "^28.1.0",
         "lint-staged": "^16.2.7",
         "prettier": "^3.8.1",
+        "rollup-plugin-visualizer": "^6.0.8",
         "typescript": "^5.9.3",
         "vite": "^7.3.1",
         "vitest": "^4.0.18"
@@ -2301,6 +2302,22 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001770",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
@@ -2420,6 +2437,39 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2976,6 +3026,49 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/delaunator": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
@@ -3362,6 +3455,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -3801,6 +3904,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3850,6 +3969,25 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3878,6 +4016,22 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -5191,6 +5345,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -5835,6 +6008,63 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-6.0.8.tgz",
+      "integrity": "sha512-MmLbgYWDiDu8XKoePA1GtmRejl+4GWJTx156zjvycoxCbOq0PkNNwbepyB5tHCfDyRc8PKDLh2f/GLVGKNeV7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^10.0.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5951,6 +6181,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -6812,6 +7052,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -6828,6 +7084,16 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",
@@ -6850,6 +7116,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "node scripts/generate-sitemap.js && tsc -b && vite build",
+    "analyze": "node scripts/generate-sitemap.js && tsc -b && vite build --mode analyze",
     "lint": "npm run typecheck",
     "typecheck": "tsc -b",
     "preview": "vite preview",
@@ -58,6 +59,7 @@
     "jsdom": "^28.1.0",
     "lint-staged": "^16.2.7",
     "prettier": "^3.8.1",
+    "rollup-plugin-visualizer": "^6.0.8",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",
     "vitest": "^4.0.18"

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -6,6 +6,7 @@
  */
 
 import { NavLink, useLocation } from 'react-router-dom'
+import { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'
 
 /**
  * Mobile navigation bar component.
@@ -24,7 +25,11 @@ export default function MobileNav() {
 
   return (
     <nav className="mobile-nav" aria-label="Mobile navigation">
-      <NavLink to="/" className={({ isActive }) => `mobile-nav-item ${isActive ? 'active' : ''}`}>
+      <NavLink
+        to="/"
+        className={({ isActive }) => `mobile-nav-item ${isActive ? 'active' : ''}`}
+        {...createRoutePrefetchHandlers('/')}
+      >
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
         </svg>
@@ -33,6 +38,7 @@ export default function MobileNav() {
       <NavLink
         to="/curriculum"
         className={({ isActive }) => `mobile-nav-item ${isActive ? 'active' : ''}`}
+        {...createRoutePrefetchHandlers('/curriculum')}
       >
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <path d="M4 19.5A2.5 2.5 0 016.5 17H20" />
@@ -43,6 +49,7 @@ export default function MobileNav() {
       <NavLink
         to="/progress"
         className={({ isActive }) => `mobile-nav-item ${isActive ? 'active' : ''}`}
+        {...createRoutePrefetchHandlers('/progress')}
       >
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
@@ -52,6 +59,7 @@ export default function MobileNav() {
       <NavLink
         to="/concepts"
         className={({ isActive }) => `mobile-nav-item ${isActive || isLesson ? 'active' : ''}`}
+        {...createRoutePrefetchHandlers('/concepts')}
       >
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <circle cx="12" cy="12" r="3" />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useTheme } from '../context/useTheme'
 import { toastInfo } from '../utils/toast'
 import { isTypingInEditableElement } from '../utils/shortcuts'
+import { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'
 
 interface NavbarProps {
   onToggleSidebar: () => void
@@ -77,7 +78,7 @@ export default function Navbar({ onToggleSidebar }: NavbarProps) {
             <path d="M3 12h18M3 6h18M3 18h18" />
           </svg>
         </button>
-        <Link to="/" className="navbar-brand">
+        <Link to="/" className="navbar-brand" {...createRoutePrefetchHandlers('/')}>
           <div className="brand-icon">M</div>
           <span>Coding for MBA</span>
         </Link>
@@ -104,13 +105,25 @@ export default function Navbar({ onToggleSidebar }: NavbarProps) {
         >
           {theme === 'dark' ? '☀️' : '🌙'}
         </button>
-        <Link to="/" className={location.pathname === '/' ? 'active' : ''}>
+        <Link
+          to="/"
+          className={location.pathname === '/' ? 'active' : ''}
+          {...createRoutePrefetchHandlers('/')}
+        >
           Home
         </Link>
-        <Link to="/curriculum" className={location.pathname === '/curriculum' ? 'active' : ''}>
+        <Link
+          to="/curriculum"
+          className={location.pathname === '/curriculum' ? 'active' : ''}
+          {...createRoutePrefetchHandlers('/curriculum')}
+        >
           Curriculum
         </Link>
-        <Link to="/search" className={location.pathname === '/search' ? 'active' : ''}>
+        <Link
+          to="/search"
+          className={location.pathname === '/search' ? 'active' : ''}
+          {...createRoutePrefetchHandlers('/search')}
+        >
           Search
         </Link>
         <a

--- a/src/utils/prefetchRoutes.ts
+++ b/src/utils/prefetchRoutes.ts
@@ -1,0 +1,41 @@
+const routePrefetchers: Array<{ match: (path: string) => boolean; load: () => Promise<unknown> }> =
+  [
+    { match: (path) => path === '/', load: () => import('../pages/Home') },
+    { match: (path) => path === '/curriculum', load: () => import('../pages/Curriculum') },
+    { match: (path) => path.startsWith('/phase/'), load: () => import('../pages/PhaseOverview') },
+    { match: (path) => path.startsWith('/lesson/'), load: () => import('../pages/Lesson') },
+    { match: (path) => path === '/progress', load: () => import('../pages/ProgressDashboard') },
+    { match: (path) => path === '/exercises', load: () => import('../pages/Exercises') },
+    {
+      match: (path) => path.startsWith('/solutions/'),
+      load: () => import('../pages/NotebookViewer'),
+    },
+    { match: (path) => path === '/search', load: () => import('../pages/SearchResults') },
+    { match: (path) => path === '/concepts', load: () => import('../pages/ConceptGraphPage') },
+    { match: (path) => path === '/stats', load: () => import('../pages/ContentStats') },
+    { match: (path) => path === '/review', load: () => import('../pages/Review') },
+  ]
+
+const prefetchedRoutes = new Set<string>()
+
+export function prefetchRoute(path: string) {
+  if (prefetchedRoutes.has(path)) {
+    return
+  }
+
+  const route = routePrefetchers.find(({ match }) => match(path))
+  if (!route) {
+    return
+  }
+
+  prefetchedRoutes.add(path)
+  void route.load()
+}
+
+export function createRoutePrefetchHandlers(path: string) {
+  return {
+    onMouseEnter: () => prefetchRoute(path),
+    onFocus: () => prefetchRoute(path),
+    onTouchStart: () => prefetchRoute(path),
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,19 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { visualizer } from 'rollup-plugin-visualizer'
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => ({
   plugins: [
     react(),
+    mode === 'analyze'
+      ? visualizer({
+          filename: 'dist/stats.html',
+          gzipSize: true,
+          brotliSize: true,
+          template: 'treemap',
+        })
+      : null,
     {
       name: 'dev-csp-relaxation',
       transformIndexHtml: {
@@ -36,6 +45,30 @@ export default defineConfig(({ mode }) => ({
   base: process.env.VITE_BASE_PATH || '/Coding-For-MBA/',
   build: {
     chunkSizeWarningLimit: 1500,
+    modulePreload: {
+      resolveDependencies(_filename, deps, context) {
+        if (context.hostType !== 'js') {
+          return deps
+        }
+
+        const priority = ['react-vendor', 'react-dom', 'motion', 'search', 'markdown']
+
+        return [...new Set(deps)]
+          .filter((dep) => dep.endsWith('.js') || dep.endsWith('.css'))
+          .sort((a, b) => {
+            const aIndex = priority.findIndex((chunk) => a.includes(chunk))
+            const bIndex = priority.findIndex((chunk) => b.includes(chunk))
+            const aRank = aIndex === -1 ? Number.MAX_SAFE_INTEGER : aIndex
+            const bRank = bIndex === -1 ? Number.MAX_SAFE_INTEGER : bIndex
+
+            if (aRank !== bRank) {
+              return aRank - bRank
+            }
+
+            return a.localeCompare(b)
+          })
+      },
+    },
     rollupOptions: {
       output: {
         manualChunks(id) {


### PR DESCRIPTION
### Motivation

- Provide an easy way to inspect build output and identify large bundles via a local visual report. 
- Improve runtime navigation performance by prioritizing module preloads for important runtime chunks and prefetching lazy route code on hover/focus/touch. 
- Reduce time-to-interactive for the home route with a pragmatic, maintainable critical CSS approach for above-the-fold content.

### Description

- Add an `analyze` npm script (`node scripts/generate-sitemap.js && tsc -b && vite build --mode analyze`) and add `rollup-plugin-visualizer` to `devDependencies` so a treemap report is emitted to `dist/stats.html` in analyze mode. 
- Wire `rollup-plugin-visualizer` into `vite.config.ts` to enable the report only when `mode === 'analyze'`. 
- Add a `modulePreload.resolveDependencies` hook in `vite.config.ts` to filter and prioritize JS/CSS dependencies (favoring `react-vendor`, `react-dom`, `motion`, `search`, `markdown`) for cleaner preload ordering. 
- Add `src/utils/prefetchRoutes.ts` implementing `prefetchRoute` and `createRoutePrefetchHandlers(path)` that preloads lazy route bundles; connect those handlers to desktop (`src/components/Navbar.tsx`) and mobile (`src/components/MobileNav.tsx`) navigation links so lazy chunks are requested on hover/focus/touch. 
- Inline a small, focused critical CSS block in `index.html` covering the root, `.page-container`, and `.hero` shell to improve first paint for the home route while keeping main stylesheets unchanged. 
- Document the new `npm run analyze` workflow and the critical CSS / prefetch approach in `README.md`.

### Testing

- Ran `npm run typecheck` (`tsc -b`) which completed successfully. 
- Ran `npm run analyze` which performed a full build and produced the bundle output (report available at `dist/stats.html`), and the build completed successfully. 
- Ran `prettier --check` via `npm run format:check` and auto-fixed formatting for the new file, after which formatting checks passed. 
- Launched the dev server and captured a headless screenshot of the home route using Playwright to validate the inlined critical CSS and navigation layout (artifact: `artifacts/perf-home.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69980b886cfc83309ea7140f0aea34d7)