### PR TITLE
Restore Deploy to Surge GitHub workflow

### DIFF
--- a/.github/workflows/deploy-surge.yml
+++ b/.github/workflows/deploy-surge.yml
@@ -1,0 +1,39 @@
+name: Deploy to Surge
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          VITE_BASE_PATH: /
+
+      - name: Install Surge
+        run: npm install --global surge
+
+      - name: Deploy to Surge
+        run: surge --project ./dist --domain coding-for-mba.surge.sh
+        env:
+          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
### Motivation
- The Surge deployment workflow at ` .github/workflows/deploy-surge.yml` was removed during a repo cleanup on 2026-02-19, which disabled automated/manual Surge deployments for the site.

### Description
- Recreated ` .github/workflows/deploy-surge.yml` to restore the original workflow with `workflow_dispatch` and release `published` triggers and steps to checkout, `actions/setup-node@v6` (Node 20), `npm ci`, build with `VITE_BASE_PATH=/`, install `surge`, and deploy using `SURGE_LOGIN`/`SURGE_TOKEN` secrets.

### Testing
- Verified the deletion history with `git log --diff-filter=D -- .github/workflows/deploy-surge.yml` and inspected the restored workflow contents with `sed -n '1,220p' .github/workflows/deploy-surge.yml`, and both checks succeeded, and the restoration was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69988ba2f72483309a27778a90308bb5)