### PR TITLE
Add Core/Stretch/Expert task blocks and shared grading rubric to Phase 2 day guides

### DIFF
--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_13_Higher_Order_Functions/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_13_Higher_Order_Functions/README.md
@@ -445,3 +445,29 @@ Today you learned:
 - ✅ Closures capture their environment
 
 **Tomorrow**: We'll explore **modules**—organizing code into reusable packages.
+
+---
+
+## Task Block (Core / Stretch / Expert)
+
+### Core
+- Complete one end-to-end task that applies today’s main concept to realistic business data.
+- Add basic validation (assertions or checks) for normal and edge-case inputs.
+
+### Stretch
+- Refactor for modularity: split logic into reusable helper functions or modules.
+- Add one additional scenario that tests robustness under imperfect data.
+
+### Expert
+- Generalize your solution for reuse across datasets or teams.
+- Document key tradeoffs and why your implementation is maintainable.
+
+## Common Grading Rubric (applies every day)
+
+| Criterion | 1 - Emerging | 2 - Developing | 3 - Proficient | 4 - Strong |
+|---|---|---|---|---|
+| Correctness | Major logic errors; results frequently wrong. | Core path works but multiple inaccuracies remain. | Outputs are correct for expected inputs and checked with examples. | Outputs are consistently correct, including tricky cases and clear verification. |
+| Robustness | Breaks on minor input changes or missing values. | Handles some variation but fails on common edge cases. | Handles expected edge cases with explicit guards/validation. | Gracefully handles unexpected data, with informative failures and recovery paths. |
+| Readability | Hard to follow; unclear naming/structure. | Partially clear but inconsistent style or organization. | Clear naming, structure, and comments/docstrings where needed. | Highly readable, well-organized, and easy for teammates to extend quickly. |
+| Reuse | One-off script with duplicated logic. | Some modularization, limited reuse. | Reusable functions/classes with sensible boundaries. | Well-factored components with clean interfaces and minimal duplication. |
+

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_14_Modules/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_14_Modules/README.md
@@ -489,3 +489,29 @@ Today you learned:
 - ✅ `__name__ == "__main__"` for script detection
 
 **Tomorrow**: We'll master **exception handling**—making code robust against errors.
+
+---
+
+## Task Block (Core / Stretch / Expert)
+
+### Core
+- Complete one end-to-end task that applies today’s main concept to realistic business data.
+- Add basic validation (assertions or checks) for normal and edge-case inputs.
+
+### Stretch
+- Refactor for modularity: split logic into reusable helper functions or modules.
+- Add one additional scenario that tests robustness under imperfect data.
+
+### Expert
+- Generalize your solution for reuse across datasets or teams.
+- Document key tradeoffs and why your implementation is maintainable.
+
+## Common Grading Rubric (applies every day)
+
+| Criterion | 1 - Emerging | 2 - Developing | 3 - Proficient | 4 - Strong |
+|---|---|---|---|---|
+| Correctness | Major logic errors; results frequently wrong. | Core path works but multiple inaccuracies remain. | Outputs are correct for expected inputs and checked with examples. | Outputs are consistently correct, including tricky cases and clear verification. |
+| Robustness | Breaks on minor input changes or missing values. | Handles some variation but fails on common edge cases. | Handles expected edge cases with explicit guards/validation. | Gracefully handles unexpected data, with informative failures and recovery paths. |
+| Readability | Hard to follow; unclear naming/structure. | Partially clear but inconsistent style or organization. | Clear naming, structure, and comments/docstrings where needed. | Highly readable, well-organized, and easy for teammates to extend quickly. |
+| Reuse | One-off script with duplicated logic. | Some modularization, limited reuse. | Reusable functions/classes with sensible boundaries. | Well-factored components with clean interfaces and minimal duplication. |
+

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_15_Exception_Handling/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_15_Exception_Handling/README.md
@@ -516,3 +516,29 @@ Today you learned:
 - ✅ Custom exceptions clarify business logic
 
 **Tomorrow**: We'll explore **file handling**—reading from and writing to files.
+
+---
+
+## Task Block (Core / Stretch / Expert)
+
+### Core
+- Complete one end-to-end task that applies today’s main concept to realistic business data.
+- Add basic validation (assertions or checks) for normal and edge-case inputs.
+
+### Stretch
+- Refactor for modularity: split logic into reusable helper functions or modules.
+- Add one additional scenario that tests robustness under imperfect data.
+
+### Expert
+- Generalize your solution for reuse across datasets or teams.
+- Document key tradeoffs and why your implementation is maintainable.
+
+## Common Grading Rubric (applies every day)
+
+| Criterion | 1 - Emerging | 2 - Developing | 3 - Proficient | 4 - Strong |
+|---|---|---|---|---|
+| Correctness | Major logic errors; results frequently wrong. | Core path works but multiple inaccuracies remain. | Outputs are correct for expected inputs and checked with examples. | Outputs are consistently correct, including tricky cases and clear verification. |
+| Robustness | Breaks on minor input changes or missing values. | Handles some variation but fails on common edge cases. | Handles expected edge cases with explicit guards/validation. | Gracefully handles unexpected data, with informative failures and recovery paths. |
+| Readability | Hard to follow; unclear naming/structure. | Partially clear but inconsistent style or organization. | Clear naming, structure, and comments/docstrings where needed. | Highly readable, well-organized, and easy for teammates to extend quickly. |
+| Reuse | One-off script with duplicated logic. | Some modularization, limited reuse. | Reusable functions/classes with sensible boundaries. | Well-factored components with clean interfaces and minimal duplication. |
+

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_16_File_Handling/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_16_File_Handling/README.md
@@ -473,3 +473,29 @@ Today you learned:
 - ✅ Use `pathlib` for cross-platform paths
 
 **Tomorrow**: We'll explore **regular expressions**—powerful pattern matching for text.
+
+---
+
+## Task Block (Core / Stretch / Expert)
+
+### Core
+- Complete one end-to-end task that applies today’s main concept to realistic business data.
+- Add basic validation (assertions or checks) for normal and edge-case inputs.
+
+### Stretch
+- Refactor for modularity: split logic into reusable helper functions or modules.
+- Add one additional scenario that tests robustness under imperfect data.
+
+### Expert
+- Generalize your solution for reuse across datasets or teams.
+- Document key tradeoffs and why your implementation is maintainable.
+
+## Common Grading Rubric (applies every day)
+
+| Criterion | 1 - Emerging | 2 - Developing | 3 - Proficient | 4 - Strong |
+|---|---|---|---|---|
+| Correctness | Major logic errors; results frequently wrong. | Core path works but multiple inaccuracies remain. | Outputs are correct for expected inputs and checked with examples. | Outputs are consistently correct, including tricky cases and clear verification. |
+| Robustness | Breaks on minor input changes or missing values. | Handles some variation but fails on common edge cases. | Handles expected edge cases with explicit guards/validation. | Gracefully handles unexpected data, with informative failures and recovery paths. |
+| Readability | Hard to follow; unclear naming/structure. | Partially clear but inconsistent style or organization. | Clear naming, structure, and comments/docstrings where needed. | Highly readable, well-organized, and easy for teammates to extend quickly. |
+| Reuse | One-off script with duplicated logic. | Some modularization, limited reuse. | Reusable functions/classes with sensible boundaries. | Well-factored components with clean interfaces and minimal duplication. |
+

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_17_Regular_Expressions/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_17_Regular_Expressions/README.md
@@ -465,3 +465,29 @@ Today you learned:
 - ✅ Compile patterns for performance
 
 **Tomorrow**: We'll explore **Classes and Objects**—the foundation of object-oriented programming.
+
+---
+
+## Task Block (Core / Stretch / Expert)
+
+### Core
+- Complete one end-to-end task that applies today’s main concept to realistic business data.
+- Add basic validation (assertions or checks) for normal and edge-case inputs.
+
+### Stretch
+- Refactor for modularity: split logic into reusable helper functions or modules.
+- Add one additional scenario that tests robustness under imperfect data.
+
+### Expert
+- Generalize your solution for reuse across datasets or teams.
+- Document key tradeoffs and why your implementation is maintainable.
+
+## Common Grading Rubric (applies every day)
+
+| Criterion | 1 - Emerging | 2 - Developing | 3 - Proficient | 4 - Strong |
+|---|---|---|---|---|
+| Correctness | Major logic errors; results frequently wrong. | Core path works but multiple inaccuracies remain. | Outputs are correct for expected inputs and checked with examples. | Outputs are consistently correct, including tricky cases and clear verification. |
+| Robustness | Breaks on minor input changes or missing values. | Handles some variation but fails on common edge cases. | Handles expected edge cases with explicit guards/validation. | Gracefully handles unexpected data, with informative failures and recovery paths. |
+| Readability | Hard to follow; unclear naming/structure. | Partially clear but inconsistent style or organization. | Clear naming, structure, and comments/docstrings where needed. | Highly readable, well-organized, and easy for teammates to extend quickly. |
+| Reuse | One-off script with duplicated logic. | Some modularization, limited reuse. | Reusable functions/classes with sensible boundaries. | Well-factored components with clean interfaces and minimal duplication. |
+

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_18_Classes_and_Objects/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_18_Classes_and_Objects/README.md
@@ -588,3 +588,33 @@ Today you learned:
 - ✅ Dunder methods customize object behavior
 
 **Tomorrow**: We'll explore **DateTime**—handling dates, times, and time zones.
+
+---
+
+## Task Block (Core / Stretch / Expert)
+
+### Project Thread (Days 18–21): Retail Operations Toolkit
+Use the same mini-project across these days so each concept compounds into a usable product artifact.
+
+### Core
+- Model `Customer`, `Product`, and `Order` classes for a retail workflow.
+- Add methods that compute order totals and update inventory in memory.
+- Write 3–5 asserts that validate class behavior and edge cases.
+
+### Stretch
+- Add inheritance or composition for discount strategies (e.g., member, promo code, seasonal).
+- Persist object state to JSON-friendly dictionaries for packaging later.
+
+### Expert
+- Refactor class boundaries to reduce coupling and document why your design supports packaging on Day 20.
+- Add a tiny CLI entry function (`main()`) that runs one realistic order scenario.
+
+## Common Grading Rubric (applies every day)
+
+| Criterion | 1 - Emerging | 2 - Developing | 3 - Proficient | 4 - Strong |
+|---|---|---|---|---|
+| Correctness | Major logic errors; results frequently wrong. | Core path works but multiple inaccuracies remain. | Outputs are correct for expected inputs and checked with examples. | Outputs are consistently correct, including tricky cases and clear verification. |
+| Robustness | Breaks on minor input changes or missing values. | Handles some variation but fails on common edge cases. | Handles expected edge cases with explicit guards/validation. | Gracefully handles unexpected data, with informative failures and recovery paths. |
+| Readability | Hard to follow; unclear naming/structure. | Partially clear but inconsistent style or organization. | Clear naming, structure, and comments/docstrings where needed. | Highly readable, well-organized, and easy for teammates to extend quickly. |
+| Reuse | One-off script with duplicated logic. | Some modularization, limited reuse. | Reusable functions/classes with sensible boundaries. | Well-factored components with clean interfaces and minimal duplication. |
+

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_19_Python_Date_Time/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_19_Python_Date_Time/README.md
@@ -503,3 +503,32 @@ Today you learned:
 - ✅ Timezone handling with `zoneinfo`
 
 **Tomorrow**: We'll explore **Python Package Manager (pip)**—installing and managing third-party packages.
+
+---
+
+## Task Block (Core / Stretch / Expert)
+
+### Project Thread (Days 18–21): Retail Operations Toolkit
+Use the same mini-project across these days so each concept compounds into a usable product artifact.
+
+### Core
+- Extend the Day 18 classes with timestamp fields (`created_at`, `updated_at`, `fulfilled_at`).
+- Implement date parsing/formatting utilities for order and shipment records.
+
+### Stretch
+- Add timezone-aware handling for at least two regions and compare fulfillment windows.
+- Build one report function that flags stale/unfulfilled orders by date threshold.
+
+### Expert
+- Create a scheduling helper class that calculates SLA deadlines and late penalties.
+- Keep interfaces packaging-ready by separating datetime utilities into a dedicated module.
+
+## Common Grading Rubric (applies every day)
+
+| Criterion | 1 - Emerging | 2 - Developing | 3 - Proficient | 4 - Strong |
+|---|---|---|---|---|
+| Correctness | Major logic errors; results frequently wrong. | Core path works but multiple inaccuracies remain. | Outputs are correct for expected inputs and checked with examples. | Outputs are consistently correct, including tricky cases and clear verification. |
+| Robustness | Breaks on minor input changes or missing values. | Handles some variation but fails on common edge cases. | Handles expected edge cases with explicit guards/validation. | Gracefully handles unexpected data, with informative failures and recovery paths. |
+| Readability | Hard to follow; unclear naming/structure. | Partially clear but inconsistent style or organization. | Clear naming, structure, and comments/docstrings where needed. | Highly readable, well-organized, and easy for teammates to extend quickly. |
+| Reuse | One-off script with duplicated logic. | Some modularization, limited reuse. | Reusable functions/classes with sensible boundaries. | Well-factored components with clean interfaces and minimal duplication. |
+

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_20_Python_Package_Manager/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_20_Python_Package_Manager/README.md
@@ -373,3 +373,37 @@ Today you learned:
 - ✅ Pin versions for reproducible builds
 
 **Tomorrow**: We'll explore **virtual environments**—isolating project dependencies.
+
+---
+
+## Task Block (Core / Stretch / Expert)
+
+### Project Thread (Days 18–21): Retail Operations Toolkit
+Use the same mini-project across these days so each concept compounds into a usable product artifact.
+
+### Prereq Refresh (2–5 minutes)
+- Confirm you can import your Day 18/19 modules from a local folder and run one function.
+- If blocked, review: `__init__.py`, absolute vs relative imports, and running `python -m package.module`.
+
+### Core
+- Convert your Days 18–19 toolkit into an installable package structure (`src/` layout preferred).
+- Expose a clean public API for core classes and datetime/report helpers.
+- Add a `pyproject.toml` with dependencies and a short package description.
+
+### Stretch
+- Add a console script entry point that runs a demo order pipeline end-to-end.
+- Add lightweight tests (or doctests) for import stability and one business flow.
+
+### Expert
+- Split optional dependencies into extras (e.g., `dev`, `analysis`) and justify each group.
+- Publish package usage notes so Day 21 can run it inside isolated environments without path hacks.
+
+## Common Grading Rubric (applies every day)
+
+| Criterion | 1 - Emerging | 2 - Developing | 3 - Proficient | 4 - Strong |
+|---|---|---|---|---|
+| Correctness | Major logic errors; results frequently wrong. | Core path works but multiple inaccuracies remain. | Outputs are correct for expected inputs and checked with examples. | Outputs are consistently correct, including tricky cases and clear verification. |
+| Robustness | Breaks on minor input changes or missing values. | Handles some variation but fails on common edge cases. | Handles expected edge cases with explicit guards/validation. | Gracefully handles unexpected data, with informative failures and recovery paths. |
+| Readability | Hard to follow; unclear naming/structure. | Partially clear but inconsistent style or organization. | Clear naming, structure, and comments/docstrings where needed. | Highly readable, well-organized, and easy for teammates to extend quickly. |
+| Reuse | One-off script with duplicated logic. | Some modularization, limited reuse. | Reusable functions/classes with sensible boundaries. | Well-factored components with clean interfaces and minimal duplication. |
+

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_21_Virtual_Environments/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_21_Virtual_Environments/README.md
@@ -419,3 +419,37 @@ Today you learned:
 - ✅ Share `requirements.txt`, not the venv folder
 
 **Tomorrow**: We'll explore **NumPy**—the foundation of numerical computing in Python.
+
+---
+
+## Task Block (Core / Stretch / Expert)
+
+### Project Thread (Days 18–21): Retail Operations Toolkit
+Use the same mini-project across these days so each concept compounds into a usable product artifact.
+
+### Prereq Refresh (2–5 minutes)
+- Create and activate one virtual environment, then install your Day 20 package in editable mode.
+- If blocked, review: activation commands by OS and how `pip list` confirms environment isolation.
+
+### Core
+- Run the packaged toolkit in a fresh virtual environment and verify reproducible setup.
+- Capture a short setup script/checklist (`create venv -> install -> run demo`).
+- Validate imports, command entry point, and one sample report.
+
+### Stretch
+- Create separate `dev` and `runtime` environments and compare installed dependency sets.
+- Add a troubleshooting note for common environment mismatch issues.
+
+### Expert
+- Automate environment bootstrap with a single command (`Makefile`, script, or task runner).
+- Demonstrate deterministic installs (pinning strategy and lockfile/tooling recommendation).
+
+## Common Grading Rubric (applies every day)
+
+| Criterion | 1 - Emerging | 2 - Developing | 3 - Proficient | 4 - Strong |
+|---|---|---|---|---|
+| Correctness | Major logic errors; results frequently wrong. | Core path works but multiple inaccuracies remain. | Outputs are correct for expected inputs and checked with examples. | Outputs are consistently correct, including tricky cases and clear verification. |
+| Robustness | Breaks on minor input changes or missing values. | Handles some variation but fails on common edge cases. | Handles expected edge cases with explicit guards/validation. | Gracefully handles unexpected data, with informative failures and recovery paths. |
+| Readability | Hard to follow; unclear naming/structure. | Partially clear but inconsistent style or organization. | Clear naming, structure, and comments/docstrings where needed. | Highly readable, well-organized, and easy for teammates to extend quickly. |
+| Reuse | One-off script with duplicated logic. | Some modularization, limited reuse. | Reusable functions/classes with sensible boundaries. | Well-factored components with clean interfaces and minimal duplication. |
+

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_22_NumPy/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_22_NumPy/README.md
@@ -435,3 +435,31 @@ Today you learned:
 - ✅ Broadcasting handles different-shaped arrays
 
 **Tomorrow**: We'll explore **Pandas**—the data analysis powerhouse built on NumPy.
+
+---
+
+## Task Block (Core / Stretch / Expert)
+
+### Data Migration Thread (Days 22–24): Arrays → DataFrame Pipelines
+
+### Core
+- Implement a NumPy-only pipeline for a small sales dataset (clean, transform, aggregate).
+- Document array shapes and dtypes at each step so migration targets are explicit.
+
+### Stretch
+- Identify two operations that become harder in raw arrays (e.g., labeled joins, mixed dtypes).
+- Write migration notes mapping each NumPy step to a future Pandas equivalent.
+
+### Expert
+- Build a side-by-side prototype: same output from NumPy arrays and a minimal DataFrame version.
+- Compare readability/performance tradeoffs and define migration criteria for Day 23.
+
+## Common Grading Rubric (applies every day)
+
+| Criterion | 1 - Emerging | 2 - Developing | 3 - Proficient | 4 - Strong |
+|---|---|---|---|---|
+| Correctness | Major logic errors; results frequently wrong. | Core path works but multiple inaccuracies remain. | Outputs are correct for expected inputs and checked with examples. | Outputs are consistently correct, including tricky cases and clear verification. |
+| Robustness | Breaks on minor input changes or missing values. | Handles some variation but fails on common edge cases. | Handles expected edge cases with explicit guards/validation. | Gracefully handles unexpected data, with informative failures and recovery paths. |
+| Readability | Hard to follow; unclear naming/structure. | Partially clear but inconsistent style or organization. | Clear naming, structure, and comments/docstrings where needed. | Highly readable, well-organized, and easy for teammates to extend quickly. |
+| Reuse | One-off script with duplicated logic. | Some modularization, limited reuse. | Reusable functions/classes with sensible boundaries. | Well-factored components with clean interfaces and minimal duplication. |
+

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_23_Pandas/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_23_Pandas/README.md
@@ -138,3 +138,31 @@ print(high_earners)
 - ✅ Filter with boolean conditions
 
 **Tomorrow**: Advanced Pandas—groupby, merges, and pivots.
+
+---
+
+## Task Block (Core / Stretch / Expert)
+
+### Data Migration Thread (Days 22–24): Arrays → DataFrame Pipelines
+
+### Core
+- Rebuild yesterday’s NumPy workflow in Pandas using explicit column names and typed parsing.
+- Verify metric parity between NumPy and Pandas outputs with assertions.
+
+### Stretch
+- Replace index-based NumPy logic with label-based Pandas operations (`loc`, `assign`, `groupby`).
+- Add one migration exercise where learners convert a provided NumPy snippet into idiomatic Pandas.
+
+### Expert
+- Package the pipeline into reusable functions (`load`, `transform`, `summarize`) with clear contracts.
+- Add validation checks for nulls, schema drift, and unexpected category values.
+
+## Common Grading Rubric (applies every day)
+
+| Criterion | 1 - Emerging | 2 - Developing | 3 - Proficient | 4 - Strong |
+|---|---|---|---|---|
+| Correctness | Major logic errors; results frequently wrong. | Core path works but multiple inaccuracies remain. | Outputs are correct for expected inputs and checked with examples. | Outputs are consistently correct, including tricky cases and clear verification. |
+| Robustness | Breaks on minor input changes or missing values. | Handles some variation but fails on common edge cases. | Handles expected edge cases with explicit guards/validation. | Gracefully handles unexpected data, with informative failures and recovery paths. |
+| Readability | Hard to follow; unclear naming/structure. | Partially clear but inconsistent style or organization. | Clear naming, structure, and comments/docstrings where needed. | Highly readable, well-organized, and easy for teammates to extend quickly. |
+| Reuse | One-off script with duplicated logic. | Some modularization, limited reuse. | Reusable functions/classes with sensible boundaries. | Well-factored components with clean interfaces and minimal duplication. |
+

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_24_Pandas_Advanced/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_24_Pandas_Advanced/README.md
@@ -181,3 +181,31 @@ sales.set_index("date")["revenue"].resample("M").sum()
 - ✅ `resample()` handles time-based aggregation
 
 **🎉 Congratulations!** You've completed **Phase 2: Functions, Modularity & Data Wrangling**!
+
+---
+
+## Task Block (Core / Stretch / Expert)
+
+### Data Migration Thread (Days 22–24): Arrays → DataFrame Pipelines
+
+### Core
+- Upgrade the Day 23 Pandas pipeline with advanced operations (`merge`, `pivot_table`, `resample`).
+- Keep each step modular so learners can trace migration from raw arrays to analytical tables.
+
+### Stretch
+- Add an explicit migration exercise: optimize one NumPy-heavy section into a Pandas-native pattern.
+- Produce a compact before/after comparison (code length, clarity, and maintainability).
+
+### Expert
+- Create a production-style mini workflow with configuration-driven transformations.
+- Add regression checks that protect outputs when new columns or dates appear.
+
+## Common Grading Rubric (applies every day)
+
+| Criterion | 1 - Emerging | 2 - Developing | 3 - Proficient | 4 - Strong |
+|---|---|---|---|---|
+| Correctness | Major logic errors; results frequently wrong. | Core path works but multiple inaccuracies remain. | Outputs are correct for expected inputs and checked with examples. | Outputs are consistently correct, including tricky cases and clear verification. |
+| Robustness | Breaks on minor input changes or missing values. | Handles some variation but fails on common edge cases. | Handles expected edge cases with explicit guards/validation. | Gracefully handles unexpected data, with informative failures and recovery paths. |
+| Readability | Hard to follow; unclear naming/structure. | Partially clear but inconsistent style or organization. | Clear naming, structure, and comments/docstrings where needed. | Highly readable, well-organized, and easy for teammates to extend quickly. |
+| Reuse | One-off script with duplicated logic. | Some modularization, limited reuse. | Reusable functions/classes with sensible boundaries. | Well-factored components with clean interfaces and minimal duplication. |
+


### PR DESCRIPTION
### Motivation
- Standardize daily practice by providing a consistent 3-tier task structure (Core / Stretch / Expert) across Phase 2 to smooth instructor and learner expectations. 
- Create coherent multi-day transitions so Topics (classes → packaging → venvs) and (NumPy → Pandas) form teachable project threads rather than isolated lessons. 
- Help mixed-experience cohorts move at the right pace by adding quick "Prereq Refresh" micro-prompts and a fixed rubric to stabilize grading.

### Description
- Added a `## Task Block (Core / Stretch / Expert)` section to each Day 13–24 `README.md` under `content/lessons/Phase_02_Functions_Modularity_Data_Wrangling` so every day includes Core, Stretch, and Expert tasks. 
- Introduced a shared "Project Thread (Days 18–21): Retail Operations Toolkit" that connects classes, datetime, packaging, and virtual environment work into a single mini-project. 
- Introduced a shared "Data Migration Thread (Days 22–24): Arrays → DataFrame Pipelines" that provides explicit NumPy→Pandas migration exercises and parity checks. 
- Added `Prereq Refresh (2–5 minutes)` micro-prompts to Day 20 and Day 21 and appended a common grading rubric (correctness, robustness, readability, reuse) to the end of each affected day.

### Testing
- Ran the scripted update which reported `updated` for each modified file and printed the list of changed files (Python patch succeeded). 
- Verified presence of new markers with `rg -n "Task Block \(Core / Stretch / Expert\)|Common Grading Rubric|Prereq Refresh|Project Thread|Data Migration Thread"` which returned matching lines in all expected `Day_13`–`Day_24` README files. 
- Confirmed repository state and commit with `git status --short` and `git log -1 --oneline`, and commit `a27f0af` shows the change was recorded. 
- All automated checks completed successfully (no failing checks reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998832b64388330a47da4bc5995be47)