### PR TITLE
Add Lighthouse CI workflow and config for PR performance/accessibility/SEO checks

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,41 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: VITE_BASE_PATH=/ npm run build
+
+      - name: Serve dist
+        run: |
+          npx --yes serve@14 dist -l 4173 >/tmp/serve.log 2>&1 &
+          npx --yes wait-on@8 http://127.0.0.1:4173
+
+      - name: Run Lighthouse CI
+        run: npx --yes @lhci/cli@0.15.x autorun --config=./lighthouserc.json
+
+      - name: Upload Lighthouse report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: .lighthouseci
+          if-no-files-found: warn

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,43 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 1,
+      "url": [
+        "http://127.0.0.1:4173/#/",
+        "http://127.0.0.1:4173/#/curriculum",
+        "http://127.0.0.1:4173/#/lesson/1",
+        "http://127.0.0.1:4173/#/progress",
+        "http://127.0.0.1:4173/#/search"
+      ],
+      "settings": {
+        "chromeFlags": "--no-sandbox --disable-dev-shm-usage"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": [
+          "error",
+          {
+            "minScore": 0.45
+          }
+        ],
+        "categories:accessibility": [
+          "error",
+          {
+            "minScore": 0.8
+          }
+        ],
+        "categories:seo": [
+          "error",
+          {
+            "minScore": 0.8
+          }
+        ]
+      }
+    },
+    "upload": {
+      "target": "filesystem",
+      "outputDir": ".lighthouseci"
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Add automated Lighthouse checks on pull requests to detect severe regressions in performance, accessibility, and SEO before merging.
- Run checks against the app's built `dist` output on a local static server so results match the production build.
- Keep CI runtime reasonable by running a single Lighthouse run per route and using conservative thresholds to only fail on major regressions.

### Description
- Add a GitHub Actions workflow at `.github/workflows/lighthouse.yml` that checks out code, sets up Node (`node-version: 20`), runs `npm ci`, builds the site with `VITE_BASE_PATH=/ npm run build`, serves `dist` on port `4173` using `serve`, waits with `wait-on`, runs `npx --yes @lhci/cli@0.15.x autorun --config=./lighthouserc.json`, and uploads the `.lighthouseci` folder as an artifact with `if: always()`.
- Add `lighthouserc.json` to configure LHCI collection for the key routes `/#/`, `/#/curriculum`, `/#/lesson/1`, `/#/progress`, and `/#/search`, set `numberOfRuns` to `1`, add `chromeFlags` for CI (`--no-sandbox --disable-dev-shm-usage`), set conservative `assert` thresholds for `performance` (`minScore: 0.45`), `accessibility` (`minScore: 0.8`), and `seo` (`minScore: 0.8`), and configure upload target to the filesystem `outputDir: .lighthouseci`.
- Limit job runtime with `timeout-minutes: 15` to keep CI costs bounded and use portable `npx --yes` invocations so the workflow requires no additional repo dependencies.

### Testing
- Ran `npm ci` in the environment and it completed successfully.
- Ran `VITE_BASE_PATH=/ npm run build` and the production build completed successfully.
- Attempted to run LHCI locally with `npx --yes @lhci/cli@0.15.x autorun --config=./lighthouserc.json` against a served `dist`, but it failed in the local container due to a missing Chrome installation; this is expected to succeed on GitHub-hosted runners which provide Chrome.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69980cf1cb688330ad8c1823ba88a5ee)