### PR TITLE
Update Phase 1 expansion notes to reflect current Day 11 coverage

### DIFF
--- a/content-expansion.md
+++ b/content-expansion.md
@@ -32,15 +32,15 @@
 
 **Current state**: 12 days, solid, 4 milestone challenges, covers D1–D12.
 
-**Gaps identified**:
-- Day 11 covers functions, but **generators & iterators** (memory efficiency) are absent
-- **Decorators** (`@property`, `@staticmethod`, `@wraps`) not covered — needed for Phase 2 OOP
-- No lesson on **debugging tools** (`pdb`, breakpoints, `traceback`) despite being beginner-critical
-- No **type hints** introduction (Python 3.9+ is assumed across later phases)
+**Validated against current content**: 2026-02-21 (`Day_11_Functions` includes intro coverage of both type hints and decorators).
+
+**Gaps identified (remaining, true gaps)**:
+- Day 11 introduces modern function syntax, but **iterators/generators depth** is still missing (custom iterator protocol, `yield from`, `itertools`, practical memory profiling)
+- No dedicated **debugging workflow** lesson (`pdb`, breakpoints/watch expressions, stack traces, reproducible bug triage)
 
 **Expansion targets** (2 new days):
-- `Day_13B_Generators_Iterators` — yield, lazy evaluation, infinite sequences
-- `Day_13C_Debugging_and_Type_Hints` — pdb, mypy basics, annotation syntax
+- `Day_13B_Generators_Iterators` — deepen iteration model beyond Day 11 (custom iterators, generator composition, lazy pipelines, business-scale data streaming examples)
+- `Day_13C_Debugging_Workflows` — structured debugging playbook (`pdb`, IDE breakpoints, `traceback`, logging-first diagnosis); avoid re-teaching Day 11 type hints/decorators except brief references
 
 ---
 


### PR DESCRIPTION
### Motivation
- Reduce drift and avoid proposing expansion work that duplicates existing lesson content by verifying Phase 1's Day 11 before keeping or adding gap claims.

### Description
- Updated the Phase 1 section in `content-expansion.md` to add a `Validated against current content` note dated `2026-02-21` and removed outdated claims that type hints and decorators were missing.
- Narrowed remaining gaps to true coverage gaps: deeper `generators/iterators` material and a dedicated `debugging workflow` lesson.
- Re-scoped expansion targets so `Day_13B_Generators_Iterators` deepens iterator/generator topics beyond Day 11, and `Day_13C_Debugging_Workflows` focuses on debugging playbooks while avoiding duplication of Day 11 type-hints/decorators material.
- Confirmed Day 11 (`content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_11_Functions/README.md`) already includes `Type Hints` and `Decorators` sections that inform these changes.

### Testing
- Ran `rg -n "Type Hints|Decorators" content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_11_Functions/README.md` to verify Day 11 contains the sections, which returned matches.
- Committed the change and pre-commit hooks ran `prettier --check` successfully during the commit (`git commit` output shows hooks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e0cec324833086202e6b4a8d5272)