### PR TITLE
Add Day 24C data cleaning playbook and dirty Phase 2 dataset

### DIFF
--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_24C_Data_Cleaning_Playbook/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_24C_Data_Cleaning_Playbook/README.md
@@ -1,0 +1,225 @@
+---
+day: "24C"
+title: "Data Cleaning Playbook"
+phase: 2
+phaseTitle: "Functions, Modularity & Data Wrangling"
+slug: "data-cleaning-playbook"
+duration: 60
+difficulty: "intermediate"
+tags: [python, pandas, data-cleaning, data-quality]
+concepts:
+  [profiling checklist, null-handling strategy, duplicate resolution, type coercion, validation assertions]
+prerequisites: [23, 24, "24B"]
+outcomes:
+  [Run a repeatable cleaning workflow, Choose null/duplicate actions with business context, Validate datasets before and after transforms]
+---
+
+# 🎯 Day 24C: Data Cleaning Playbook
+
+> *"Cleaning is not a one-time fix. It's an operational process with explicit decisions and checks."*
+
+---
+
+## The "Never-Coded" Bridge
+
+In most MBA projects, analysis fails for one reason: hidden data quality problems.
+
+- Dates parse in one file but fail in another
+- IDs are duplicated with conflicting records
+- Missing values are handled inconsistently
+- Numeric columns silently become text
+
+This playbook gives you a repeatable, auditable workflow you can run before every analysis or dashboard.
+
+---
+
+## Step 1) Profiling Checklist (Always First)
+
+Run this checklist before editing values:
+
+### Structural checks
+
+- Row count and column count match expectation
+- Column names are unique and meaningful
+- Key columns (e.g., `customer_id`, `order_id`) exist
+
+### Type and parse checks
+
+- `df.dtypes` matches intended schema
+- Numeric columns contain only numeric-like values
+- Date columns parse cleanly under an explicit format
+
+### Completeness checks
+
+- Missingness by column (`isna().mean()`)
+- Missingness by critical segment (region/channel/source)
+- Required fields have acceptable null rates
+
+### Integrity checks
+
+- Primary key uniqueness (`duplicated(subset=[...])`)
+- Referential consistency across joins (if multiple tables)
+- Domain constraints (e.g., age >= 0, probability in [0,1])
+
+```python
+import pandas as pd
+
+df = pd.read_csv(
+    "content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/extras/sample_customers_dirty.csv"
+)
+
+profile = pd.DataFrame(
+    {
+        "dtype": df.dtypes.astype(str),
+        "missing_pct": df.isna().mean().mul(100).round(2),
+        "n_unique": df.nunique(dropna=True),
+        "sample": df.apply(lambda s: ", ".join(s.dropna().astype(str).head(3)), axis=0),
+    }
+)
+print(profile)
+print("Duplicate customer_id rows:", df.duplicated(subset=["customer_id"]).sum())
+```
+
+---
+
+## Step 2) Null Handling Decision Tree
+
+Use a decision tree instead of defaulting to `fillna(0)`.
+
+```text
+Is the column required for the business decision?
+├─ No → Keep nulls, flag in documentation, continue.
+└─ Yes
+   ├─ Is missingness < 5% and random?
+   │  ├─ Yes → Drop affected rows (if sample size remains sufficient).
+   │  └─ No
+   ├─ Can value be safely imputed from business logic?
+   │  ├─ Yes → Impute (median/mode/rules), add "imputed_*" flag.
+   │  └─ No
+   └─ Escalate: collect source fix or exclude metric from decision.
+```
+
+### Practical policy example
+
+```python
+# Example policy
+required = ["customer_id", "signup_date", "email"]
+optional = ["lifetime_value"]
+
+# Required fields: drop rows with nulls
+clean = df.dropna(subset=required).copy()
+
+# Optional numeric: median imputation + indicator
+clean["lifetime_value_imputed"] = clean["lifetime_value"].isna().astype(int)
+clean["lifetime_value"] = clean["lifetime_value"].fillna(clean["lifetime_value"].median())
+```
+
+---
+
+## Step 3) Duplicate & Entity Resolution Basics
+
+Duplicates are rarely just exact row repeats. Common patterns:
+
+- Same `customer_id` appears multiple times
+- Same email appears with different casing/spaces
+- Same person appears with small text variations
+
+### Minimum viable entity resolution flow
+
+1. Standardize string keys (`strip`, `lower`)
+2. Detect exact duplicate IDs
+3. Detect probable duplicates by email/phone
+4. Decide rule: keep latest, highest confidence, or merge fields
+
+```python
+clean["email_norm"] = clean["email"].str.strip().str.lower()
+clean["updated_at"] = pd.to_datetime(clean["updated_at"], errors="coerce")
+
+# Keep latest record per customer_id
+clean = (
+    clean.sort_values("updated_at")
+    .drop_duplicates(subset=["customer_id"], keep="last")
+)
+```
+
+---
+
+## Step 4) Type Coercion + Date Parsing Failure Handling
+
+Never trust inferred types for operational pipelines.
+
+### Numeric coercion with error audit
+
+```python
+for col in ["age", "lifetime_value"]:
+    clean[f"{col}_raw"] = clean[col]
+    clean[col] = pd.to_numeric(clean[col], errors="coerce")
+
+bad_age_rows = clean[clean["age"].isna() & clean["age_raw"].notna()]
+print("Rows with failed age coercion:", len(bad_age_rows))
+```
+
+### Date parsing with explicit format + fallback
+
+```python
+clean["signup_date_raw"] = clean["signup_date"]
+clean["signup_date"] = pd.to_datetime(
+    clean["signup_date"],
+    format="%Y-%m-%d",
+    errors="coerce",
+)
+
+failed_dates = clean[clean["signup_date"].isna() & clean["signup_date_raw"].notna()]
+print("Date parse failures:", len(failed_dates))
+```
+
+If failures are material, stop downstream analysis and escalate source formatting rules.
+
+---
+
+## Step 5) Validation Assertions Before/After Transforms
+
+Assertions turn assumptions into executable guardrails.
+
+### Before transform (raw input contract)
+
+```python
+assert "customer_id" in df.columns
+assert df.shape[0] > 0
+assert df["customer_id"].notna().all(), "Missing customer IDs in raw feed"
+```
+
+### After transform (clean output contract)
+
+```python
+assert clean["customer_id"].is_unique, "Customer IDs must be unique"
+assert clean["email"].str.contains(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", na=False).all(), "Invalid emails remain"
+assert clean["signup_date"].notna().all(), "Unparsed signup_date values remain"
+assert clean["age"].between(0, 120).all(), "Age out of range"
+```
+
+Treat assertion failures as data-quality incidents, not minor warnings.
+
+---
+
+## Hands-on Lab: Clean the Dirty Customer File
+
+Use this file from extras:
+
+`content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/extras/sample_customers_dirty.csv`
+
+### Your tasks
+
+1. Build a profile table (`dtype`, `missing_pct`, `n_unique`, sample values)
+2. Apply the null decision tree and document each decision
+3. Resolve duplicate `customer_id` records
+4. Coerce numeric/date fields and capture parse failures
+5. Write 5+ assertions that must pass before analysis
+
+### Output deliverables
+
+- `clean_customers.csv`
+- `cleaning_decisions.md` (short rationale log)
+- `validation_report.md` (passed/failed checks)
+
+➡️ After this playbook, you are ready for Phase 3 visualization and pipeline automation with much lower risk.

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Phase_Overview.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Phase_Overview.md
@@ -1,8 +1,8 @@
 ---
 phase: 2
 title: "Functions, Modularity & Data Wrangling"
-days: [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, "24B"]
-totalDuration: 670
+days: [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, "24B", "24C"]
+totalDuration: 730
 difficulty: "intermediate"
 ---
 
@@ -30,8 +30,8 @@ Classes, encapsulation, and inheritance. Date/time handling for business applica
 **Days 20-21: Environment Management**
 pip for package management, virtual environments for project isolation. The foundation for reproducible, shareable projects.
 
-**Days 22-24B: Data Science Foundation + EDA Bridge**
-NumPy for fast numerical computing. Pandas for data wrangling, analysis, and transformation. GroupBy, merges, pivots, and business-first exploratory data analysis (EDA)—the workflow that validates assumptions before visualization. Day 24B is the bridge to Phase 3: you learn which patterns are trustworthy enough to visualize and present to decision-makers.
+**Days 22-24C: Data Science Foundation + EDA + Cleaning Playbook**
+NumPy for fast numerical computing. Pandas for data wrangling, analysis, and transformation. GroupBy, merges, pivots, and business-first exploratory data analysis (EDA)—the workflow that validates assumptions before visualization. Day 24B is the bridge to Phase 3: you learn which patterns are trustworthy enough to visualize and present to decision-makers. Day 24C adds the operational cleaning playbook (profiling, null strategy, deduplication, coercion, and assertions) so your analyses are reproducible under real data quality constraints.
 
 ### Skills Unlocked
 

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/extras/sample_customers_dirty.csv
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/extras/sample_customers_dirty.csv
@@ -1,0 +1,13 @@
+customer_id,name,email,signup_date,age,lifetime_value,updated_at,region
+1001,John Doe,john.doe@email.com,2024-01-15,34,12500.50,2024-02-01 09:15:00,North
+1002, Jane Smith ,jane.smith@company.org,2024-02-30,29,9800,2024-02-05 10:00:00,West
+1003,Bob Wilson,bob.wilson@email,2024/03/12,thirty-two,11000.75,2024-03-14 18:20:00,South
+1004,Alice Jones,alice.jones@email.com,2024-03-25,,8700.20,2024-03-26 08:45:00,East
+1005,Priya Sharma,priya.sharma@email.com,15-04-2024,41,N/A,2024-04-16 12:00:00,North
+1006,Carlos Garcia,carlos.garcia@email.com,2024-04-20,27,5400.00,2024-04-22 14:35:00,South
+1003,BOB WILSON,bob.wilson@email.com,2024-03-12,32,11200.00,2024-03-20 09:05:00,South
+1007,Emily Zhang,emily.zhang@valid.org,2024-05-02,not_available,7600.40,2024-05-05 16:10:00,West
+1008,Frank Miller,frank@bad email.com,2024-05-18,45,13200.10,2024-05-19 11:11:00,East
+1009,Grace Lee,,2024-06-01,38,10100.00,2024-06-02 13:00:00,North
+1010,Liam Patel,liam.patel@email.com,2024-13-01,26,6200.90,2024-06-20 07:30:00,West
+1011,Nora Khan,nora.khan@email.com,2024-07-09,31,"7,500",2024-07-10 10:10:00,South


### PR DESCRIPTION
### Motivation

- Provide an operational, repeatable data-cleaning checklist for Phase 2 so learners can handle real-world data quality problems before analysis. 
- Teach concrete decisions and guardrails for nulls, duplicates, type coercion, date parsing, and validation assertions to reduce downstream surprises. 
- Surface a faulty/"dirty" dataset for hands-on practice that includes mixed types, malformed dates, duplicate IDs, and invalid/missing emails.

### Description

- Added a new lesson `Day_24C_Data_Cleaning_Playbook/README.md` containing a profiling checklist, a null-handling decision tree, duplicate/entity resolution basics, type coercion and date-parsing failure handling, and before/after validation assertions, plus a hands-on lab linked to an extras file. 
- Added an intentionally messy dataset `content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/extras/sample_customers_dirty.csv` with mixed-type fields, malformed dates, duplicate `customer_id` rows, invalid emails, and other issues for cleaning practice. 
- Updated `content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Phase_Overview.md` to include Day `24C`, increment the total duration, and describe the new cleaning playbook in the phase summary.

### Testing

- Ran content/frontmatter validation with `npm run validate-content` which completed successfully and reported all lessons valid. 
- Performed a CSV structural check using a small Python `csv` script to ensure row/column counts and no malformed rows, which succeeded. 
- Attempted a `pandas`-based load/preview but the environment lacks `pandas`, so full data-parsing checks were not run in this CI; the examples in the lesson assume `pandas` is available when executed by learners.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ecafffac8330970dbb7290c94918)