### PR TITLE
Promote deploy workflow to run after CI success and remove duplicated quality gates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,10 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
     branches: [main]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -16,6 +18,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,21 +32,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Type check
-        run: npm run typecheck
-
-      - name: Validate content
-        run: node scripts/validate-content.js
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-
-      - name: End-to-end tests
-        run: npm run test:e2e -- --project=chromium
 
       - name: Build
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@
 
 - **Primary production environment:** GitHub Pages via `.github/workflows/deploy.yml`.
 - **Surge (`coding-for-mba.surge.sh`) usage:** optional preview/release deployment, triggered manually (`workflow_dispatch`) or on published GitHub releases.
-- **Default behavior:** pushes to `main` continue to rely on the GitHub Pages deployment workflow.
+- **Promotion model (CI → Deploy):**
+  1. `CI` (`.github/workflows/ci.yml`) runs on PRs and pushes to `main` and is the canonical gate for linting, type checking, content validation, and test coverage.
+  2. `Deploy to GitHub Pages` (`.github/workflows/deploy.yml`) runs automatically only after `CI` completes successfully on `main` (`workflow_run` trigger).
+  3. Deploy workflow now performs only deployment-critical tasks (install deps, build artifact, upload, Pages deploy), with no duplicated quality gates.
+  4. Manual deploy remains available through `workflow_dispatch` for maintainer-controlled re-deploys.
 
 ## 📚 What's Inside
 


### PR DESCRIPTION
### Motivation
- Ensure CI is the canonical quality gate (lint/typecheck/content validation/tests) and avoid running the same checks again during deploy. 
- Make GitHub Pages deployment a promotion step that runs only after `CI` finishes successfully on `main`, while preserving manual `workflow_dispatch` redeploys. 

### Description
- Changed `on` for `.github/workflows/deploy.yml` from `push` to `workflow_run` tied to the `CI` workflow on `main` and added `types: [completed]` to the trigger. 
- Added an `if` guard to the deploy `build` job so it runs only when `github.event_name == 'workflow_dispatch'` or `github.event.workflow_run.conclusion == 'success'`. 
- Removed duplicated non-deploy quality steps (lint, typecheck, content validation, Playwright browser install, and e2e tests) from the deploy workflow, leaving only `npm ci`, `npm run build`, artifact upload, and Pages deploy. 
- Documented the CI → Deploy promotion model in `README.md` under the deployment section describing that `CI` is the canonical gate and `Deploy to GitHub Pages` runs after successful CI or manually. 

### Testing
- Ran `npm run typecheck` which completed successfully. 
- `prettier --check` was executed via the pre-commit hook on staged markdown changes and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aceeb05c08330a279b29ca4b10417)