### PR TITLE
Palette: Add reset confirmation to code playground

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-23 - Confirmation for Destructive Actions
+**Learning:** Destructive actions like "Reset Code" in a learning environment are high-risk because they can wipe out user progress. Users often click "Reset" expecting a soft reset or just exploring the UI.
+**Action:** Implement a two-step confirmation pattern (e.g., "Reset" -> "⚠️ Confirm?") with a timeout auto-revert. This reduces accidental data loss without adding the friction of a full modal dialog. Apply this to all irreversible code/content reset actions.

--- a/src/components/CodePlayground.tsx
+++ b/src/components/CodePlayground.tsx
@@ -79,17 +79,43 @@ const normalizeOutput = (value: string): string => value.trim().replace(/\r\n/g,
 const CodePlayground = forwardRef<CodePlaygroundHandle, CodePlaygroundProps>(
   ({ initialCode, expectedOutput, onExpectedOutputMatched, onSubmissionEvaluated }, ref) => {
     const [code, setCode] = useState(initialCode)
+    const [isConfirmingReset, setIsConfirmingReset] = useState(false)
     const textareaRef = useRef<HTMLTextAreaElement>(null)
     const preRef = useRef<HTMLDivElement>(null)
     const runnerRef = useRef<PythonRunnerHandle>(null)
     const runCountRef = useRef(0)
+    const resetTimeoutRef = useRef<number | null>(null)
 
     /**
      * Resets the code editor to its initial state.
      */
     const handleReset = useCallback(() => {
       setCode(initialCode)
+      setIsConfirmingReset(false)
+      if (resetTimeoutRef.current) {
+        clearTimeout(resetTimeoutRef.current)
+        resetTimeoutRef.current = null
+      }
     }, [initialCode])
+
+    const handleResetClick = useCallback(() => {
+      if (isConfirmingReset) {
+        handleReset()
+      } else {
+        setIsConfirmingReset(true)
+        if (resetTimeoutRef.current) clearTimeout(resetTimeoutRef.current)
+        resetTimeoutRef.current = window.setTimeout(() => {
+          setIsConfirmingReset(false)
+          resetTimeoutRef.current = null
+        }, 3000)
+      }
+    }, [isConfirmingReset, handleReset])
+
+    useEffect(() => {
+      return () => {
+        if (resetTimeoutRef.current) clearTimeout(resetTimeoutRef.current)
+      }
+    }, [])
 
     useImperativeHandle(
       ref,
@@ -176,12 +202,16 @@ const CodePlayground = forwardRef<CodePlaygroundHandle, CodePlaygroundProps>(
           <div className="code-playground__actions">
             <CopyButton text={code} className="code-playground__btn" showEmoji={true} />
             <button
-              className="code-playground__btn code-playground__btn--reset"
-              onClick={handleReset}
-              aria-label="Reset code to original"
-              title="Reset code to original"
+              className={`code-playground__btn code-playground__btn--reset ${isConfirmingReset ? 'code-playground__btn--confirm' : ''}`}
+              onClick={handleResetClick}
+              aria-label={
+                isConfirmingReset
+                  ? 'Confirm reset? This will discard your changes'
+                  : 'Reset code to original'
+              }
+              title={isConfirmingReset ? 'Click again to confirm reset' : 'Reset code to original'}
             >
-              ↺ Reset
+              {isConfirmingReset ? '⚠️ Confirm?' : '↺ Reset'}
             </button>
           </div>
         </div>

--- a/src/styles/interactive.css
+++ b/src/styles/interactive.css
@@ -163,6 +163,18 @@
   background: rgba(255, 255, 255, 0.06);
 }
 
+.code-playground__btn--confirm {
+  color: #fca5a5 !important;
+  border-color: rgba(239, 68, 68, 0.5) !important;
+  background: rgba(239, 68, 68, 0.1) !important;
+}
+
+.code-playground__btn--confirm:hover {
+  color: #fecaca !important;
+  background: rgba(239, 68, 68, 0.2) !important;
+  border-color: rgba(239, 68, 68, 0.7) !important;
+}
+
 .code-playground__editor-area {
   position: relative;
   min-height: 60px;


### PR DESCRIPTION
💡 What: Added a confirmation state to the "Reset" button in the Python playground.
🎯 Why: Prevents users from accidentally clearing their code progress with a single click.
♿ Accessibility: Updates aria-label and title dynamically to reflect the confirmation state.

---
*PR created automatically by Jules for task [16636875867469503012](https://jules.google.com/task/16636875867469503012) started by @saint2706*