### PR TITLE
Enhance Day 34/35 lessons with deployment-readiness sections and DoD labs

### DIFF
--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_34_Building_an_API/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_34_Building_an_API/README.md
@@ -212,6 +212,57 @@ class User(BaseModel):
         return v
 ```
 
+### Deployment-Ready Baseline (FastAPI)
+
+**API contract tests (minimum set):**
+
+- Happy path: valid request returns expected status + response shape.
+- Validation failure: invalid type/missing field returns `422` with stable error keys.
+
+```python
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_create_item_happy_path():
+    r = client.post("/items", json={"name": "Pen", "price": 1.5})
+    assert r.status_code == 200
+    assert r.json()["name"] == "Pen"
+
+
+def test_create_item_validation_error():
+    r = client.post("/items", json={"name": "Pen", "price": "bad"})
+    assert r.status_code == 422
+    assert "detail" in r.json()
+```
+
+**Structured logging with request IDs:**
+
+```python
+import logging, uuid
+from fastapi import Request
+
+logger = logging.getLogger("api")
+
+
+@app.middleware("http")
+async def add_request_context(request: Request, call_next):
+    req_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+    response = await call_next(request)
+    response.headers["X-Request-ID"] = req_id
+    logger.info("request_complete", extra={"request_id": req_id, "path": request.url.path, "status": response.status_code})
+    return response
+```
+
+**Security baseline (Phase 3 level):**
+
+- Validate all external input with Pydantic constraints (length, bounds, formats).
+- Keep secrets in env vars (`DATABASE_URL`, `API_KEY`), never in source.
+- If browser clients call your API, allow only trusted CORS origins + needed methods.
+- Return safe client errors; log technical context internally with request IDs.
+
 ---
 
 ## Hands-on Lab
@@ -361,6 +412,19 @@ Your debugging goals:
 1. Catch the regression via contract tests.
 2. Restore backward compatibility (or version the endpoint).
 3. Update API docs/changelog with clear migration notes.
+
+### Exercise 5: Definition of Done (DoD) Drill
+
+For one endpoint you built today, ship it only when all boxes are checked:
+
+- [ ] Contract tests include one happy path and one validation failure.
+- [ ] Logs include `request_id`, route, status, and one error-context field.
+- [ ] Input constraints are explicit (type + range/length rules).
+- [ ] Secrets come from env vars (no hardcoded tokens/passwords).
+- [ ] CORS policy is explicit (no wildcard in production intent).
+- [ ] API docs show success + error examples.
+
+Reuse this checklist in later MLOps phases as your minimum release gate.
 
 ---
 

--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_35_Flask_Web_Framework/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_35_Flask_Web_Framework/README.md
@@ -214,6 +214,56 @@ class LoginForm(FlaskForm):
 # {{ user_input|safe }}  <- Dangerous, renders raw HTML
 ```
 
+### Deployment-Ready Baseline (Flask)
+
+**API contract tests (minimum set):**
+
+- Happy path: valid request returns expected status + response keys.
+- Validation failure: bad/missing form or JSON input returns `400` with stable error fields.
+
+```python
+# tests/test_contact.py
+
+def test_contact_happy_path(client):
+    r = client.post("/contact", data={"name": "Ana", "email": "ana@example.com", "message": "Hi"})
+    assert r.status_code in (200, 302)
+
+
+def test_contact_validation_error(client):
+    r = client.post("/contact", data={"name": "", "email": "bad", "message": ""})
+    assert r.status_code == 400
+    assert "error" in r.get_json()
+```
+
+**Structured logging with request IDs + error context:**
+
+```python
+import logging, uuid
+from flask import g, request
+
+logger = logging.getLogger("web")
+
+
+@app.before_request
+def attach_request_id():
+    g.request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+
+
+@app.after_request
+def log_response(response):
+    response.headers["X-Request-ID"] = g.request_id
+    logger.info("request_complete", extra={"request_id": g.request_id, "path": request.path, "status": response.status_code})
+    return response
+```
+
+**Security baseline (Phase 3 level):**
+
+- Validate/sanitize form and JSON input (length, format, required fields).
+- Store `SECRET_KEY`, DB creds, and API tokens in env vars; never commit them.
+- Harden sessions (`SESSION_COOKIE_HTTPONLY=True`, `SESSION_COOKIE_SECURE=True` in prod).
+- Restrict CORS origins and methods if frontend is hosted separately.
+
+
 ---
 
 ## Hands-on Lab
@@ -318,6 +368,19 @@ Your debugging goals:
 1. Fail fast at startup with actionable config validation errors.
 2. Verify error middleware returns consistent `500` behavior without stack traces to users.
 3. Use structured logs to trace the failing request end-to-end.
+
+### Exercise 5: Definition of Done (DoD) Drill
+
+For one Flask feature you built today, release only when all boxes are checked:
+
+- [ ] Contract tests include one happy path and one validation failure.
+- [ ] Request logs include `request_id`, route, status, and error context when failures happen.
+- [ ] Input validation exists for all user-provided fields.
+- [ ] Secrets/config are loaded from env vars and validated at startup.
+- [ ] Session + CORS settings are explicitly reviewed for production defaults.
+- [ ] User-facing errors are safe; debugging detail stays in logs.
+
+Reuse this checklist in Phase 5 when deploying model-backed web services.
 
 ---
 


### PR DESCRIPTION
### Motivation

- Improve Phase 3 API and web lessons with concise, practical guidance that prepares learners for deployment and Phase 5 MLOps concerns while keeping pace with the course.
- Add small, reusable labs and a Definition of Done checklist so students can apply the same release-readiness checks to model-backed services later.

### Description

- Added a `Deployment-Ready Baseline (FastAPI)` section to Day 34 that includes minimal API contract test examples (happy path + validation failure), a lightweight request-ID middleware example, and a short Phase-3 security baseline (Pydantic validation, env-var secrets, CORS/error hygiene).
- Added `Exercise 5: Definition of Done (DoD) Drill` to Day 34 with a reusable checklist of contract tests, logging, input constraints, secret handling, CORS policy, and docs requirements.
- Added a `Deployment-Ready Baseline (Flask)` section to Day 35 with small contract-test examples for forms, request-ID attach/log hooks, and a Phase-3 security baseline (input validation, env secrets, session/CORS hardening).
- Added `Exercise 5: Definition of Done (DoD) Drill` to Day 35 mirroring the FastAPI checklist and aligning to later Phase 5 deployment expectations.

### Testing

- Ran `git diff --check` to validate whitespace and simple diff issues and it passed. 
- Pre-commit hooks ran `prettier --check` on the changed markdown files via the commit workflow and it passed. 
- Changes were committed successfully; the added contract-test snippets are examples in the lessons and were not executed as part of this commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699acdb4bcb08330b8c0ee827072ce28)