### PR TITLE
Harden GitHub Actions workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,6 +7,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  # Required for actions/upload-artifact to publish Lighthouse reports.
+  actions: write
+
 jobs:
   lighthouse:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- Reduce GitHub Actions token scope to least privilege by explicitly setting top-level `permissions` for workflows so read-only jobs only receive `contents: read` and artifact-publishing jobs receive only the additional scopes they require.

### Description
- Added top-level `permissions` to `.github/workflows/ci.yml` and `.github/workflows/lighthouse.yml`, set `contents: read` for the CI workflow, and added `actions: write` to `lighthouse.yml` with an inline comment explaining it is required for `actions/upload-artifact` while otherwise keeping scopes minimal.

### Testing
- Verified both updated workflow files parse as valid YAML using Ruby's `YAML.load_file` (parsing succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699acffa58dc83308d947debdf4496c4)