### PR TITLE
Add Optional Build Tracks (NLP, Forecasting, Recommenders/Graph) to Phase 5 Days 49–60

### DIFF
--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_49_NLP/README.md
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_49_NLP/README.md
@@ -764,3 +764,24 @@ Today you learned:
 - ✅ Production pipelines: From raw text to deployed classification system
 
 **Tomorrow**: MLOps—versioning, deploying, and monitoring ML models in production.
+
+---
+
+## Optional Build Tracks (Day 49-60 Extension)
+
+Keep the **core lab tasks** in this lesson common for all learners, then add one optional extension artifact per track:
+
+| Track | Day 49 assignment artifact |
+| --- | --- |
+| **NLP** | Intent & sentiment baseline (TF-IDF + Logistic Regression) vs advanced transformer classifier (DistilBERT). |
+| **Forecasting** | Text-derived demand-signal extractor baseline (keyword rules) vs advanced embedding-based signal model. |
+| **Recommenders/Graph** | Item text-representation baseline (TF-IDF cosine features) vs advanced sentence-embedding retrieval features. |
+
+### Track requirements (apply to all three tracks)
+
+1. **Baseline + advanced model comparison (required):** report offline metrics, error slices, and deployment trade-offs.
+2. **Constraint scenario test (required):** run at least one scenario each day from: **limited data**, **latency limit**, **explainability requirement**.
+3. **Refactoring checkpoint #1 (Day 53):** modularize data prep, training, evaluation, and inference into reusable pipeline components.
+4. **Refactoring checkpoint #2 (Day 58):** externalize hyperparameters/model settings into versioned config files.
+5. **Final deliverable (Day 60):** submit a concise **performance + business-impact memo** tying model lift to ROI, risk, and rollout recommendation.
+

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_50_MLOps/README.md
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_50_MLOps/README.md
@@ -1088,3 +1088,24 @@ Today you learned:
 - ✅ Production MLOps requires orchestration, monitoring, and feedback loops
 
 **Tomorrow**: Regularization techniques—preventing overfitting in complex models.
+
+---
+
+## Optional Build Tracks (Day 49-60 Extension)
+
+Keep the **core lab tasks** in this lesson common for all learners, then add one optional extension artifact per track:
+
+| Track | Day 50 assignment artifact |
+| --- | --- |
+| **NLP** | NLP model delivery pipeline baseline (manual batch scoring) vs advanced CI/CD + monitoring deployment. |
+| **Forecasting** | Forecast retraining ops baseline (weekly notebook rerun) vs advanced scheduled feature/model pipeline with drift alerts. |
+| **Recommenders/Graph** | Recommendation serving ops baseline (offline top-N export) vs advanced online feature store + canary rollout. |
+
+### Track requirements (apply to all three tracks)
+
+1. **Baseline + advanced model comparison (required):** report offline metrics, error slices, and deployment trade-offs.
+2. **Constraint scenario test (required):** run at least one scenario each day from: **limited data**, **latency limit**, **explainability requirement**.
+3. **Refactoring checkpoint #1 (Day 53):** modularize data prep, training, evaluation, and inference into reusable pipeline components.
+4. **Refactoring checkpoint #2 (Day 58):** externalize hyperparameters/model settings into versioned config files.
+5. **Final deliverable (Day 60):** submit a concise **performance + business-impact memo** tying model lift to ROI, risk, and rollout recommendation.
+

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_51_Regularized_Models/README.md
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_51_Regularized_Models/README.md
@@ -867,3 +867,24 @@ Today you learned:
 - ✅ Use cross-validation (RidgeCV, LassoCV) to find optimal alpha
 
 **Tomorrow**: Ensemble methods—combining multiple models for superior performance.
+
+---
+
+## Optional Build Tracks (Day 49-60 Extension)
+
+Keep the **core lab tasks** in this lesson common for all learners, then add one optional extension artifact per track:
+
+| Track | Day 51 assignment artifact |
+| --- | --- |
+| **NLP** | Sparse text classifier baseline (unregularized linear model) vs advanced L1/L2/ElasticNet regularized model. |
+| **Forecasting** | Demand regression baseline (OLS) vs advanced regularized forecaster (Ridge/Lasso/ElasticNet). |
+| **Recommenders/Graph** | Ranking baseline (plain matrix factorization) vs advanced regularized latent-factor model. |
+
+### Track requirements (apply to all three tracks)
+
+1. **Baseline + advanced model comparison (required):** report offline metrics, error slices, and deployment trade-offs.
+2. **Constraint scenario test (required):** run at least one scenario each day from: **limited data**, **latency limit**, **explainability requirement**.
+3. **Refactoring checkpoint #1 (Day 53):** modularize data prep, training, evaluation, and inference into reusable pipeline components.
+4. **Refactoring checkpoint #2 (Day 58):** externalize hyperparameters/model settings into versioned config files.
+5. **Final deliverable (Day 60):** submit a concise **performance + business-impact memo** tying model lift to ROI, risk, and rollout recommendation.
+

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_52_Ensemble_Methods/README.md
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_52_Ensemble_Methods/README.md
@@ -891,3 +891,24 @@ Today you learned:
 - ✅ Feature importance helps interpret black-box ensembles
 
 **Tomorrow**: Model tuning and feature selection—systematic optimization for production.
+
+---
+
+## Optional Build Tracks (Day 49-60 Extension)
+
+Keep the **core lab tasks** in this lesson common for all learners, then add one optional extension artifact per track:
+
+| Track | Day 52 assignment artifact |
+| --- | --- |
+| **NLP** | Ensemble moderation baseline (single classifier) vs advanced stacking/voting ensemble. |
+| **Forecasting** | Forecast baseline (single tree model) vs advanced boosted/bagged ensemble. |
+| **Recommenders/Graph** | Recommendation ranker baseline (single model) vs advanced blended ensemble ranker. |
+
+### Track requirements (apply to all three tracks)
+
+1. **Baseline + advanced model comparison (required):** report offline metrics, error slices, and deployment trade-offs.
+2. **Constraint scenario test (required):** run at least one scenario each day from: **limited data**, **latency limit**, **explainability requirement**.
+3. **Refactoring checkpoint #1 (Day 53):** modularize data prep, training, evaluation, and inference into reusable pipeline components.
+4. **Refactoring checkpoint #2 (Day 58):** externalize hyperparameters/model settings into versioned config files.
+5. **Final deliverable (Day 60):** submit a concise **performance + business-impact memo** tying model lift to ROI, risk, and rollout recommendation.
+

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_53_Model_Tuning_and_Feature_Selection/README.md
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_53_Model_Tuning_and_Feature_Selection/README.md
@@ -939,3 +939,24 @@ Today you learned:
 - ✅ Production requires monitoring feature availability and performance
 
 **Tomorrow**: Probabilistic modeling—reasoning under uncertainty with Bayesian methods.
+
+---
+
+## Optional Build Tracks (Day 49-60 Extension)
+
+Keep the **core lab tasks** in this lesson common for all learners, then add one optional extension artifact per track:
+
+| Track | Day 53 assignment artifact |
+| --- | --- |
+| **NLP** | Hyperparameter optimization baseline (manual tuning) vs advanced Bayesian/Optuna tuning for NLP classifier. |
+| **Forecasting** | Forecast tuning baseline (grid search on one model) vs advanced multi-model Bayesian tuning. |
+| **Recommenders/Graph** | Recsys tuning baseline (manual K/regularization sweeps) vs advanced automated search. |
+
+### Track requirements (apply to all three tracks)
+
+1. **Baseline + advanced model comparison (required):** report offline metrics, error slices, and deployment trade-offs.
+2. **Constraint scenario test (required):** run at least one scenario each day from: **limited data**, **latency limit**, **explainability requirement**.
+3. **Refactoring checkpoint #1 (Day 53):** modularize data prep, training, evaluation, and inference into reusable pipeline components.
+4. **Refactoring checkpoint #2 (Day 58):** externalize hyperparameters/model settings into versioned config files.
+5. **Final deliverable (Day 60):** submit a concise **performance + business-impact memo** tying model lift to ROI, risk, and rollout recommendation.
+

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_54_Probabilistic_Modeling/README.md
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_54_Probabilistic_Modeling/README.md
@@ -1001,3 +1001,24 @@ Today you learned:
 - ✅ Uncertainty matters as much as accuracy in risk-sensitive applications
 
 **Tomorrow**: Advanced unsupervised learning—clustering, dimensionality reduction, and anomaly detection.
+
+---
+
+## Optional Build Tracks (Day 49-60 Extension)
+
+Keep the **core lab tasks** in this lesson common for all learners, then add one optional extension artifact per track:
+
+| Track | Day 54 assignment artifact |
+| --- | --- |
+| **NLP** | Probabilistic classification baseline (point predictions only) vs advanced calibrated uncertainty model. |
+| **Forecasting** | Probabilistic forecast baseline (point estimate) vs advanced quantile/interval forecasting. |
+| **Recommenders/Graph** | CTR prediction baseline (deterministic score) vs advanced Bayesian uncertainty-aware ranking. |
+
+### Track requirements (apply to all three tracks)
+
+1. **Baseline + advanced model comparison (required):** report offline metrics, error slices, and deployment trade-offs.
+2. **Constraint scenario test (required):** run at least one scenario each day from: **limited data**, **latency limit**, **explainability requirement**.
+3. **Refactoring checkpoint #1 (Day 53):** modularize data prep, training, evaluation, and inference into reusable pipeline components.
+4. **Refactoring checkpoint #2 (Day 58):** externalize hyperparameters/model settings into versioned config files.
+5. **Final deliverable (Day 60):** submit a concise **performance + business-impact memo** tying model lift to ROI, risk, and rollout recommendation.
+

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_55_Advanced_Unsupervised_Learning/README.md
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_55_Advanced_Unsupervised_Learning/README.md
@@ -1134,3 +1134,24 @@ Today you learned:
 - ✅ Always validate clustering results with metrics in original high-dimensional space
 
 **Tomorrow**: Time series forecasting—predicting future values from sequential data.
+
+---
+
+## Optional Build Tracks (Day 49-60 Extension)
+
+Keep the **core lab tasks** in this lesson common for all learners, then add one optional extension artifact per track:
+
+| Track | Day 55 assignment artifact |
+| --- | --- |
+| **NLP** | Document clustering baseline (k-means on TF-IDF) vs advanced topic/embedding clustering. |
+| **Forecasting** | Demand regime discovery baseline (k-means on aggregate stats) vs advanced latent-state clustering. |
+| **Recommenders/Graph** | User/item segmentation baseline (k-means) vs advanced graph/representation clustering. |
+
+### Track requirements (apply to all three tracks)
+
+1. **Baseline + advanced model comparison (required):** report offline metrics, error slices, and deployment trade-offs.
+2. **Constraint scenario test (required):** run at least one scenario each day from: **limited data**, **latency limit**, **explainability requirement**.
+3. **Refactoring checkpoint #1 (Day 53):** modularize data prep, training, evaluation, and inference into reusable pipeline components.
+4. **Refactoring checkpoint #2 (Day 58):** externalize hyperparameters/model settings into versioned config files.
+5. **Final deliverable (Day 60):** submit a concise **performance + business-impact memo** tying model lift to ROI, risk, and rollout recommendation.
+

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_56_Time_Series_and_Forecasting/README.md
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_56_Time_Series_and_Forecasting/README.md
@@ -1223,3 +1223,24 @@ Today you learned:
 - ✅ Production monitoring for concept drift and model degradation
 
 **Tomorrow**: Recommender systems—collaborative filtering, matrix factorization, and content-based recommendations.
+
+---
+
+## Optional Build Tracks (Day 49-60 Extension)
+
+Keep the **core lab tasks** in this lesson common for all learners, then add one optional extension artifact per track:
+
+| Track | Day 56 assignment artifact |
+| --- | --- |
+| **NLP** | Temporal text trend model baseline (moving-average keyword trends) vs advanced sequence model for text-driven demand. |
+| **Forecasting** | Core time-series assignment baseline (ARIMA/Prophet) vs advanced deep forecaster (TFT/LSTM). |
+| **Recommenders/Graph** | Time-aware recommendation features baseline (recency heuristics) vs advanced sequential interaction model. |
+
+### Track requirements (apply to all three tracks)
+
+1. **Baseline + advanced model comparison (required):** report offline metrics, error slices, and deployment trade-offs.
+2. **Constraint scenario test (required):** run at least one scenario each day from: **limited data**, **latency limit**, **explainability requirement**.
+3. **Refactoring checkpoint #1 (Day 53):** modularize data prep, training, evaluation, and inference into reusable pipeline components.
+4. **Refactoring checkpoint #2 (Day 58):** externalize hyperparameters/model settings into versioned config files.
+5. **Final deliverable (Day 60):** submit a concise **performance + business-impact memo** tying model lift to ROI, risk, and rollout recommendation.
+

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_57_Recommender_Systems/README.md
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_57_Recommender_Systems/README.md
@@ -1385,3 +1385,24 @@ Today you learned:
 - ✅ Offline RMSE ≠ online engagement; always A/B test with business metrics
 
 **Tomorrow**: Transformers and Attention mechanisms—the architecture behind BERT, GPT, and modern NLP.
+
+---
+
+## Optional Build Tracks (Day 49-60 Extension)
+
+Keep the **core lab tasks** in this lesson common for all learners, then add one optional extension artifact per track:
+
+| Track | Day 57 assignment artifact |
+| --- | --- |
+| **NLP** | Content recommendation baseline (keyword similarity) vs advanced embedding + reranking recommender. |
+| **Forecasting** | Inventory recommendation baseline (rule-based reorder policy) vs advanced forecast-informed policy model. |
+| **Recommenders/Graph** | Core recommender assignment baseline (user/item CF) vs advanced hybrid or two-tower model. |
+
+### Track requirements (apply to all three tracks)
+
+1. **Baseline + advanced model comparison (required):** report offline metrics, error slices, and deployment trade-offs.
+2. **Constraint scenario test (required):** run at least one scenario each day from: **limited data**, **latency limit**, **explainability requirement**.
+3. **Refactoring checkpoint #1 (Day 53):** modularize data prep, training, evaluation, and inference into reusable pipeline components.
+4. **Refactoring checkpoint #2 (Day 58):** externalize hyperparameters/model settings into versioned config files.
+5. **Final deliverable (Day 60):** submit a concise **performance + business-impact memo** tying model lift to ROI, risk, and rollout recommendation.
+

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_58_Transformers_and_Attention/README.md
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_58_Transformers_and_Attention/README.md
@@ -1396,3 +1396,24 @@ Today you learned:
 - ✅ Production optimization: distillation, quantization, ONNX, batching
 
 **Tomorrow**: Generative Models—GANs, VAEs, and modern diffusion models for creating realistic images and data.
+
+---
+
+## Optional Build Tracks (Day 49-60 Extension)
+
+Keep the **core lab tasks** in this lesson common for all learners, then add one optional extension artifact per track:
+
+| Track | Day 58 assignment artifact |
+| --- | --- |
+| **NLP** | Transformer NLP baseline (frozen encoder + linear head) vs advanced fine-tuned attention model. |
+| **Forecasting** | Attention forecaster baseline (LSTM) vs advanced transformer-based time-series model. |
+| **Recommenders/Graph** | Session recommendation baseline (Markov or GRU) vs advanced attention/transformer session model. |
+
+### Track requirements (apply to all three tracks)
+
+1. **Baseline + advanced model comparison (required):** report offline metrics, error slices, and deployment trade-offs.
+2. **Constraint scenario test (required):** run at least one scenario each day from: **limited data**, **latency limit**, **explainability requirement**.
+3. **Refactoring checkpoint #1 (Day 53):** modularize data prep, training, evaluation, and inference into reusable pipeline components.
+4. **Refactoring checkpoint #2 (Day 58):** externalize hyperparameters/model settings into versioned config files.
+5. **Final deliverable (Day 60):** submit a concise **performance + business-impact memo** tying model lift to ROI, risk, and rollout recommendation.
+

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_59_Generative_Models/README.md
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_59_Generative_Models/README.md
@@ -1375,3 +1375,24 @@ Today you learned:
 - ✅ Modern approaches: Stable Diffusion (latent diffusion), DALL-E 3, Midjourney
 
 **Tomorrow**: Graph Neural Networks—learning on network data (social networks, molecules, knowledge graphs).
+
+---
+
+## Optional Build Tracks (Day 49-60 Extension)
+
+Keep the **core lab tasks** in this lesson common for all learners, then add one optional extension artifact per track:
+
+| Track | Day 59 assignment artifact |
+| --- | --- |
+| **NLP** | Generative assistant baseline (template responses) vs advanced retrieval-augmented generation workflow. |
+| **Forecasting** | Scenario planning baseline (static what-if spreadsheet) vs advanced generative simulation narratives. |
+| **Recommenders/Graph** | Recommendation explanation baseline (static rules) vs advanced generative explanation model. |
+
+### Track requirements (apply to all three tracks)
+
+1. **Baseline + advanced model comparison (required):** report offline metrics, error slices, and deployment trade-offs.
+2. **Constraint scenario test (required):** run at least one scenario each day from: **limited data**, **latency limit**, **explainability requirement**.
+3. **Refactoring checkpoint #1 (Day 53):** modularize data prep, training, evaluation, and inference into reusable pipeline components.
+4. **Refactoring checkpoint #2 (Day 58):** externalize hyperparameters/model settings into versioned config files.
+5. **Final deliverable (Day 60):** submit a concise **performance + business-impact memo** tying model lift to ROI, risk, and rollout recommendation.
+

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_60_Graph_and_Geometric_Learning/README.md
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_60_Graph_and_Geometric_Learning/README.md
@@ -1477,3 +1477,24 @@ You've mastered:
 - Graph neural networks
 
 **Next**: Apply these skills to real-world projects and continue learning cutting-edge ML research!
+
+---
+
+## Optional Build Tracks (Day 49-60 Extension)
+
+Keep the **core lab tasks** in this lesson common for all learners, then add one optional extension artifact per track:
+
+| Track | Day 60 assignment artifact |
+| --- | --- |
+| **NLP** | Graph-enhanced NLP baseline (non-graph model) vs advanced knowledge-graph-aware NLP system + final memo. |
+| **Forecasting** | Graph-based forecasting baseline (tabular-only model) vs advanced graph temporal network + final memo. |
+| **Recommenders/Graph** | Graph recommendation baseline (matrix factorization) vs advanced GNN recommender + final memo. |
+
+### Track requirements (apply to all three tracks)
+
+1. **Baseline + advanced model comparison (required):** report offline metrics, error slices, and deployment trade-offs.
+2. **Constraint scenario test (required):** run at least one scenario each day from: **limited data**, **latency limit**, **explainability requirement**.
+3. **Refactoring checkpoint #1 (Day 53):** modularize data prep, training, evaluation, and inference into reusable pipeline components.
+4. **Refactoring checkpoint #2 (Day 58):** externalize hyperparameters/model settings into versioned config files.
+5. **Final deliverable (Day 60):** submit a concise **performance + business-impact memo** tying model lift to ROI, risk, and rollout recommendation.
+


### PR DESCRIPTION
### Motivation
- Provide an advanced-learner pathway across Phase 5 Days 49–60 by adding optional, track-specific extensions while keeping the core lab tasks common. 
- Ensure learners perform rigorous model evaluations by requiring baseline vs advanced comparisons, constraint scenario testing, and engineering-focused refactors. 
- Surface a business-facing deliverable at the end of the module so technical improvements are tied to ROI and rollout recommendations. 

### Description
- Added an `## Optional Build Tracks (Day 49-60 Extension)` section to each Day 49–60 lesson README that maps a single track-specific artifact per day for three tracks: `NLP`, `Forecasting`, and `Recommenders/Graph`. 
- For each track/day entry the PR defines a concrete baseline and advanced artifact (e.g., TF-IDF baseline vs transformer classifier for NLP on Day 49). 
- Introduced a shared requirement list applied across tracks that mandates baseline vs advanced model comparison, daily constraint scenario testing (`limited data`, `latency limit`, `explainability requirement`), two refactoring checkpoints (Day 53 pipeline modularization and Day 58 hyperparameter/config externalization), and a Day 60 performance + business-impact memo. 
- Updated 12 lesson files under `content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_49_*` through `Day_60_*` to include the new section. 

### Testing
- Verified presence of the new `## Optional Build Tracks (Day 49-60 Extension)` section and the requirement strings across all Day 49–60 README files using repository search with `rg`. 
- Confirmed the new sections appear at expected locations via line-inspection (`nl`) for representative files. 
- Pre-commit formatting/lint checks (including `prettier` on staged markdown) completed successfully during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69988335170c83309148b088d3cd235e)