### PR TITLE
Add workflow concurrency guards for CI, Lighthouse, and Nightly Smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -3,6 +3,10 @@ name: Lighthouse CI
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lighthouse:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -12,6 +12,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   issues: write


### PR DESCRIPTION
### Motivation
- Prevent duplicate or overlapping GitHub Actions runs for the same PR/ref and ensure superseded runs are canceled.
- Ensure PR-scoped workflows (CI and Lighthouse) cancel only their own superseded runs and do not affect other workflows.
- Ensure long-running scheduled/manual Nightly Smoke runs are serialized per ref/event to avoid overlaps.

### Description
- Added a top-level `concurrency` block to `.github/workflows/ci.yml` with `group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}` and `cancel-in-progress: true` to scope cancellations to the same workflow+PR or ref.
- Added a matching top-level `concurrency` block to `.github/workflows/lighthouse.yml` with the same PR/ref-scoped group and `cancel-in-progress: true` so superseded PR runs are canceled.
- Added a deterministic top-level `concurrency` block to `.github/workflows/nightly-smoke.yml` using `group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}` and `cancel-in-progress: true` to serialize scheduled and manual runs per event+ref while keeping different workflows isolated.
- Chose group keys that always include `github.workflow` so different workflows cannot cancel one another.

### Testing
- Parsed all three modified workflow files with Ruby using `YAML.load_file` and the parser reported success for each file.
- Attempted to parse with Python `PyYAML` using `yaml.safe_load`, but the environment lacked the `PyYAML` module so that run failed with a module error.
- Verified the workflow files are syntactically valid YAML via the Ruby parser (all three returned OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699acf6a37c88330830bf3bc9603820b)