### PR TITLE
Align Day 36B frontmatter and make alphanumeric day ordering deterministic

### DIFF
--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_36B_Docker_Fundamentals/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_36B_Docker_Fundamentals/README.md
@@ -1,5 +1,5 @@
 ---
-day: 36
+day: 36B
 title: "Docker Fundamentals"
 phase: 3
 phaseTitle: "Data Engineering & Web Development"

--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Phase_Overview.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Phase_Overview.md
@@ -1,7 +1,7 @@
 ---
 phase: 3
 title: "Data Engineering & Web Development"
-days: [25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, "36B"]
+days: [25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, "36B", "36C"]
 totalDuration: 640
 difficulty: "intermediate"
 ---
@@ -27,8 +27,8 @@ You progressed from basic Matplotlib charts to sophisticated Seaborn statistical
 **Days 30-32: Data Sources**
 You discovered that data doesn't always arrive in clean CSVs. You learned to scrape websites ethically with BeautifulSoup, query relational databases with SQL, and understand when NoSQL document stores like MongoDB make sense. You can now pull data from anywhere.
 
-**Days 33-36B: Web Development**
-You evolved from consuming APIs to building them. You created REST endpoints with FastAPI, built full web applications with Flask, and designed end-to-end data pipelines that extract, transform, and load data automatically.
+**Days 33-36C: Web Development**
+You evolved from consuming APIs to building them. The sequencing at the end of this phase is explicit: **Day 36 = ETL Case Study**, **Day 36B = Docker Fundamentals**, and **Day 36C = Async Python + FastAPI (after creation)**. You created REST endpoints with FastAPI, built full web applications with Flask, and designed end-to-end data pipelines that extract, transform, and load data automatically.
 
 ### Skills Unlocked
 

--- a/src/utils/__tests__/dayToken.test.ts
+++ b/src/utils/__tests__/dayToken.test.ts
@@ -1,0 +1,38 @@
+import {
+  compareDayTokens,
+  dayTokenFromPath,
+  dayTokenFromReference,
+  dayTokenToProgressId,
+  normalizeDayToken,
+} from '../dayToken'
+
+describe('dayToken utilities', () => {
+  it('normalizes and sorts alphanumeric day tokens deterministically', () => {
+    const tokens = ['36C', '36', '36b', '37', '35']
+    const sorted = [...tokens].sort(compareDayTokens)
+
+    expect(sorted).toEqual(['35', '36', '36b', '36C', '37'])
+    expect(sorted.map((token) => normalizeDayToken(token))).toEqual([
+      '35',
+      '36',
+      '36B',
+      '36C',
+      '37',
+    ])
+  })
+
+  it('extracts day tokens from path and references with letter suffixes', () => {
+    expect(
+      dayTokenFromPath(
+        '/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_36B_Docker_Fundamentals/README.md',
+      ),
+    ).toBe('36B')
+    expect(dayTokenFromReference('Day 36c: Async Python + FastAPI')).toBe('36C')
+  })
+
+  it('creates stable progress ids for day suffix variants', () => {
+    expect(dayTokenToProgressId('36')).toBe(36)
+    expect(dayTokenToProgressId('36B')).toBeGreaterThan(dayTokenToProgressId('36A'))
+    expect(dayTokenToProgressId('36C')).toBeGreaterThan(dayTokenToProgressId('36B'))
+  })
+})

--- a/src/utils/dayToken.ts
+++ b/src/utils/dayToken.ts
@@ -7,7 +7,7 @@ export interface ParsedDayToken {
   sortKey: string
 }
 
-const DAY_TOKEN_PATTERN = /^(\d+)([A-Za-z]?)$/
+const DAY_TOKEN_PATTERN = /^(\d+)([A-Za-z]*)$/
 
 export function normalizeDayToken(value: string | number): DayToken {
   const raw = String(value ?? '').trim()
@@ -38,10 +38,14 @@ export function compareDayTokens(a: string | number, b: string | number): number
   const aa = parseDayToken(a)
   const bb = parseDayToken(b)
   if (!aa || !bb) {
-    return normalizeDayToken(a).localeCompare(normalizeDayToken(b))
+    const normalizedA = normalizeDayToken(a)
+    const normalizedB = normalizeDayToken(b)
+    if (normalizedA === normalizedB) return 0
+    return normalizedA < normalizedB ? -1 : 1
   }
   if (aa.number !== bb.number) return aa.number - bb.number
-  return aa.suffix.localeCompare(bb.suffix)
+  if (aa.suffix === bb.suffix) return 0
+  return aa.suffix < bb.suffix ? -1 : 1
 }
 
 export function extractDayToken(value: unknown): DayToken | null {
@@ -53,16 +57,16 @@ export function extractDayToken(value: unknown): DayToken | null {
 export function dayTokenFromPath(path: string): DayToken | null {
   const segments = path.split('/')
   const lessonDir = segments[segments.length - 2] || ''
-  const match = lessonDir.match(/^Day_(\d+[A-Za-z]?)/)
+  const match = lessonDir.match(/^Day_(\d+[A-Za-z]*)/)
   return match && match[1] ? normalizeDayToken(match[1]) : null
 }
 
 export function dayTokenFromReference(value: unknown): DayToken | null {
   if (typeof value === 'number' || typeof value === 'string') {
     const raw = String(value).trim()
-    const direct = raw.match(/^(\d+[A-Za-z]?)$/)
+    const direct = raw.match(/^(\d+[A-Za-z]*)$/)
     if (direct && direct[1]) return normalizeDayToken(direct[1])
-    const dayPrefix = raw.match(/^Day\s*(\d+[A-Za-z]?)/i)
+    const dayPrefix = raw.match(/^Day\s*(\d+[A-Za-z]*)/i)
     if (dayPrefix && dayPrefix[1]) return normalizeDayToken(dayPrefix[1])
   }
   return null
@@ -72,6 +76,11 @@ export function dayTokenToProgressId(value: string | number): number {
   const parsed = parseDayToken(value)
   if (!parsed) return Number.NaN
   if (!parsed.suffix) return parsed.number
-  const suffixCode = parsed.suffix.charCodeAt(0) - 64
-  return parsed.number * 100 + suffixCode
+
+  const suffixCode = [...parsed.suffix].reduce((acc, char) => {
+    const code = char.charCodeAt(0) - 64
+    return acc * 26 + Math.max(code, 0)
+  }, 0)
+
+  return parsed.number * 10000 + suffixCode
 }


### PR DESCRIPTION
### Motivation
- Ensure the Day 36B lesson frontmatter token matches its directory name and sequencing so curriculum tooling treats it as an alphanumeric day token.
- Make curriculum indexing and sorting deterministic for alphanumeric day tokens (e.g. `36`, `36B`, `36C`) to avoid locale-dependent or inconsistent ordering.

### Description
- Updated `content/lessons/Phase_03_Data_Engineering_Web_Development/Day_36B_Docker_Fundamentals/README.md` frontmatter to use `day: 36B` so the lesson token matches the folder name.
- Updated `content/lessons/Phase_03_Data_Engineering_Web_Development/Phase_Overview.md` to include `"36B"` and planned `"36C"` in the `days` list and to make the end-of-phase sequencing explicit in the narrative.
- Hardened day-token parsing and comparison in `src/utils/dayToken.ts` by allowing multi-letter suffixes, replacing locale-dependent `localeCompare` usage with deterministic lexical comparisons, and improving `dayTokenToProgressId` to generate monotonic progress ids for multi-letter suffixes.
- Added focused unit tests at `src/utils/__tests__/dayToken.test.ts` to verify normalization, extraction from paths/references, deterministic ordering, and progress-id monotonicity for suffixed day tokens.

### Testing
- Ran targeted Vitest suites with `npm run test -- src/utils/__tests__/dayToken.test.ts src/utils/__tests__/contentLoader.test.ts`, and all tests passed.
- Ran content validation with `npm run validate-content`, which completed successfully and reported all lessons valid.
- Ran static type checks with `npm run typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699acc4da0fc8330bc0b3901fb049d8f)