### PR TITLE
Add translation labs to Phase 06 Days 63–72 lessons

### DIFF
--- a/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_63_Causal_Inference_and_Uplift/README.md
+++ b/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_63_Causal_Inference_and_Uplift/README.md
@@ -245,6 +245,19 @@ Customer Z Uplift: -0.05 (Do Not Contact)
 
 ---
 
+## Translation Lab: Causal Findings to KPI Story
+
+**Scenario**: Your uplift model shows positive treatment effect overall, but negative effect for one protected segment.
+
+**Your task**:
+
+1. Translate causal and fairness outputs (ATE/CATE + subgroup parity gap) into a business KPI narrative for revenue, retention, and brand trust.
+2. Define BI metrics to track model degradation and bias over time (weekly uplift drift, subgroup conversion delta, intervention ROI by segment).
+3. Draft dashboard tiles and escalation rules for non-technical stakeholders (e.g., pause campaign if subgroup harm exceeds threshold).
+4. Write a one-page decision memo with technical evidence and a business recommendation.
+
+---
+
 ## Mastery Check
 
 ### Question 1: Confounders

--- a/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_64_Modern_NLP_Pipelines/README.md
+++ b/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_64_Modern_NLP_Pipelines/README.md
@@ -226,6 +226,19 @@ Score: 0.75 (approx)
 
 ---
 
+## Translation Lab: NLP Quality to Business Outcomes
+
+**Scenario**: A support-ticket classifier improves macro F1, but error analysis shows intent confusion for high-value customers.
+
+**Your task**:
+
+1. Convert model-quality and fairness findings into KPI impact language (AHT, CSAT, churn risk, escalations).
+2. Define BI metrics that detect degradation and bias over time (topic drift score, F1 by customer tier, false-negative rate for priority intents).
+3. Propose stakeholder dashboard views and escalation logic when priority-intent performance drops.
+4. Produce a one-page memo that combines technical evidence with a go/no-go recommendation.
+
+---
+
 ## Mastery Check
 
 ### Question 1: Context

--- a/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_65_MLOps_Pipelines_and_CI/README.md
+++ b/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_65_MLOps_Pipelines_and_CI/README.md
@@ -242,6 +242,19 @@ Input: {'usage_minutes': 5.5, 'contract_months': 1} -> Churn Probability: True
 
 ---
 
+## Translation Lab: CI/CD Signals to BI Controls
+
+**Scenario**: Your CI pipeline starts failing data-validation checks intermittently after schema changes.
+
+**Your task**:
+
+1. Translate pipeline reliability and fairness test outputs into KPI narratives (release velocity, incident cost, customer-impact risk).
+2. Define BI metrics for ongoing degradation/bias detection (failed fairness gate rate, retrain frequency, lead time to recovery).
+3. Design dashboard requirements and escalation paths for engineering, product, and compliance stakeholders.
+4. Deliver a one-page decision memo recommending deploy, rollback, or conditional release.
+
+---
+
 ## Mastery Check
 
 ### Question 1: MLOps Definition

--- a/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_66_Model_Deployment_and_Serving/README.md
+++ b/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_66_Model_Deployment_and_Serving/README.md
@@ -234,6 +234,24 @@ Processed 100 records in 1.05 seconds.
 
 ---
 
+## Translation Lab: Deployment Telemetry to Executive Decisions
+
+**Scenario**: A new model endpoint reduces latency but increases prediction disparity for a protected segment during peak traffic.
+
+**Required artifacts**:
+
+* **Notebook analysis**: quantify latency/cost gains, segment-level performance changes, and fairness gaps from deployment logs.
+* **Dashboard specification**: define tiles, filters, thresholds, owners, and escalation SLAs for deployment health + bias monitoring.
+
+**Your task**:
+
+1. Turn deployment and fairness signals into KPI narratives (conversion, SLA compliance, trust, regulatory exposure).
+2. Define BI metrics that catch degradation and bias over time (p95 latency by segment, calibration drift, disparity index).
+3. Convert monitoring signals into stakeholder dashboard and escalation rules.
+4. Produce a one-page decision memo with technical evidence and business recommendation.
+
+---
+
 ## Mastery Check
 
 ### Question 1: Latency

--- a/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_67_Model_Monitoring_and_Reliability/README.md
+++ b/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_67_Model_Monitoring_and_Reliability/README.md
@@ -232,6 +232,24 @@ Current Fraud Rate: 40.0%
 
 ---
 
+## Translation Lab: Monitoring Alerts to Action Plan
+
+**Scenario**: Monitoring detects data drift, rising false negatives, and widening error-rate gaps across regions.
+
+**Required artifacts**:
+
+* **Notebook analysis**: compute drift, reliability, and fairness diagnostics from the last 30 days.
+* **Dashboard specification**: map each monitoring signal to executive/ops views, escalation triggers, and response owners.
+
+**Your task**:
+
+1. Translate reliability and fairness outputs into KPI narratives (revenue leakage, customer experience, compliance risk).
+2. Define BI metrics for degradation/bias over time (drift index, performance decay slope, fairness gap trend).
+3. Build dashboard and escalation rules from monitoring signals.
+4. Write a one-page decision memo recommending retrain, threshold change, or rollback.
+
+---
+
 ## Mastery Check
 
 ### Question 1: Drift Types

--- a/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_68_BI_Analyst_Foundations/README.md
+++ b/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_68_BI_Analyst_Foundations/README.md
@@ -163,6 +163,19 @@ WHERE
 
 ---
 
+## Translation Lab: Analyst Storytelling for Model Risk
+
+**Scenario**: BI analysts receive weekly ML reports but leaders are unclear on business implications.
+
+**Your task**:
+
+1. Translate causal/fairness outputs into KPI narratives executives can act on.
+2. Define BI metrics that reveal degradation and bias trends over time.
+3. Specify dashboard visuals and escalation rules for analyst-to-leadership handoff.
+4. Deliver a one-page decision memo that merges technical evidence and business action.
+
+---
+
 ## Mastery Check
 
 ### Question 1: Descriptive Analytics

--- a/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_69_BI_Strategy_and_Stakeholders/README.md
+++ b/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_69_BI_Strategy_and_Stakeholders/README.md
@@ -165,6 +165,19 @@ executives don't want to see your "work." They want to see your **conclusion**.
 
 ---
 
+## Translation Lab: Stakeholder Alignment Under Model Uncertainty
+
+**Scenario**: Product, Finance, and Risk teams disagree on whether to scale a model with uneven segment performance.
+
+**Your task**:
+
+1. Translate technical causality/fairness outputs into a shared KPI narrative tied to strategic goals.
+2. Define BI metrics for degradation and bias tracking that each stakeholder group accepts.
+3. Convert deployment/monitoring signals into dashboard ownership and escalation governance.
+4. Produce a one-page decision memo with recommendation, trade-offs, and accountability.
+
+---
+
 ## Mastery Check
 
 ### Question 1: Data Translation

--- a/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_70_BI_Metrics_and_Data_Literacy/README.md
+++ b/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_70_BI_Metrics_and_Data_Literacy/README.md
@@ -167,6 +167,19 @@ How addictive is your app?
 
 ---
 
+## Translation Lab: Metric Design for ML Accountability
+
+**Scenario**: Teams track accuracy but miss model decay and subgroup harm until quarterly reviews.
+
+**Your task**:
+
+1. Reframe causal/fairness outputs into business KPI narratives for growth, efficiency, and trust.
+2. Define a BI metric framework to detect degradation and bias over time (leading + lagging indicators).
+3. Convert monitoring signals into dashboard layouts, threshold bands, and escalation rules.
+4. Write a one-page decision memo justifying metric priorities and intervention policy.
+
+---
+
 ## Mastery Check
 
 ### Question 1: Goodhart's Law

--- a/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_71_BI_Data_Landscape/README.md
+++ b/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_71_BI_Data_Landscape/README.md
@@ -185,6 +185,19 @@ WHERE status = 'succeeded'
 
 ---
 
+## Translation Lab: Data Landscape to Decision Readiness
+
+**Scenario**: Source-system inconsistencies create different fairness conclusions across business units.
+
+**Your task**:
+
+1. Translate causal/fairness findings from heterogeneous datasets into a single KPI narrative.
+2. Define BI metrics that monitor degradation and bias over time across domains and geographies.
+3. Map deployment/monitoring signals to stakeholder dashboards and escalation ownership.
+4. Produce a one-page decision memo combining technical caveats with business recommendation.
+
+---
+
 ## Mastery Check
 
 ### Question 1: OLAP vs OLTP

--- a/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_72_BI_Data_Formats_and_Ingestion/README.md
+++ b/content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_72_BI_Data_Formats_and_Ingestion/README.md
@@ -195,6 +195,19 @@ print(flat_rows[1])
 
 ---
 
+## Translation Lab: Ingestion Quality to Governance Signals
+
+**Scenario**: A schema migration introduces silent null inflation that skews fairness monitoring.
+
+**Your task**:
+
+1. Translate ingestion-quality, causal, and fairness outputs into KPI impact narratives.
+2. Define BI metrics for long-term degradation and bias detection (null-rate drift, schema-change impact, subgroup metric stability).
+3. Convert pipeline/deployment monitoring signals into dashboard specs and escalation rules.
+4. Write a one-page decision memo with technical evidence and business recommendation.
+
+---
+
 ## Mastery Check
 
 ### Question 1: Parquet


### PR DESCRIPTION
### Motivation

- Strengthen the bridge between technical ML outputs (causal/fairness/monitoring) and business decision-making by adding practical "translation" exercises to the Phase 06 lesson sequence. 
- Ensure learners practice producing BI-facing artifacts (KPIs, dashboards, escalation rules, and decision memos) so models can be governed operationally and communicated to stakeholders.

### Description

- Added a `## Translation Lab` section to each README in `content/lessons/Phase_06_Cutting_Edge_ML_BI_Foundations/Day_63` through `Day_72` that instructs learners to translate causal/fairness outputs into KPI narratives, define BI metrics for degradation and bias, convert monitoring signals into dashboard/escalation rules, and produce a one-page decision memo. 
- Inserted the new lab content immediately before each lesson's `## Mastery Check` to keep exercises adjacent to conceptual material. 
- Made Days 66 (`Model_Deployment_and_Serving`) and 67 (`Model_Monitoring_and_Reliability`) explicitly require both `notebook analysis` and a `dashboard specification` artifact to satisfy the requirement for at least two labs that include both analysis and dashboard specs. 
- This is a content-only change restricted to the lesson markdown files and does not modify runtime code paths.

### Testing

- Repository pre-commit checks ran including `prettier --check`, and the formatting check passed for all modified markdown files. 
- Presence of the new labs was verified via ripgrep using `rg -n '## Translation Lab'` across Days 63–72 and confirmed for each file. 
- No runtime unit tests were applicable because the changes are documentation-only and therefore no code test failures occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699883378c188330836c520954e8ecc4)