### PR TITLE
Enhance Day 24B EDA lesson with hypothesis and handoff artifacts

### DIFF
--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_24B_Exploratory_Data_Analysis/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_24B_Exploratory_Data_Analysis/README.md
@@ -52,6 +52,16 @@ Key segments to compare:
 Must-pass data quality checks:
 ```
 
+### EDA Hypothesis Log
+
+Track how your assumptions evolve as evidence accumulates.
+
+| Hypothesis | Metric | Segment | Evidence Status | Confidence | Next Test |
+|---|---|---|---|---|---|
+| Discounts are driving revenue decline through margin erosion | Revenue, gross margin % | Region A, promo orders | Pending / Supported / Rejected | Low / Medium / High | Compare pre/post promo cohorts controlling for product mix |
+| Missing orders in one channel are distorting conversion trends | Conversion rate, order count | Paid channel by month | Pending / Supported / Rejected | Low / Medium / High | Audit ingestion completeness vs source system logs |
+| VIP customers offset volume declines with higher basket size | Order value, customer count | VIP vs non-VIP | Pending / Supported / Rejected | Low / Medium / High | Segment bivariate check with outlier-flagged and raw views |
+
 ---
 
 ## The Technical Deep Dive
@@ -225,23 +235,35 @@ Title: EDA Memo — <Project / Dataset / Date>
 
 You are given a monthly transaction dataset where revenue declined in one region.
 
-Tasks:
+Follow these explicit steps in order:
 
-1. Frame three business-first EDA questions.
-2. Run univariate checks for `revenue`, `discount`, and `order_count`.
-3. Perform a missingness audit and identify high-risk columns.
-4. Create an outlier strategy for `order_value` and justify it.
-5. Run bivariate checks against `revenue` and draft the 1-page EDA memo.
+1. **Question framing** → Frame three business-first EDA questions tied to a decision and KPI.
+2. **Profiling** → Run univariate checks for `revenue`, `discount`, and `order_count` to baseline distribution and quality.
+3. **Diagnostics** → Perform a missingness audit and define an outlier strategy for `order_value` with justification.
+4. **Hypothesis updates** → Update the EDA Hypothesis Log with evidence status, confidence, and the next test for each hypothesis.
+5. **Memo + handoff** → Draft the 1-page EDA memo and complete the visualization handoff checklist for Day 27.
 
 ---
 
 ## Mastery Check
 
-**Q1**: Why start EDA with business questions instead of charts?
+**Q1.** Why start EDA with business questions instead of charts?
 
-**Q2**: When should outliers be retained rather than removed?
+**Q2.** When should outliers be retained rather than removed?
 
-**Q3**: Give one example of why a high correlation might still be non-actionable.
+**Q3.** Give one example of why a high correlation might still be non-actionable.
+
+---
+
+## Visualization Handoff Checklist (for Day 27)
+
+Before moving from EDA to visualization/storytelling, confirm these outputs are finalized:
+
+- [ ] **Validated metrics**: Final KPI definitions and formulas are locked.
+- [ ] **Analytical grain**: Time/entity grain is explicitly stated (e.g., monthly-region, customer-week).
+- [ ] **Exclusions**: Rows/segments removed from analysis are listed with business rationale.
+- [ ] **Caveats**: Data quality limits, missingness risk, and causal uncertainty are documented.
+- [ ] **Chart recommendation**: Proposed chart type(s) and decision narrative are specified for Day 27 build.
 
 ---
 


### PR DESCRIPTION
### Motivation

- Provide operational artifacts to bridge EDA work and visualization handoff so analysts can track evolving hypotheses and prepare validated inputs for Day 27 builds.
- Standardize the hands-on lab into a reproducible, stepwise workflow that enforces decision-first framing and explicit diagnostic steps.
- Reduce ambiguity in assessment by normalizing the Mastery Check labels for clearer grading and student feedback.

### Description

- Added an **EDA Hypothesis Log** immediately after the `Practical Template` with a markdown table containing `Hypothesis`, `Metric`, `Segment`, `Evidence Status`, `Confidence`, and `Next Test` columns to capture evolving evidence and test plans (file: `content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_24B_Exploratory_Data_Analysis/README.md`).
- Converted the Hands-on Lab into explicit ordered steps: `Question framing` → `Profiling` → `Diagnostics` → `Hypothesis updates` → `Memo + handoff` to guide workflow and ensure the hypothesis log is updated before handoff.
- Inserted a **Visualization Handoff Checklist (for Day 27)** before `Summary` with required outputs: `Validated metrics`, `Analytical grain`, `Exclusions`, `Caveats`, and `Chart recommendation`.
- Fixed Mastery Check formatting so questions are uniquely labeled as `Q1`, `Q2`, and `Q3`.

### Testing

- Ran `git diff --check` to verify no whitespace or patch-format issues and it returned clean.
- Pre-commit checks (including `prettier --check` for markdown) ran during staging and passed. 
- Confirmed the updated `README.md` content includes the new sections and the Hands-on Lab step flow by inspecting the file locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac89995e88330800fb5b48dbf6683)