### PR TITLE
Include Day 24D in Phase 2 overview metadata and completion checklist

### DIFF
--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Phase_Overview.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Phase_Overview.md
@@ -1,7 +1,7 @@
 ---
 phase: 2
 title: "Functions, Modularity & Data Wrangling"
-days: [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, "24B", "24C"]
+days: [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, "24B", "24C", "24D"]
 totalDuration: 730
 difficulty: "intermediate"
 ---
@@ -30,8 +30,8 @@ Classes, encapsulation, and inheritance. Date/time handling for business applica
 **Days 20-21: Environment Management**
 pip for package management, virtual environments for project isolation. The foundation for reproducible, shareable projects.
 
-**Days 22-24C: Data Science Foundation + EDA + Cleaning Playbook**
-NumPy for fast numerical computing. Pandas for data wrangling, analysis, and transformation. GroupBy, merges, pivots, and business-first exploratory data analysis (EDA)—the workflow that validates assumptions before visualization. Day 24B is the bridge to Phase 3: you learn which patterns are trustworthy enough to visualize and present to decision-makers. Day 24C adds the operational cleaning playbook (profiling, null strategy, deduplication, coercion, and assertions) so your analyses are reproducible under real data quality constraints.
+**Days 22-24D: Data Science Foundation + EDA + Cleaning Playbook**
+NumPy for fast numerical computing. Pandas for data wrangling, analysis, and transformation. GroupBy, merges, pivots, and business-first exploratory data analysis (EDA)—the workflow that validates assumptions before visualization. Day 24B is the bridge to Phase 3: you learn which patterns are trustworthy enough to visualize and present to decision-makers. Day 24C adds the operational cleaning playbook (profiling, null strategy, deduplication, coercion, and assertions) so your analyses are reproducible under real data quality constraints. Day 24D is the phase synthesis milestone where you finalize `final_metrics.csv` and deliver a concise business insight brief.
 
 ### Skills Unlocked
 
@@ -543,6 +543,7 @@ Before moving to Phase 3, ensure you can:
 - [ ] Perform vectorized operations with NumPy (no Python loops over arrays)
 - [ ] Analyze data with Pandas `groupby`, `merge`, and `pivot_table`
 - [ ] Profile code performance and know when to use chunking vs in-memory
+- [ ] Complete Day 24D capstone deliverables: `final_metrics.csv` plus a business insight brief
 
 ---
 
@@ -550,4 +551,4 @@ Before moving to Phase 3, ensure you can:
 
 You now have the professional-grade Python skills to work with real business data. In **Phase 3**, you'll apply these skills to data engineering pipelines, web APIs, and data visualization.
 
-> 🔗 **Forward reference**: The Pandas skills from Days 22–24 are the foundation for Phases 4–6's ML preprocessing pipelines. The OOP patterns from Days 18–19 appear in sklearn's Transformer/Estimator pattern. Exception handling from Days 13–15 is critical for Phase 3's API development.
+> 🔗 **Forward reference**: The Pandas skills from Days 22–24D are the foundation for Phases 4–6's ML preprocessing pipelines. The OOP patterns from Days 18–19 appear in sklearn's Transformer/Estimator pattern. Exception handling from Days 13–15 is critical for Phase 3's API development.


### PR DESCRIPTION
### Motivation
- Make Phase 2 explicitly include the new Day `24D` milestone in metadata and narrative so learners and tooling reflect the updated endpoint.
- Ensure completion criteria and forward references mention Day `24D` where the narrative previously implied the phase ended at `24C`.

### Description
- Appended `"24D"` to the `days` frontmatter array in `content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Phase_Overview.md` after `"24C"`.
- Renamed the final narrative block from **Days 22–24C** to **Days 22–24D** and added a sentence describing Day `24D` as the phase synthesis milestone that finalizes `final_metrics.csv` and a business insight brief.
- Added a Completion Checklist item: `Complete Day 24D capstone deliverables: final_metrics.csv plus a business insight brief`.
- Updated forward-reference wording to `Days 22–24D` for consistency across the file.

### Testing
- Verified the file was updated and the new day appears in frontmatter by inspecting `content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Phase_Overview.md` with line checks.
- Ran a targeted search `rg -n "24C|22–24|22-24|24D"` against the file to ensure all references now include `24D` and the search succeeded.
- Confirmed the working tree shows the modified file via `git status --short` and validated the diff summary with `git show --stat --oneline`, both of which reported the single updated file.
- All automated checks and searches ran successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac82068f08330a07b8ba2554532a2)