### PR TITLE
Add recurring 'Retail Pulse' mini-scenario across Phase 1 Days 2–12

### DIFF
--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_02_Variables_Builtin_Functions/README.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_02_Variables_Builtin_Functions/README.md
@@ -413,3 +413,18 @@ Today you learned:
 - ✅ Professional code uses consistent naming conventions
 
 **Tomorrow**: We'll explore **operators**—the tools for comparing, combining, and transforming your data.
+
+---
+
+## Recurring Mini-Scenario Challenge: Retail Pulse Sales Tracker (Day 2)
+
+Build the starter for a single script named `sales_tracker_phase1.py` that you will extend through Day 12.
+
+**Challenge**
+- Create well-named variables in `snake_case` for one day of kiosk data: `store_code`, `report_date`, `orders_count`, `avg_ticket_usd`, `is_weekend`.
+- Add one constant in `UPPER_SNAKE_CASE`: `ANOMALY_ORDER_LIMIT`.
+- Print one progress line using f-strings: `"KPI | {store_code} | Orders={orders_count}"`.
+
+**Measurable output**
+- Output exactly one KPI line that includes the store code and order count so you can compare later days against a visible baseline.
+

--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_03_Operators/README.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_03_Operators/README.md
@@ -490,3 +490,18 @@ Today you learned:
 - ✅ Operator precedence determines evaluation order
 
 **Tomorrow**: We'll explore **strings**—the primary way programs handle text, names, and messages.
+
+---
+
+## Recurring Mini-Scenario Challenge: Retail Pulse Sales Tracker (Day 3)
+
+Continue in `sales_tracker_phase1.py` using yesterday's variables.
+
+**Challenge**
+- Add operator-based calculations: `daily_revenue = orders_count * avg_ticket_usd` and `is_anomaly = orders_count > ANOMALY_ORDER_LIMIT`.
+- Build a label code with operators and conversion, e.g. `report_label = store_code + "-" + str(report_date)`.
+- Print a status line that includes both `daily_revenue` and `is_anomaly`.
+
+**Measurable output**
+- Print one formatted report line: `"REPORT {report_label} | Revenue=$... | Anomaly=True/False"`.
+

--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_04_Strings/README.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_04_Strings/README.md
@@ -475,3 +475,18 @@ Today you learned:
 - ✅ Strings are immutable—operations create new strings
 
 **Tomorrow**: We'll explore **lists**—collections that let you store and manipulate multiple values at once.
+
+---
+
+## Recurring Mini-Scenario Challenge: Retail Pulse Sales Tracker (Day 4)
+
+Keep extending `sales_tracker_phase1.py`; do not restart.
+
+**Challenge**
+- Parse a raw text code like `"KIOSK-NYC-2024-07-15"` using string methods/splitting.
+- Extract and store `channel`, `city_code`, and date parts in clearly named variables.
+- Generate a cleaned label in title case for reporting, such as `"Kiosk | Nyc | 2024-07-15"`.
+
+**Measurable output**
+- Print one parsed-label line showing extracted city and normalized date so correctness is visible immediately.
+

--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_05_Lists/README.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_05_Lists/README.md
@@ -468,3 +468,18 @@ Today you learned:
 - ✅ Lists are passed by reference—be careful with modifications
 
 **Tomorrow**: We'll explore **tuples**—lists that can't be changed, perfect for data integrity.
+
+---
+
+## Recurring Mini-Scenario Challenge: Retail Pulse Sales Tracker (Day 5)
+
+Extend the same `sales_tracker_phase1.py` file with multi-day tracking.
+
+**Challenge**
+- Model 5 daily order counts in a list (e.g., `daily_orders = [...]`).
+- Reuse earlier variables by appending today's `orders_count` to that list.
+- Compute total orders and average orders from the list.
+
+**Measurable output**
+- Print one KPI line: `"WEEK-TO-DATE | total_orders=... | avg_orders=..."`.
+

--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_06_Tuples/README.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_06_Tuples/README.md
@@ -451,3 +451,18 @@ Today you learned:
 - ✅ Tuples can be dictionary keys; lists cannot
 
 **Tomorrow**: We'll explore **sets**—collections optimized for uniqueness and fast membership testing.
+
+---
+
+## Recurring Mini-Scenario Challenge: Retail Pulse Sales Tracker (Day 6)
+
+Continue in `sales_tracker_phase1.py` with immutable record modeling.
+
+**Challenge**
+- Represent one transaction summary as a tuple: `(store_code, report_date, orders_count, daily_revenue)`.
+- Store multiple tuple records in a list to preserve sequence.
+- Reuse Day 5 totals and compare latest tuple orders vs list average.
+
+**Measurable output**
+- Print one report line showing the latest tuple and whether orders are above/below average.
+

--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_07_Sets/README.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_07_Sets/README.md
@@ -460,3 +460,18 @@ Today you learned:
 - ✅ Perfect for deduplication and comparison tasks
 
 **Tomorrow**: We'll explore **dictionaries**—key-value pairs that let you look up data instantly.
+
+---
+
+## Recurring Mini-Scenario Challenge: Retail Pulse Sales Tracker (Day 7)
+
+Keep extending `sales_tracker_phase1.py` by tracking uniqueness.
+
+**Challenge**
+- Build a set of unique customer IDs from a list that intentionally contains duplicates.
+- Reuse prior-day records by associating each tuple record with a customer ID list for the same day.
+- Identify repeated IDs by comparing raw count vs unique count.
+
+**Measurable output**
+- Print one anomaly line: `"DUPLICATE_CUSTOMERS=<count>"`.
+

--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_08_Dictionaries/README.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_08_Dictionaries/README.md
@@ -497,3 +497,18 @@ Today you learned:
 - ✅ Dictionary lookups are O(1)—instant regardless of size
 
 **Tomorrow**: We'll explore **conditionals**—teaching your programs to make decisions.
+
+---
+
+## Recurring Mini-Scenario Challenge: Retail Pulse Sales Tracker (Day 8)
+
+Extend `sales_tracker_phase1.py` into a richer business model.
+
+**Challenge**
+- Create a dictionary per day with keys like `store_code`, `orders_count`, `daily_revenue`, `unique_customers`, `is_anomaly`.
+- Store all day dictionaries in a list called `weekly_snapshots`.
+- Reuse Day 7 duplicate logic to populate dictionary fields.
+
+**Measurable output**
+- Print one dictionary-driven summary line for the latest day: `"SNAPSHOT <date> | revenue=... | unique_customers=..."`.
+

--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_09_Conditionals/README.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_09_Conditionals/README.md
@@ -562,3 +562,21 @@ Today you learned:
 - ✅ Order matters in elif chains—check specific cases first
 
 **Tomorrow**: We'll explore **loops**—repeating actions without repeating code.
+
+---
+
+## Recurring Mini-Scenario Challenge: Retail Pulse Sales Tracker (Day 9)
+
+Continue in `sales_tracker_phase1.py` by adding policy decisions.
+
+**Challenge**
+- Define policy rules with `if/elif/else`, such as:
+  - `orders_count < 40` → `"LOW_TRAFFIC"`
+  - `40-120` → `"NORMAL"`
+  - `>120` → `"SURGE"`
+- Apply rule classification to each day's dictionary.
+- Flag discount eligibility when `LOW_TRAFFIC` and not weekend.
+
+**Measurable output**
+- Print one policy result line for the latest day: `"POLICY=<tier> | discount_action=True/False"`.
+

--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_10_Loops/README.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_10_Loops/README.md
@@ -539,3 +539,18 @@ Today you learned:
 - ✅ `break` exits loops; `continue` skips iterations
 
 **Tomorrow**: We'll explore **functions**—reusable blocks of code that make programs modular.
+
+---
+
+## Recurring Mini-Scenario Challenge: Retail Pulse Sales Tracker (Day 10)
+
+Extend `sales_tracker_phase1.py` with loop-based rollups.
+
+**Challenge**
+- Loop over `weekly_snapshots` to count how many days are `LOW_TRAFFIC`, `NORMAL`, and `SURGE`.
+- Accumulate weekly revenue and compute average daily revenue.
+- Reuse Day 9 policy tiers rather than recalculating from scratch.
+
+**Measurable output**
+- Print one weekly summary line: `"WEEKLY_SUMMARY | low=... normal=... surge=... avg_revenue=..."`.
+

--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_11_Functions/README.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_11_Functions/README.md
@@ -611,3 +611,21 @@ Today you learned:
 - ✅ Scope determines variable visibility (LEGB rule)
 
 **Tomorrow**: We'll explore **list comprehensions**—a powerful Pythonic way to create and transform lists.
+
+---
+
+## Recurring Mini-Scenario Challenge: Retail Pulse Sales Tracker (Day 11)
+
+Refactor `sales_tracker_phase1.py` into reusable functions.
+
+**Challenge**
+- Decompose logic into at least three functions, for example:
+  - `classify_traffic(orders_count, is_weekend)`
+  - `build_snapshot(...)`
+  - `summarize_week(weekly_snapshots)`
+- Ensure functions reuse existing Day 2-10 variables/data structures.
+- Keep outputs identical to prior summary lines for easy regression checks.
+
+**Measurable output**
+- Print one function-generated line confirming KPI parity, e.g., `"FUNCTION_CHECK | weekly_revenue=..."`.
+

--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_12_List_Comprehension/README.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_12_List_Comprehension/README.md
@@ -508,3 +508,18 @@ You now understand:
 - Functions and Pythonic list comprehensions
 
 **Next Phase**: Functions, Modularity & Data Wrangling—where you'll learn to build larger, more organized programs.
+
+---
+
+## Recurring Mini-Scenario Challenge: Retail Pulse Sales Tracker (Day 12)
+
+Complete the end-of-phase version of `sales_tracker_phase1.py`.
+
+**Challenge**
+- Refactor at least one loop into a list comprehension (for example, collecting surge-day dates or discount-eligible days).
+- Keep function boundaries from Day 11 and only replace internals where comprehension improves clarity.
+- Produce a final runnable script that executes the full Day 2-12 flow in order.
+
+**Measurable output**
+- Print one final report line that includes both a KPI value and a computed list, e.g., `"FINAL_REPORT | weekly_revenue=... | surge_days=[...]"`.
+


### PR DESCRIPTION
### Motivation
- Introduce a single, cumulative mini-scenario so learners practice building on prior work across Days 2–12 rather than restarting each day. 
- Encourage progressive skill application from naming and string parsing through collections, control flow, and refactoring into functions and list comprehensions. 
- Produce a visible, measurable progression and a single end-of-phase runnable script for regression-style checks.

### Description
- Appended a "Recurring Mini-Scenario Challenge: Retail Pulse Sales Tracker" section to the README for each Day 2–12 that specifies a day-by-day challenge that must reuse prior-day logic. 
- Defined the learning arc so Day 2–4 cover variable naming and string parsing, Day 5–8 cover lists/tuples/sets/dictionaries, Day 9–10 add conditionals and loop summarization, and Day 11–12 focus on function decomposition and list-comprehension refactor. 
- Required a single end-of-phase script named `sales_tracker_phase1.py` that is extended each day and produces measurable outputs (KPI lines, anomaly counts, summary/report lines) for easy comparison. 
- Updated 11 README files with the new scenario content (roughly 171 lines of appended guidance and measurable output requirements). 

### Testing
- Ran a repository search with `rg -n

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69988322fb308330b2713c28bc7556be)