### PR TITLE
Add reliability & failure-injection exercises to Days 30–36

### DIFF
--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_30_Web_Scraping/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_30_Web_Scraping/README.md
@@ -285,6 +285,22 @@ gdp_table = tables[0]
 print(gdp_table.head())
 ```
 
+
+### Reliability & Maintainability Tasks
+
+- Add retry + exponential backoff to every network request and log each retry attempt with URL, status, and wait time.
+- Implement schema drift guards: if expected selectors are missing, write the raw HTML snapshot to a `debug/` folder and raise a descriptive parsing error.
+- Add an ethics checklist prompt before each run: review `robots.txt`, terms of service, crawl frequency, and contact info in User-Agent.
+
+### Exercise 4: Failure Injection — Broken HTML Layout
+
+Simulate a controlled breakage by changing one critical CSS selector (for example, `span.text` → `span.quote-text`) and run your scraper.
+
+Your debugging goals:
+1. Detect the selector failure quickly with explicit assertions.
+2. Capture a sample failing page for investigation.
+3. Patch the extractor to support both old and new selector variants without silently dropping rows.
+
 ---
 
 ## Mastery Check

--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_31_Databases/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_31_Databases/README.md
@@ -326,6 +326,22 @@ print(top_customers)
 conn.close()
 ```
 
+
+### Reliability & Maintainability Tasks
+
+- Add transaction boundaries and rollback handling for all multi-step writes.
+- Document indexing decisions (`why this index exists`) alongside each analytics query.
+- Add a lightweight data contract for key tables (required columns, data types, uniqueness rules).
+
+### Exercise 4: Failure Injection — Partial Commit Bug
+
+Inject a failure between two dependent inserts (for example, write to `orders` succeeds but write to `order_items` fails).
+
+Your debugging goals:
+1. Reproduce the inconsistent state intentionally.
+2. Wrap writes in a transaction and confirm rollback restores consistency.
+3. Add a verification query that fails CI if orphaned records appear.
+
 ---
 
 ## Mastery Check

--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_32_Other_Databases/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_32_Other_Databases/README.md
@@ -205,6 +205,22 @@ Match each scenario to the best database:
 
 </details>
 
+
+### Reliability & Maintainability Tasks
+
+- Create schema validation rules for NoSQL documents (required fields, allowed types, defaults).
+- Add migration/version metadata to documents so future structure changes are traceable.
+- Define read/write consistency expectations for each workload and document tradeoffs.
+
+### Exercise 4: Failure Injection — Document Shape Drift
+
+Insert malformed documents with missing or renamed fields into a collection, then run your aggregation pipeline.
+
+Your debugging goals:
+1. Identify where the pipeline breaks or produces wrong counts.
+2. Add validation + fallback transforms to normalize legacy documents.
+3. Produce a short migration plan to repair historical records safely.
+
 ---
 
 ## Mastery Check

--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_33_API/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_33_API/README.md
@@ -247,6 +247,22 @@ def get_all_repos(username, max_pages=3):
 repos = get_all_repos("torvalds", max_pages=2)
 ```
 
+
+### Reliability & Maintainability Tasks
+
+- Build an input validation matrix for each endpoint (valid, boundary, invalid, and malicious payloads).
+- Write status-code contract tests for success and error paths (`200`, `400`, `401`, `404`, `429`, `500` as relevant).
+- Implement robust pagination + rate-limit handling (`next` links, `Retry-After`, bounded retries, checkpoint resume).
+
+### Exercise 4: Failure Injection — Throttling and Bad Payload
+
+Use a mock/stub API mode that intermittently returns `429` and occasionally malformed JSON.
+
+Your debugging goals:
+1. Confirm your client honors `Retry-After` and backoff limits.
+2. Validate payload shape before transformation.
+3. Record failed pages for replay without re-fetching successful pages.
+
 ---
 
 ## Mastery Check

--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_34_Building_an_API/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_34_Building_an_API/README.md
@@ -317,6 +317,22 @@ def get_user(username: str):
     return {"username": user.username, "email": user.email}
 ```
 
+
+### Reliability & Maintainability Tasks
+
+- Define an input validation matrix per route (query params, body fields, edge constraints, unsafe input).
+- Add status-code contract tests covering expected responses and stable error models.
+- Implement first-class pagination and rate-limit behavior, including documented headers and client guidance.
+
+### Exercise 4: Failure Injection — Contract Break Regression
+
+Introduce a controlled breaking change (for example, return `201` instead of `200`, rename `message` → `detail`, or remove pagination metadata).
+
+Your debugging goals:
+1. Catch the regression via contract tests.
+2. Restore backward compatibility (or version the endpoint).
+3. Update API docs/changelog with clear migration notes.
+
 ---
 
 ## Mastery Check

--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_35_Flask_Web_Framework/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_35_Flask_Web_Framework/README.md
@@ -286,6 +286,22 @@ if __name__ == "__main__":
     app.run(debug=True)
 ```
 
+
+### Reliability & Maintainability Tasks
+
+- Split configuration by environment (`development`, `testing`, `production`) and load settings from env vars instead of hardcoding secrets.
+- Add structured logging (JSON or key-value) with request ID, route, status, latency, and user/session context where appropriate.
+- Add centralized error-handling middleware for consistent responses and safe user-facing messages.
+
+### Exercise 4: Failure Injection — Production Misconfiguration
+
+Deliberately remove one required environment variable and trigger an unhandled exception in a route.
+
+Your debugging goals:
+1. Fail fast at startup with actionable config validation errors.
+2. Verify error middleware returns consistent `500` behavior without stack traces to users.
+3. Use structured logs to trace the failing request end-to-end.
+
 ---
 
 ## Mastery Check

--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_36_Case_Study/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_36_Case_Study/README.md
@@ -365,6 +365,22 @@ if __name__ == "__main__":
     app.run(debug=True)
 ```
 
+
+### Reliability & Maintainability Tasks
+
+- Add data quality checks at transform/load boundaries: null-rate thresholds, uniqueness constraints, and freshness SLA checks.
+- Complete an idempotency challenge: rerun the same batch twice and prove no duplicate or conflicting records are created.
+- Add an incident postmortem template (`impact`, `timeline`, `root cause`, `detection gaps`, `action items`, `owner`, `due date`).
+
+### Exercise 4: Failure Injection — Stale + Duplicate Batch
+
+Inject a controlled pipeline incident where the source sends yesterday's snapshot with duplicated IDs.
+
+Your debugging goals:
+1. Trip freshness and uniqueness quality checks automatically.
+2. Contain blast radius by quarantining bad data instead of loading to production tables.
+3. Write a short postmortem using the template and propose prevention controls.
+
 ---
 
 ## Mastery Check


### PR DESCRIPTION
### Motivation

- Strengthen lesson coverage around reliability, observability, and maintainability for the Data Engineering & Web Development week (Days 30–36). 
- Teach defensive patterns (retries, schema validation, config management) and make debugging repeatable by including intentional, controlled failures. 
- Provide learners with practical tasks that mirror production concerns: rate limits, schema drift, transactional consistency, idempotency, and incident response.

### Description

- Added a new **"Reliability & Maintainability Tasks"** section and an accompanying **Exercise 4: Failure Injection** to each lesson README for Day_30 through Day_36, updating the following files: `content/lessons/Phase_03_Data_Engineering_Web_Development/Day_30_Web_Scraping/README.md`, `Day_31_Databases/README.md`, `Day_32_Other_Databases/README.md`, `Day_33_API/README.md`, `Day_34_Building_an_API/README.md`, `Day_35_Flask_Web_Framework/README.md`, and `Day_36_Case_Study/README.md`.
- Domain-specific additions: Web scraping gets retry/exponential backoff, schema-drift guards, and ethics/robots prompts; API lessons get input validation matrices, status-code contract tests, and pagination/rate-limit handling; Flask gets environment-based config, structured logging, and centralized error-handling middleware; ETL case study gets data-quality checks, an idempotency challenge, and an incident postmortem template.
- Each day now includes one controlled failure-injection exercise with concrete debugging goals so learners practice detection, containment, and remediation (e.g., broken CSS selector, partial DB commit, malformed NoSQL documents, intermittent `429`/bad JSON, contract regression, missing env var, stale/duplicate batch).

### Testing

- Ran formatting check with `npx prettier --check content/lessons/Phase_03_Data_Engineering_Web_Development/Day_3{0,1,2,3,4,5,6}_*/README.md` and all updated files passed the Prettier check. 
- Pre-commit hooks (which include `prettier --check`) executed during the change workflow and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998832e03d083309375d449642b2adf)