### PR TITLE
Add Math-to-Debug tasks to Phase 4 Days 38–45 lessons

### DIFF
--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_38_Linear_Algebra/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_38_Linear_Algebra/README.md
@@ -531,6 +531,13 @@ D, I = index.search(query_vector.reshape(1, -1), 10)
 
 ---
 
+## Math-to-Debug Tasks
+
+1. **Operation-to-symptom mapping drill**: For each operation (`scaling`, `matrix projection`, `feature interaction`, `PCA rotation`), map how it changes feature geometry and identify one multicollinearity symptom (unstable coefficients, inflated variance, sign flips).
+2. **Collinearity diagnosis mini-case**: You observe opposite-signed coefficients for two nearly identical marketing spend variables. Explain conceptually (linear dependence in `X^T X`) *why the model failed*, then take corrective action by computing VIF and applying either feature dropping, Ridge regularization, or PCA.
+
+---
+
 ## Summary
 
 Today you learned:

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_39_Calculus/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_39_Calculus/README.md
@@ -695,6 +695,13 @@ print(f"Max gradient: {np.max(np.abs(gradient))}")
 
 ---
 
+## Math-to-Debug Tasks
+
+1. **Gradient behavior explanation**: Given three training logs (smooth convergence, oscillation, exploding loss), use derivative magnitude and curvature intuition to explain gradient behavior in each run.
+2. **Learning instability case**: A network loss becomes `nan` after 40 iterations. Explain conceptually *why the model failed* (step size too large on steep curvature + unstable updates), then apply concrete fixes: lower learning rate, gradient clipping, and feature normalization; verify by plotting gradient norms over epochs.
+
+---
+
 ## Summary
 
 Today you learned:

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_40_Intro_to_ML/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_40_Intro_to_ML/README.md
@@ -691,6 +691,13 @@ For 10,000 samples, 5-fold gives reliable estimates while training only 5 models
 
 ---
 
+## Math-to-Debug Tasks
+
+1. **Math-foundation failure map**: For one failed baseline model, connect symptoms to foundation-level causes (linear algebra: collinearity, calculus: unstable optimization, statistics: distribution shift).
+2. **Why-model-failed case**: Validation accuracy drops while training accuracy rises. Explain conceptually *why the model failed* (high variance + weak generalization assumptions), then take corrective action using stronger regularization, simpler hypothesis class, and cross-validation-based model selection.
+
+---
+
 ## Summary
 
 Today you learned:

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_41_Supervised_Learning_Regression/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_41_Supervised_Learning_Regression/README.md
@@ -754,6 +754,13 @@ Monitor the train-test gap as you tune!
 
 ---
 
+## Math-to-Debug Tasks
+
+1. **Residual diagnostics tied to assumptions**: Use residual-vs-fitted and Q-Q plots to test linearity, constant variance, and near-normal error assumptions; document which assumption breaks first and expected business impact on predictions.
+2. **Why-model-failed case (regression)**: RMSE is good on train but poor on test, with funnel-shaped residuals. Explain conceptually *why the model failed* (heteroscedasticity + omitted nonlinearity), then take corrective action with log/Box-Cox transform, interaction or polynomial terms, and weighted/robust regression.
+
+---
+
 ## Summary
 
 Today you learned:

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_42_Supervised_Learning_Classification_Part_1/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_42_Supervised_Learning_Classification_Part_1/README.md
@@ -708,6 +708,13 @@ y_pred = (y_prob >= 0.3).astype(int)
 
 ---
 
+## Math-to-Debug Tasks
+
+1. **Confusion-matrix diagnosis tied to assumptions**: Diagnose whether class overlap, threshold choice, or class imbalance is driving FP/FN patterns; relate findings to probability calibration and decision-threshold assumptions.
+2. **Why-model-failed case (classification)**: Model shows 92% accuracy but misses most positives. Explain conceptually *why the model failed* (accuracy paradox under imbalance + default threshold assumption), then take corrective action with class-weighting, threshold tuning, and PR-AUC/F1 tracking.
+
+---
+
 ## Summary
 
 Today you learned:

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_43_Supervised_Learning_Classification_Part_2/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_43_Supervised_Learning_Classification_Part_2/README.md
@@ -659,6 +659,13 @@ A decision tree for loan approval says: "IF credit_score > 700 AND income > 5000
 
 ---
 
+## Math-to-Debug Tasks
+
+1. **Tree/forest confusion-matrix deep dive**: Compare confusion matrices across depth settings and explain how bias-variance tradeoffs alter error types under the assumption that training and production class mix are similar.
+2. **Why-model-failed case (classification)**: Random forest recall collapses after deployment. Explain conceptually *why the model failed* (distribution shift + overfit leaf rules), then take corrective action with re-stratified validation, probability calibration, depth/min-samples constraints, and retraining on fresher data.
+
+---
+
 ## Summary
 
 Today you learned:

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_44_Unsupervised_Learning/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_44_Unsupervised_Learning/README.md
@@ -806,6 +806,13 @@ profiles_normalized = profiles / overall  # Ratio to average
 
 ---
 
+## Math-to-Debug Tasks
+
+1. **Geometry-to-debug mapping**: Connect linear transformations (scaling, PCA projection, distance metric changes) to cluster boundary changes and instability symptoms.
+2. **Why-model-failed case**: K-Means segments look random between runs. Explain conceptually *why the model failed* (poor feature geometry + weak cluster separation), then take corrective action with standardized features, informed `k` selection (silhouette/elbow), multiple initializations, and cluster-stability checks.
+
+---
+
 ## Summary
 
 Today you learned:

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_45_Feature_Engineering_and_Evaluation/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_45_Feature_Engineering_and_Evaluation/README.md
@@ -314,6 +314,14 @@ Why use sklearn Pipeline over manual preprocessing?
 
 ---
 
+## Math-to-Debug Tasks
+
+1. **Leakage detection protocol**: Audit each feature with a timestamp and data-availability table; flag any feature that is unavailable at prediction time or computed before split.
+2. **Metric selection under class imbalance**: For the same model, compare accuracy, balanced accuracy, F1, ROC-AUC, and PR-AUC; justify which metric should govern decisions when positives are rare.
+3. **Why-model-failed case**: Offline AUC is excellent but production performance collapses. Explain conceptually *why the model failed* (target leakage + metric mismatch), then take corrective action by rebuilding a leakage-safe pipeline, enforcing temporal validation, and selecting threshold/metric based on minority-class business cost.
+
+---
+
 ## Summary
 
 - ✅ Feature engineering transforms raw data into model-ready signals


### PR DESCRIPTION
### Motivation
- Strengthen students' ability to diagnose model failures by tying mathematical foundations (linear algebra, calculus, statistics) to concrete debugging steps across Phase 4 lessons. 
- Provide a short, reproducible exercise in each day that maps math operations to observable symptoms and requires both a conceptual explanation and a corrective action. 
- Ensure regression/classification days include diagnostics tied to modeling assumptions and the feature-engineering day covers leakage detection and metric choice under imbalance. 

### Description
- Appended a `## Math-to-Debug Tasks` section to each lesson README for Days 38–45 with targeted tasks and one "why model failed" case per day; files updated are the Day 38–45 `README.md` under `content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals`. 
- Linear algebra day: added operation-to-symptom mapping and a collinearity diagnosis mini-case with VIF / Ridge / PCA remedies. 
- Calculus and optimization: added gradient-behavior interpretation and an instability case with concrete fixes (lower LR, clipping, normalization) and verification guidance. 
- Supervised/unsupervised/feature-engineering: added residual diagnostics for regression, confusion-matrix diagnosis and threshold/imbalance remedies for classification, tree/forest deployment failure guidance, cluster-geometry debugging, and a leakage/metric-selection protocol for feature engineering. 

### Testing
- Ran the repository pre-commit checks which executed `prettier --check` on the changed markdown and the formatter passed. 
- Verified presence of the new `## Math-to-Debug Tasks` section in each modified file using ripgrep checks. 
- Confirmed the updated markdown files were written successfully and no formatting errors were reported by the automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998833138cc8330861672d1555af098)