### PR TITLE
Add curriculum-wide day-token support (e.g. 11B) across loading, routing, and search

### DIFF
--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Phase_Overview.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Phase_Overview.md
@@ -1,7 +1,7 @@
 ---
 phase: 1
 title: "Algorithmic Thinking & Python Foundations"
-days: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+days: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 11B, 11C, 12]
 totalDuration: 570
 difficulty: "beginner"
 ---

--- a/scripts/content-schemas.js
+++ b/scripts/content-schemas.js
@@ -15,16 +15,17 @@ import { z } from 'zod'
 const nonEmptyString = z.string().trim().min(1)
 const positiveInt = z.coerce.number().int().positive()
 const positiveNumber = z.coerce.number().positive()
-const bDayString = z
+const dayTokenString = z
   .string()
   .trim()
-  .regex(/^\d+B$/i)
-const phaseDayValueSchema = z.union([positiveInt, bDayString])
+  .regex(/^\d+[A-Za-z]?$/)
+const dayTokenSchema = z.union([positiveInt, dayTokenString])
+const phaseDayValueSchema = z.union([positiveInt, dayTokenString])
 
 export const difficultyLevelSchema = z.enum(['beginner', 'intermediate', 'advanced', 'expert'])
 
 export const lessonFrontmatterSchema = z.object({
-  day: positiveInt,
+  day: dayTokenSchema,
   title: nonEmptyString,
   phase: positiveInt,
   difficulty: difficultyLevelSchema,
@@ -44,7 +45,7 @@ export const phaseOverviewFrontmatterSchema = z.object({
 })
 
 export const exerciseSchema = z.object({
-  day: positiveInt,
+  day: dayTokenSchema,
   lessonTitle: nonEmptyString,
   phase: positiveInt,
   difficulty: difficultyLevelSchema,

--- a/scripts/day-token.js
+++ b/scripts/day-token.js
@@ -1,0 +1,30 @@
+const DAY_TOKEN_PATTERN = /^(\d+)([A-Za-z]?)$/
+
+export function normalizeDayToken(value) {
+  const raw = String(value ?? '').trim()
+  const match = raw.match(DAY_TOKEN_PATTERN)
+  if (!match) return raw.toUpperCase()
+  const dayNumber = Number(match[1])
+  const suffix = (match[2] || '').toUpperCase()
+  return `${dayNumber}${suffix}`
+}
+
+export function compareDayTokens(a, b) {
+  const parse = (v) => {
+    const normalized = normalizeDayToken(v)
+    const match = normalized.match(DAY_TOKEN_PATTERN)
+    if (!match) return { numeric: Number.POSITIVE_INFINITY, suffix: normalized }
+    return { numeric: Number(match[1]), suffix: (match[2] || '').toUpperCase() }
+  }
+  const aa = parse(a)
+  const bb = parse(b)
+  if (aa.numeric !== bb.numeric) return aa.numeric - bb.numeric
+  return aa.suffix.localeCompare(bb.suffix)
+}
+
+export function getDayTokenFromLessonPath(filePath) {
+  const segments = String(filePath).split(/[\\/]/)
+  const lessonDir = segments[segments.length - 2] || ''
+  const match = lessonDir.match(/^Day_(\d+[A-Za-z]?)/)
+  return match && match[1] ? normalizeDayToken(match[1]) : null
+}

--- a/scripts/validate-content.js
+++ b/scripts/validate-content.js
@@ -32,6 +32,7 @@ import {
   phaseOverviewFrontmatterSchema,
   exerciseSchema,
 } from './content-schemas.js'
+import { compareDayTokens, getDayTokenFromLessonPath, normalizeDayToken } from './day-token.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const LESSONS_DIR = path.join(__dirname, '..', 'content', 'lessons')
@@ -124,34 +125,6 @@ function extractExercisesFromLesson(fields, body) {
   }
 
   return exercises
-}
-
-function normalizeDayToken(value) {
-  const raw = String(value ?? '').trim()
-  const match = raw.match(/^(\d+)([a-zA-Z]?)$/)
-  if (!match) return raw.toUpperCase()
-  const number = Number(match[1])
-  const suffix = (match[2] || '').toUpperCase()
-  return `${number}${suffix}`
-}
-
-function compareDayTokens(a, b) {
-  const parse = (v) => {
-    const normalized = normalizeDayToken(v)
-    const match = normalized.match(/^(\d+)([A-Z]?)$/)
-    if (!match) return { numeric: Number.POSITIVE_INFINITY, suffix: normalized }
-    return { numeric: Number(match[1]), suffix: match[2] || '' }
-  }
-  const aa = parse(a)
-  const bb = parse(b)
-  if (aa.numeric !== bb.numeric) return aa.numeric - bb.numeric
-  return aa.suffix.localeCompare(bb.suffix)
-}
-
-function getDayTokenFromLessonPath(filePath) {
-  const lessonDir = path.basename(path.dirname(filePath))
-  const match = lessonDir.match(/^Day_(\d+[A-Za-z]?)/)
-  return match ? normalizeDayToken(match[1]) : null
 }
 
 function getPhaseRoot(filePath, lessonsDir) {

--- a/src/components/ConceptGraph.tsx
+++ b/src/components/ConceptGraph.tsx
@@ -10,6 +10,7 @@ import { useRef, useEffect, useCallback, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import * as d3 from 'd3'
 import { getAllLessons, phaseIcons } from '../utils/contentLoader'
+import { dayTokenFromReference } from '../utils/dayToken'
 
 /**
  * Color palette for phase differentiation in the graph.
@@ -37,7 +38,7 @@ const PHASE_COLORS = [
  * @property concepts - Array of concept tags associated with the lesson
  */
 interface GraphNode extends d3.SimulationNodeDatum {
-  id: number
+  id: string
   label: string
   title: string
   phase: number
@@ -51,8 +52,8 @@ interface GraphNode extends d3.SimulationNodeDatum {
  * @property target - Target node or node ID
  */
 interface GraphEdge extends d3.SimulationLinkDatum<GraphNode> {
-  source: GraphNode | number
-  target: GraphNode | number
+  source: GraphNode | string
+  target: GraphNode | string
 }
 
 /**
@@ -110,7 +111,7 @@ export default function ConceptGraph({ search = '', highlightPhase = null }: Con
 
     // Build nodes & edges
     const nodes: GraphNode[] = lessons.map((l) => ({
-      id: l.day,
+      id: String(l.day),
       label: `D${l.day}`,
       title: l.title,
       phase: l.phase,
@@ -122,12 +123,14 @@ export default function ConceptGraph({ search = '', highlightPhase = null }: Con
     const edges: GraphEdge[] = []
     const edgeSet = new Set<string>()
     for (const l of lessons) {
-      const prereqs = (l.prerequisites as number[]) || []
+      const prereqs = ((l.prerequisites as unknown[]) || [])
+        .map((entry) => dayTokenFromReference(entry))
+        .filter((entry): entry is string => Boolean(entry))
       for (const p of prereqs) {
         const key = `${p}-${l.day}`
         if (!edgeSet.has(key) && nodeById.has(p)) {
           edgeSet.add(key)
-          edges.push({ source: p, target: l.day })
+          edges.push({ source: p, target: String(l.day) })
         }
       }
     }
@@ -310,7 +313,7 @@ export default function ConceptGraph({ search = '', highlightPhase = null }: Con
     const hasFilter = search.length > 0 || highlightPhase !== null
 
     // Track visible node IDs to efficiently update edges without DOM re-querying
-    const visibleNodeIds = new Set<number>()
+    const visibleNodeIds = new Set<string>()
 
     // 1. First pass: Check all nodes and determine visibility
     d3Svg.selectAll<SVGGElement, GraphNode>('.graph-node').each(function (d) {
@@ -344,8 +347,8 @@ export default function ConceptGraph({ search = '', highlightPhase = null }: Con
       }
 
       // Handle both number (initial) and object (simulated) references
-      const sId = typeof d.source === 'number' ? d.source : (d.source as GraphNode).id
-      const tId = typeof d.target === 'number' ? d.target : (d.target as GraphNode).id
+      const sId = typeof d.source === 'string' ? d.source : (d.source as GraphNode).id
+      const tId = typeof d.target === 'string' ? d.target : (d.target as GraphNode).id
 
       const sMatch = visibleNodeIds.has(sId)
       const tMatch = visibleNodeIds.has(tId)

--- a/src/components/ExerciseWidget.tsx
+++ b/src/components/ExerciseWidget.tsx
@@ -28,6 +28,7 @@ import CopyButton from './CopyButton'
 import { useLocation } from 'react-router-dom'
 import { getAllExercises } from '../utils/contentLoader'
 import { markExerciseComplete } from '../utils/exerciseProgress'
+import { dayTokenToProgressId, normalizeDayToken } from '../utils/dayToken'
 import { triggerDayExercisesCompleteConfetti } from '../utils/confetti'
 import { toastSuccess } from '../utils/toast'
 import { useQuizStore } from '../stores/quizStore'
@@ -82,13 +83,14 @@ export default function ExerciseWidget({
 
   const location = useLocation()
   const lessonDay = useMemo(() => {
-    const match = location.pathname.match(/\/lesson\/(\d+)/)
-    return match ? Number(match[1]) : null
+    const match = location.pathname.match(/\/lesson\/([^/]+)/)
+    return match && match[1] ? normalizeDayToken(match[1]) : null
   }, [location.pathname])
 
   const totalExercisesForDay = useMemo(() => {
     if (!lessonDay) return 0
-    return getAllExercises().filter((exercise) => exercise.day === lessonDay).length
+    return getAllExercises().filter((exercise) => normalizeDayToken(exercise.day) === lessonDay)
+      .length
   }, [lessonDay])
 
   const exerciseId = useMemo(() => {
@@ -101,8 +103,14 @@ export default function ExerciseWidget({
 
   const handleExerciseMatch = useCallback(() => {
     if (!lessonDay) return
-    useGamificationStore.getState().awardExerciseCompletion(lessonDay, exerciseId)
-    const completedAll = markExerciseComplete(lessonDay, exerciseId, totalExercisesForDay)
+    useGamificationStore
+      .getState()
+      .awardExerciseCompletion(dayTokenToProgressId(lessonDay), exerciseId)
+    const completedAll = markExerciseComplete(
+      dayTokenToProgressId(lessonDay),
+      exerciseId,
+      totalExercisesForDay,
+    )
     if (completedAll) {
       triggerDayExercisesCompleteConfetti()
       toastSuccess(`All exercises complete for Day ${lessonDay}!`)

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import { Link, useLocation } from 'react-router-dom'
 import { getAllPhases, getLessonsByPhase, phaseIcons } from '../utils/contentLoader'
 import { isLessonComplete, getCompletedForPhase } from '../utils/progressTracker'
 import { getReviewDueCountByPhase, getReviewStreak } from '../utils/reviewTracker'
+import { dayTokenToProgressId, normalizeDayToken } from '../utils/dayToken'
 
 /**
  * Props for the Sidebar component.
@@ -45,10 +46,10 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
   const prefersReducedMotion = useReducedMotion()
 
   const derivedOpenPhase = useMemo(() => {
-    const lessonMatch = location.pathname.match(/\/lesson\/(\d+)/)
-    if (lessonMatch) {
-      const dayNum = Number(lessonMatch[1])
-      const phase = phases.find((p) => p.days && p.days.includes(dayNum))
+    const lessonMatch = location.pathname.match(/\/lesson\/([^/]+)/)
+    if (lessonMatch && lessonMatch[1]) {
+      const dayToken = normalizeDayToken(lessonMatch[1])
+      const phase = phases.find((p) => p.days && p.days.includes(dayToken))
       if (phase) return phase.phase
     }
     const phaseMatch = location.pathname.match(/\/phase\/(\d+)/)
@@ -262,7 +263,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                             className={`day-link ${location.pathname === `/lesson/${lesson.day}` ? 'active' : ''}`}
                             onClick={onClose}
                           >
-                            {isLessonComplete(lesson.day) && (
+                            {isLessonComplete(dayTokenToProgressId(lesson.day)) && (
                               <span className="day-link-check" aria-label="Completed">
                                 ✓
                               </span>

--- a/src/pages/Exercises.tsx
+++ b/src/pages/Exercises.tsx
@@ -20,6 +20,7 @@ import {
   phaseIcons,
 } from '../utils/contentLoader'
 import Breadcrumb from '../components/Breadcrumb'
+import { compareDayTokens } from '../utils/dayToken'
 import { useQuizStore } from '../stores/quizStore'
 
 /**
@@ -139,9 +140,9 @@ export default function Exercises() {
     })
 
     return results.sort((a, b) => {
-      if (sortOrder === 'phase-desc') return b.phase - a.phase || b.day - a.day
+      if (sortOrder === 'phase-desc') return b.phase - a.phase || compareDayTokens(b.day, a.day)
       if (sortOrder === 'title-asc') return a.title.localeCompare(b.title)
-      return a.phase - b.phase || a.day - b.day
+      return a.phase - b.phase || compareDayTokens(a.day, b.day)
     })
   }, [exercises, phaseFilter, difficultyFilter, searchQuery, sortOrder])
 

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -26,6 +26,7 @@ import SEOHead from '../components/SEOHead'
  */
 
 import { buildLessonSchema } from '../utils/seoSchemas'
+import { dayTokenToProgressId, parseDayToken } from '../utils/dayToken'
 import {
   getLesson,
   getAdjacentLessons,
@@ -77,7 +78,7 @@ export default function Lesson() {
   const lesson = getLesson(dayNum!)
   const { prev, next } = getAdjacentLessons(dayNum!)
   const [completed, setCompleted] = useState(() =>
-    dayNum ? isLessonComplete(Number(dayNum)) : false,
+    dayNum ? isLessonComplete(dayTokenToProgressId(dayNum)) : false,
   )
   const lastToastAtRef = useRef(0)
 
@@ -90,11 +91,11 @@ export default function Lesson() {
 
   // Sync completed state when navigating between lessons
   useEffect(() => {
-    setCompleted(isLessonComplete(Number(dayNum)))
+    setCompleted(dayNum ? isLessonComplete(dayTokenToProgressId(dayNum)) : false)
   }, [dayNum])
 
   const handleToggleComplete = useCallback(() => {
-    const day = Number(dayNum)
+    const day = dayNum ? dayTokenToProgressId(dayNum) : Number.NaN
     const beforeCompleted = new Set(getCompletedLessons())
     const nowComplete = toggleLessonComplete(day)
     setCompleted(nowComplete)
@@ -114,10 +115,14 @@ export default function Lesson() {
 
       const afterCompleted = getCompletedLessons()
       const wasPhaseCompleted = lesson
-        ? getLessonsByPhase(lesson.phase).every((entry) => beforeCompleted.has(entry.day))
+        ? getLessonsByPhase(lesson.phase).every((entry) =>
+            beforeCompleted.has(dayTokenToProgressId(entry.day)),
+          )
         : false
       const isPhaseCompleted = lesson
-        ? getLessonsByPhase(lesson.phase).every((entry) => afterCompleted.includes(entry.day))
+        ? getLessonsByPhase(lesson.phase).every((entry) =>
+            afterCompleted.includes(dayTokenToProgressId(entry.day)),
+          )
         : false
 
       if (lesson && !wasPhaseCompleted && isPhaseCompleted) {
@@ -195,7 +200,13 @@ export default function Lesson() {
         path={lessonPath}
         ogType="article"
         jsonLd={[
-          buildLessonSchema(lessonTitle, lessonDescription, lessonPath, lesson.day, lesson.phase),
+          buildLessonSchema(
+            lessonTitle,
+            lessonDescription,
+            lessonPath,
+            parseDayToken(lesson.day)?.number || 0,
+            lesson.phase,
+          ),
         ]}
         breadcrumbs={[
           { name: 'Home', url: '/' },

--- a/src/pages/__tests__/Lesson.test.tsx
+++ b/src/pages/__tests__/Lesson.test.tsx
@@ -20,7 +20,7 @@ const {
 }))
 
 vi.mock('react-router-dom', () => ({
-  useParams: () => ({ dayNum: '1' }),
+  useParams: () => ({ dayNum: '1B' }),
   useNavigate: () => vi.fn(),
   Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
     <a href={to} {...props}>
@@ -31,7 +31,7 @@ vi.mock('react-router-dom', () => ({
 
 vi.mock('../../utils/contentLoader', () => ({
   getLesson: () => ({
-    day: 1,
+    day: '1B',
     title: 'Intro',
     phase: 1,
     content: '# Intro',
@@ -40,7 +40,7 @@ vi.mock('../../utils/contentLoader', () => ({
   }),
   getAdjacentLessons: () => ({ prev: null, next: null }),
   getAllPhases: () => [{ phase: 1 }, { phase: 2 }],
-  getLessonsByPhase: (phase: number) => (phase === 1 ? [{ day: 1 }] : [{ day: 2 }]),
+  getLessonsByPhase: (phase: number) => (phase === 1 ? [{ day: '1B' }] : [{ day: '2' }]),
   difficultyConfig: {
     beginner: { label: 'Beginner', color: '#000', bg: '#fff' },
   },

--- a/src/stores/gamificationStore.ts
+++ b/src/stores/gamificationStore.ts
@@ -17,6 +17,7 @@ import { getAllPhases, getLessonsByPhase } from '../utils/contentLoader'
 import { useProgressStore } from './progressStore'
 import { triggerSparkle } from '../utils/confetti'
 import { toastSuccess } from '../utils/toast'
+import { dayTokenToProgressId } from '../utils/dayToken'
 
 const STORAGE_KEY = 'coding-for-mba-gamification'
 
@@ -169,7 +170,9 @@ function resolveChallengeCandidates(): number[] {
   }
 
   return getAllPhases().flatMap((phase) =>
-    getLessonsByPhase(phase.phase).map((lesson) => lesson.day),
+    getLessonsByPhase(phase.phase)
+      .map((lesson) => dayTokenToProgressId(lesson.day))
+      .filter((day) => Number.isInteger(day) && day > 0),
   )
 }
 

--- a/src/stores/progressStore.ts
+++ b/src/stores/progressStore.ts
@@ -13,6 +13,7 @@
 import { create } from 'zustand'
 import { StateStorage, createJSONStorage, persist } from 'zustand/middleware'
 import { getStoredString, removeStoredValue } from '../utils/safeStorage'
+import { dayTokenToProgressId } from '../utils/dayToken'
 
 const STORAGE_KEY = 'coding-for-mba-progress'
 const LAST_VISITED_KEY = 'coding-for-mba-last-visited'
@@ -63,15 +64,15 @@ type ProgressStore = {
   completionDates: Record<number, string>
   hasHydrated: boolean
   hydrate: () => void
-  markLessonComplete: (day: number, completedAt?: Date) => void
-  markLessonIncomplete: (day: number) => void
-  toggleLessonComplete: (day: number, completedAt?: Date) => boolean
-  isLessonComplete: (day: number) => boolean
+  markLessonComplete: (day: string | number, completedAt?: Date) => void
+  markLessonIncomplete: (day: string | number) => void
+  toggleLessonComplete: (day: string | number, completedAt?: Date) => boolean
+  isLessonComplete: (day: string | number) => boolean
   clearAllProgress: () => void
-  setLastVisited: (day: number) => void
-  getCompletedForPhase: (phaseLessonDays: number[]) => number[]
+  setLastVisited: (day: string | number) => void
+  getCompletedForPhase: (phaseLessonDays: Array<string | number>) => number[]
   completedLessonsCount: () => number
-  phaseProgress: (phaseLessonDays: number[]) => PhaseProgress
+  phaseProgress: (phaseLessonDays: Array<string | number>) => PhaseProgress
   streakDays: (now?: Date) => number
 }
 
@@ -184,42 +185,47 @@ export const useProgressStore = create<ProgressStore>()(
         useProgressStore.persist.rehydrate()
       },
       markLessonComplete: (day, completedAt = new Date()) => {
-        if (!Number.isInteger(day) || day < 1) return
+        const normalizedDay = dayTokenToProgressId(day)
+        if (!Number.isInteger(normalizedDay) || normalizedDay < 1) return
 
         set((state) => {
-          if (state.completedLessons.includes(day)) return state
+          if (state.completedLessons.includes(normalizedDay)) return state
           return {
-            completedLessons: [...state.completedLessons, day].sort((a, b) => a - b),
+            completedLessons: [...state.completedLessons, normalizedDay].sort((a, b) => a - b),
             completionDates: {
               ...state.completionDates,
-              [day]: toDayKey(completedAt),
+              [normalizedDay]: toDayKey(completedAt),
             },
           }
         })
       },
       markLessonIncomplete: (day) => {
-        if (!Number.isInteger(day) || day < 1) return
+        const normalizedDay = dayTokenToProgressId(day)
+        if (!Number.isInteger(normalizedDay) || normalizedDay < 1) return
 
         set((state) => ({
-          completedLessons: state.completedLessons.filter((value) => value !== day),
+          completedLessons: state.completedLessons.filter((value) => value !== normalizedDay),
           completionDates: Object.fromEntries(
-            Object.entries(state.completionDates).filter(([savedDay]) => Number(savedDay) !== day),
+            Object.entries(state.completionDates).filter(
+              ([savedDay]) => Number(savedDay) !== normalizedDay,
+            ),
           ),
         }))
       },
       toggleLessonComplete: (day, completedAt = new Date()) => {
-        if (!Number.isInteger(day) || day < 1) return false
+        const normalizedDay = dayTokenToProgressId(day)
+        if (!Number.isInteger(normalizedDay) || normalizedDay < 1) return false
 
-        const isCompleted = get().completedLessons.includes(day)
+        const isCompleted = get().completedLessons.includes(normalizedDay)
         if (isCompleted) {
-          get().markLessonIncomplete(day)
+          get().markLessonIncomplete(normalizedDay)
           return false
         }
 
-        get().markLessonComplete(day, completedAt)
+        get().markLessonComplete(normalizedDay, completedAt)
         return true
       },
-      isLessonComplete: (day) => get().completedLessons.includes(day),
+      isLessonComplete: (day) => get().completedLessons.includes(dayTokenToProgressId(day)),
       clearAllProgress: () => {
         set({
           completedLessons: [],
@@ -229,12 +235,15 @@ export const useProgressStore = create<ProgressStore>()(
         removeStoredValue(LAST_VISITED_KEY)
       },
       setLastVisited: (day) => {
-        if (!Number.isInteger(day) || day < 1) return
-        set({ lastVisitedLesson: day })
+        const normalizedDay = dayTokenToProgressId(day)
+        if (!Number.isInteger(normalizedDay) || normalizedDay < 1) return
+        set({ lastVisitedLesson: normalizedDay })
       },
       getCompletedForPhase: (phaseLessonDays) => {
         const completed = new Set(get().completedLessons)
-        return phaseLessonDays.filter((day) => completed.has(day))
+        return phaseLessonDays
+          .map((day) => dayTokenToProgressId(day))
+          .filter((day) => completed.has(day))
       },
       completedLessonsCount: () => get().completedLessons.length,
       phaseProgress: (phaseLessonDays) => {

--- a/src/utils/__tests__/contentLoader.test.ts
+++ b/src/utils/__tests__/contentLoader.test.ts
@@ -18,7 +18,9 @@ describe('contentLoader', () => {
     const lessons = getAllLessons()
 
     expect(lessons.length).toBeGreaterThan(100)
-    expect(lessons.every((lesson) => typeof lesson.day === 'number' && lesson.day > 0)).toBe(true)
+    expect(lessons.every((lesson) => typeof lesson.day === 'string' && lesson.day.length > 0)).toBe(
+      true,
+    )
     expect(new Set(lessons.map((lesson) => lesson.path)).size).toBe(lessons.length)
   })
 
@@ -27,7 +29,7 @@ describe('contentLoader', () => {
 
     expect(phases.length).toBeGreaterThan(0)
 
-    const lesson = getLesson(1)
+    const lesson = getLesson('1')
     expect(lesson).toBeDefined()
 
     const phaseLessons = getLessonsByPhase(lesson!.phase)
@@ -82,6 +84,20 @@ test words repeated `.repeat(120)
     expect(getAdjacentLessons(999999)).toEqual({ prev: null, next: null })
   })
 
+  it('supports mixed day tokens for lookup and sorting', () => {
+    const day36 = getLesson('36')
+    const day36B = getLesson('36B')
+
+    expect(day36).toBeDefined()
+    expect(day36B).toBeDefined()
+
+    const around36 = getAdjacentLessons('36')
+    expect(around36.next?.day).toBe('36B')
+
+    const around36B = getAdjacentLessons('36B')
+    expect(around36B.prev?.day).toBe('36')
+  })
+
   it('handles notebook lookups safely', () => {
     const notebooks = getAllNotebooks()
     expect(notebooks.length).toBeGreaterThan(0)
@@ -106,7 +122,7 @@ test words repeated `.repeat(120)
 
     const prereqs = getPrerequisiteLessons(lessonWithPrereqs!)
     expect(Array.isArray(prereqs)).toBe(true)
-    expect(prereqs.every((lesson) => typeof lesson.day === 'number')).toBe(true)
+    expect(prereqs.every((lesson) => typeof lesson.day === 'string')).toBe(true)
 
     const related = getRelatedLessons(lessonWithPrereqs!, 4)
     expect(related.length).toBeLessThanOrEqual(4)

--- a/src/utils/__tests__/contentSchemas.test.ts
+++ b/src/utils/__tests__/contentSchemas.test.ts
@@ -11,7 +11,7 @@ const {
 describe('content zod schemas', () => {
   it('accepts valid lesson frontmatter fixture', () => {
     const validLesson = {
-      day: 1,
+      day: '11B',
       title: 'Python Basics for Business',
       phase: 1,
       difficulty: 'beginner',
@@ -47,7 +47,7 @@ describe('content zod schemas', () => {
     const validPhase = {
       phase: 2,
       title: 'Functions & Modularity',
-      days: [13, 14, 15],
+      days: [13, '14B', 15],
       totalDuration: 360,
       difficulty: 'intermediate',
     }

--- a/src/utils/__tests__/searchIndex-functions.test.ts
+++ b/src/utils/__tests__/searchIndex-functions.test.ts
@@ -4,7 +4,8 @@ import type { Lesson } from '../contentLoader'
 
 const lessons: Lesson[] = [
   {
-    day: 1,
+    day: '1',
+    daySortKey: '00001:',
     title: 'Python Variables',
     phase: 1,
     tags: ['basics'],
@@ -13,7 +14,8 @@ const lessons: Lesson[] = [
     path: '/fake/1',
   },
   {
-    day: 2,
+    day: '2',
+    daySortKey: '00002:',
     title: 'Intro',
     phase: 1,
     tags: ['python variables'],
@@ -22,7 +24,8 @@ const lessons: Lesson[] = [
     path: '/fake/2',
   },
   {
-    day: 3,
+    day: '3',
+    daySortKey: '00003:',
     title: 'Intro to loops',
     phase: 1,
     tags: ['control flow'],
@@ -55,6 +58,6 @@ describe('search index', () => {
   it('returns title match first from fuse search', () => {
     const engine = createSearchEngine(lessons)
     const results = engine.search('python variables')
-    expect(results[0]?.item.day).toBe(1)
+    expect(results[0]?.item.day).toBe('1')
   })
 })

--- a/src/utils/__tests__/searchIndex.test.ts
+++ b/src/utils/__tests__/searchIndex.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const lessons = [
   {
-    day: 1,
+    day: '11',
+    daySortKey: '00011:',
     title: 'Intro to Python Variables',
     phase: 1,
     tags: ['python', 'basics'],
@@ -11,7 +12,8 @@ const lessons = [
     path: '/content/lessons/Phase_1/README.md',
   },
   {
-    day: 2,
+    day: '11B',
+    daySortKey: '00011:B',
     title: 'SQL JOIN Deep Dive',
     phase: 2,
     tags: ['sql'],
@@ -41,11 +43,11 @@ describe('searchIndex', () => {
   it('finds and ranks likely results by relevance', () => {
     const results = search('python')
     expect(results.length).toBeGreaterThan(0)
-    expect((results[0] as { item: { day: number } }).item.day).toBe(1)
+    expect((results[0] as { item: { day: string } }).item.day).toBe('11')
   })
 
   it('respects result limit', () => {
-    const results = search('learn', 1)
+    const results = search('11B', 1)
     expect(results.length).toBe(1)
   })
 })

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -13,6 +13,14 @@
 
 import { parseMarkdown } from './frontmatter'
 import { difficultyConfig, phaseIcons } from './curriculumConfig'
+import {
+  compareDayTokens,
+  dayTokenFromPath,
+  dayTokenFromReference,
+  normalizeDayToken,
+  parseDayToken,
+  type DayToken,
+} from './dayToken'
 
 /**
  * Represents a single lesson unit.
@@ -20,7 +28,8 @@ import { difficultyConfig, phaseIcons } from './curriculumConfig'
  */
 export interface Lesson {
   /** The day number of the lesson (unique ID). */
-  day: number
+  day: DayToken
+  daySortKey?: string
   title: string
   phase: number
   difficulty?: string
@@ -38,7 +47,7 @@ export interface Phase {
   title: string
   difficulty?: string
   totalDuration?: number
-  days?: readonly number[]
+  days?: readonly DayToken[]
   content: string
   path: string
   [key: string]: unknown
@@ -59,19 +68,41 @@ const phaseFiles = import.meta.glob('/content/lessons/**/Phase_Overview.md', {
 const lessons: Lesson[] = Object.entries(lessonFiles)
   .map(([path, raw]) => {
     const { frontmatter, content } = parseMarkdown(raw)
+    const frontmatterDay =
+      typeof frontmatter.day === 'string' || typeof frontmatter.day === 'number'
+        ? normalizeDayToken(frontmatter.day)
+        : null
+    const pathDay = dayTokenFromPath(path)
+    const day = pathDay || frontmatterDay || '0'
+    const parsedDay = parseDayToken(day)
+    const prerequisites = Array.isArray(frontmatter.prerequisites)
+      ? frontmatter.prerequisites
+          .map((entry) => dayTokenFromReference(entry))
+          .filter((entry): entry is DayToken => Boolean(entry))
+      : undefined
+
     return {
       ...frontmatter,
+      day,
+      daySortKey: parsedDay?.sortKey || day,
+      prerequisites,
       content,
       path,
-    } as Lesson
+    } as unknown as Lesson
   })
-  .sort((a, b) => (a.day || 0) - (b.day || 0))
+  .sort((a, b) => compareDayTokens(a.day, b.day))
 
 const phases: Phase[] = Object.entries(phaseFiles)
   .map(([path, raw]) => {
     const { frontmatter, content } = parseMarkdown(raw)
+    const days = Array.isArray(frontmatter.days)
+      ? frontmatter.days
+          .map((entry) => dayTokenFromReference(entry))
+          .filter((entry): entry is DayToken => Boolean(entry))
+      : undefined
     return {
       ...frontmatter,
+      days,
       content,
       path,
     } as Phase
@@ -95,7 +126,8 @@ export function getAllLessons(): readonly ImmutableLesson[] {
 
 /** Return a lesson by day number. */
 export function getLesson(dayNum: string | number): ImmutableLesson | undefined {
-  return immutableLessons.find((l) => l.day === Number(dayNum))
+  const dayToken = normalizeDayToken(dayNum)
+  return immutableLessons.find((l) => l.day === dayToken)
 }
 
 /** Return all lessons in a phase. */
@@ -108,8 +140,8 @@ export function getAdjacentLessons(dayNum: string | number): {
   prev: ImmutableLesson | null
   next: ImmutableLesson | null
 } {
-  const day = Number(dayNum)
-  const currentIndex = immutableLessons.findIndex((l) => l.day === day)
+  const dayToken = normalizeDayToken(dayNum)
+  const currentIndex = immutableLessons.findIndex((l) => l.day === dayToken)
 
   if (currentIndex === -1) {
     return { prev: null, next: null }
@@ -126,7 +158,7 @@ export function getAdjacentLessons(dayNum: string | number): {
 
 /** Exercise parsed from lesson markdown. */
 export interface Exercise {
-  day: number
+  day: DayToken
   lessonTitle: string
   phase: number
   difficulty: string
@@ -138,7 +170,7 @@ export interface Exercise {
 
 export interface ReviewCardSeed {
   id: string
-  day: number
+  day: DayToken
   phase: number
   lessonTitle: string
   sourceType: 'concept' | 'heading' | 'exercise'
@@ -329,7 +361,7 @@ function freezeStringArray(values?: readonly string[]): readonly string[] | unde
   return values ? Object.freeze([...values]) : undefined
 }
 
-function freezeNumberArray(values?: readonly number[]): readonly number[] | undefined {
+function freezeDayTokenArray(values?: readonly DayToken[]): readonly DayToken[] | undefined {
   return values ? Object.freeze([...values]) : undefined
 }
 
@@ -338,14 +370,14 @@ function freezeLesson(lesson: Lesson): ImmutableLesson {
     ...lesson,
     tags: freezeStringArray(lesson.tags),
     concepts: freezeStringArray(lesson.concepts),
-    prerequisites: freezeNumberArray(lesson.prerequisites as readonly number[] | undefined),
+    prerequisites: freezeDayTokenArray(lesson.prerequisites as readonly DayToken[] | undefined),
   })
 }
 
 function freezePhase(phase: Phase): ImmutablePhase {
   return Object.freeze({
     ...phase,
-    days: freezeNumberArray(phase.days),
+    days: freezeDayTokenArray(phase.days),
   })
 }
 
@@ -451,16 +483,21 @@ export function getReadingTime(content: string): number {
 
 /** Resolve prerequisite day references into lesson objects. */
 export function getPrerequisiteLessons(lesson: Readonly<Lesson>): readonly ImmutableLesson[] {
-  const prereqs = lesson.prerequisites as readonly number[] | undefined
+  const prereqs = lesson.prerequisites as readonly unknown[] | undefined
   if (!prereqs || !Array.isArray(prereqs) || prereqs.length === 0) return []
   return prereqs
-    .map((day) => immutableLessons.find((l) => l.day === Number(day)))
+    .map((day) => dayTokenFromReference(day))
+    .map((day) => (day ? immutableLessons.find((l) => l.day === day) : undefined))
     .filter((l): l is ImmutableLesson => l !== undefined)
 }
 
 /** Return top related lessons ranked by shared tags/concepts and phase proximity. */
 export function getRelatedLessons(lesson: Readonly<Lesson>, count = 4): readonly ImmutableLesson[] {
-  const prereqs = new Set((lesson.prerequisites as readonly number[]) || [])
+  const prereqs = new Set(
+    ((lesson.prerequisites as readonly unknown[]) || [])
+      .map((entry) => dayTokenFromReference(entry))
+      .filter((entry): entry is DayToken => Boolean(entry)),
+  )
   const myTags = new Set((lesson.tags as readonly string[]) || [])
   const myConcepts = new Set((lesson.concepts as readonly string[]) || [])
 

--- a/src/utils/dayToken.ts
+++ b/src/utils/dayToken.ts
@@ -1,0 +1,77 @@
+export type DayToken = string
+
+export interface ParsedDayToken {
+  token: DayToken
+  number: number
+  suffix: string
+  sortKey: string
+}
+
+const DAY_TOKEN_PATTERN = /^(\d+)([A-Za-z]?)$/
+
+export function normalizeDayToken(value: string | number): DayToken {
+  const raw = String(value ?? '').trim()
+  const match = raw.match(DAY_TOKEN_PATTERN)
+  if (!match) return raw.toUpperCase()
+  const [, numericPart = '0', suffixPart = ''] = match
+  const dayNumber = Number(numericPart)
+  const suffix = suffixPart.toUpperCase()
+  return `${dayNumber}${suffix}`
+}
+
+export function parseDayToken(value: string | number): ParsedDayToken | null {
+  const token = normalizeDayToken(value)
+  const match = token.match(DAY_TOKEN_PATTERN)
+  if (!match) return null
+  const [, numericPart = '0', suffixPart = ''] = match
+  const dayNumber = Number(numericPart)
+  const suffix = suffixPart.toUpperCase()
+  return {
+    token,
+    number: dayNumber,
+    suffix,
+    sortKey: `${String(dayNumber).padStart(5, '0')}:${suffix}`,
+  }
+}
+
+export function compareDayTokens(a: string | number, b: string | number): number {
+  const aa = parseDayToken(a)
+  const bb = parseDayToken(b)
+  if (!aa || !bb) {
+    return normalizeDayToken(a).localeCompare(normalizeDayToken(b))
+  }
+  if (aa.number !== bb.number) return aa.number - bb.number
+  return aa.suffix.localeCompare(bb.suffix)
+}
+
+export function extractDayToken(value: unknown): DayToken | null {
+  if (typeof value !== 'string' && typeof value !== 'number') return null
+  const parsed = parseDayToken(value)
+  return parsed ? parsed.token : null
+}
+
+export function dayTokenFromPath(path: string): DayToken | null {
+  const segments = path.split('/')
+  const lessonDir = segments[segments.length - 2] || ''
+  const match = lessonDir.match(/^Day_(\d+[A-Za-z]?)/)
+  return match && match[1] ? normalizeDayToken(match[1]) : null
+}
+
+export function dayTokenFromReference(value: unknown): DayToken | null {
+  if (typeof value === 'number' || typeof value === 'string') {
+    const raw = String(value).trim()
+    const direct = raw.match(/^(\d+[A-Za-z]?)$/)
+    if (direct && direct[1]) return normalizeDayToken(direct[1])
+    const dayPrefix = raw.match(/^Day\s*(\d+[A-Za-z]?)/i)
+    if (dayPrefix && dayPrefix[1]) return normalizeDayToken(dayPrefix[1])
+  }
+  return null
+}
+
+export function dayTokenToProgressId(value: string | number): number {
+  const parsed = parseDayToken(value)
+  if (!parsed) return Number.NaN
+  if (!parsed.suffix) return parsed.number
+  const suffixCode = parsed.suffix.charCodeAt(0) - 64
+  return parsed.number * 100 + suffixCode
+}

--- a/src/utils/progressTracker.ts
+++ b/src/utils/progressTracker.ts
@@ -30,22 +30,22 @@ if (typeof window !== 'undefined') {
   })
 }
 
-export function markLessonComplete(day: number): void {
+export function markLessonComplete(day: string | number): void {
   ensureHydrated()
   useProgressStore.getState().markLessonComplete(day)
 }
 
-export function markLessonIncomplete(day: number): void {
+export function markLessonIncomplete(day: string | number): void {
   ensureHydrated()
   useProgressStore.getState().markLessonIncomplete(day)
 }
 
-export function isLessonComplete(day: number): boolean {
+export function isLessonComplete(day: string | number): boolean {
   ensureHydrated()
   return useProgressStore.getState().isLessonComplete(day)
 }
 
-export function toggleLessonComplete(day: number): boolean {
+export function toggleLessonComplete(day: string | number): boolean {
   ensureHydrated()
   return useProgressStore.getState().toggleLessonComplete(day)
 }
@@ -60,12 +60,12 @@ export function getCompletedCount(): number {
   return useProgressStore.getState().completedLessonsCount()
 }
 
-export function getCompletedForPhase(phaseLessonDays: number[]): number[] {
+export function getCompletedForPhase(phaseLessonDays: Array<string | number>): number[] {
   ensureHydrated()
   return useProgressStore.getState().getCompletedForPhase(phaseLessonDays)
 }
 
-export function setLastVisited(day: number): void {
+export function setLastVisited(day: string | number): void {
   ensureHydrated()
   useProgressStore.getState().setLastVisited(day)
 }
@@ -80,7 +80,7 @@ export function clearAllProgress(): void {
   useProgressStore.getState().clearAllProgress()
 }
 
-export function getPhaseProgress(phaseLessonDays: number[]): {
+export function getPhaseProgress(phaseLessonDays: Array<string | number>): {
   completed: number
   total: number
   percent: number

--- a/src/utils/reviewTracker.ts
+++ b/src/utils/reviewTracker.ts
@@ -50,7 +50,7 @@ interface LegacyReviewStateV1 {
  * Full review card data including seed metadata and scheduling state.
  */
 export interface ReviewCard extends StoredReviewCard {
-  day: number
+  day: string | number
   phase: number
   lessonTitle: string
   sourceType: 'concept' | 'heading' | 'exercise'

--- a/src/utils/searchIndex.ts
+++ b/src/utils/searchIndex.ts
@@ -13,6 +13,7 @@
 
 import Fuse from 'fuse.js'
 import { getAllLessons, type Lesson } from './contentLoader'
+import { parseDayToken } from './dayToken'
 
 export interface SearchDocument extends Lesson {
   plainContent: string
@@ -37,29 +38,39 @@ const BODY_WEIGHT = 1
  * Optimized for performance by reducing regex passes and string allocations.
  */
 function stripMarkdown(md: string): string {
-  return md
-    // Remove code blocks (heavy content)
-    .replace(/```[\s\S]*?```/g, ' ')
-    // Remove inline code
-    .replace(/`[^`]*`/g, ' ')
-    // Remove images
-    .replace(/!\[[^\]]*\]\([^)]+\)/g, ' ')
-    // Remove links but keep text
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    // Remove list markers (e.g. "1. ") OR special chars/whitespace
-    // This combines two steps:
-    // 1. ^\s*\d+\.\s+ matches ordered list markers at start of line
-    // 2. [#>*_~\-|\s]+ matches markdown chars and whitespace
-    // Both are replaced by a single space.
-    .replace(/(^\s*\d+\.\s+|[#>*_~\-|\s]+)/gm, ' ')
-    .trim()
+  return (
+    md
+      // Remove code blocks (heavy content)
+      .replace(/```[\s\S]*?```/g, ' ')
+      // Remove inline code
+      .replace(/`[^`]*`/g, ' ')
+      // Remove images
+      .replace(/!\[[^\]]*\]\([^)]+\)/g, ' ')
+      // Remove links but keep text
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+      // Remove list markers (e.g. "1. ") OR special chars/whitespace
+      // This combines two steps:
+      // 1. ^\s*\d+\.\s+ matches ordered list markers at start of line
+      // 2. [#>*_~\-|\s]+ matches markdown chars and whitespace
+      // Both are replaced by a single space.
+      .replace(/(^\s*\d+\.\s+|[#>*_~\-|\s]+)/gm, ' ')
+      .trim()
+  )
 }
 
 function toDocument(lesson: Lesson): SearchDocument {
+  const parsedDay = parseDayToken(lesson.day)
+  const dayParts = parsedDay
+    ? [
+        `day ${parsedDay.token}`,
+        `day ${parsedDay.number}`,
+        parsedDay.suffix ? `day ${parsedDay.number} ${parsedDay.suffix}` : '',
+      ]
+    : [`day ${lesson.day}`]
   return {
     ...lesson,
     plainContent: stripMarkdown(lesson.content),
-    dayText: `day ${lesson.day}`,
+    dayText: dayParts.filter(Boolean).join(' '),
     phaseText: `phase ${lesson.phase}`,
   }
 }


### PR DESCRIPTION
### Motivation
- Support alphanumeric day tokens (e.g. `11B`, `11C`) across the curriculum instead of assuming numeric-only days. 
- Centralize parsing/comparison logic for day tokens so lesson lookup, sorting, prerequisites, and validation all behave consistently. 
- Update routing/progress and search/indexing to correctly handle token-based lesson identifiers and adjacent navigation.

### Description
- Added centralized helpers `src/utils/dayToken.ts` (runtime) and `scripts/day-token.js` (script/CI) for normalization, parsing, comparison, path extraction, and progress-id mapping for day tokens. 
- Updated frontmatter schemas in `scripts/content-schemas.js` to accept numeric or token strings and wired `scripts/validate-content.js` to reuse the script helper functions. 
- Refactored `src/utils/contentLoader.ts` to treat lesson day as a token (`day: DayToken`), normalize from frontmatter/path, sort using token-aware compare, and normalize prerequisites/phase days. 
- Updated routing and UI consumers to remove numeric-only assumptions: `src/pages/Lesson.tsx`, `src/components/Sidebar.tsx`, `src/components/ExerciseWidget.tsx`, `src/components/ConceptGraph.tsx`, `src/pages/Exercises.tsx`, progress/gamification store logic and related utilities now convert tokens to a stable numeric progress id when interacting with persisted progress. 
- Enhanced search indexing in `src/utils/searchIndex.ts` to index token variants (e.g. `day 11`, `day 11B`) for more accurate day-based queries. 
- Updated and added tests to cover mixed day tokens for loading, sorting, adjacency, lookup, and search, and updated Phase 1 overview days to include `11B`/`11C` so validation matches actual lesson files.

### Testing
- Ran TypeScript compilation: `npm run typecheck` — succeeded with no errors. 
- Ran focused unit tests: `npm run test -- src/utils/__tests__/contentLoader.test.ts src/pages/__tests__/Lesson.test.tsx src/utils/__tests__/searchIndex.test.ts src/utils/__tests__/contentSchemas.test.ts` — all test files passed (4 files, 21 tests). 
- Ran content validation script: `npm run validate-content` — validation completed successfully for all lessons (141 files passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e727b4f88330a49256e444f785a9)