### PR TITLE
Add dependency-review workflow to gate PR dependency changes

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          license-check: true
+          vulnerability-check: true
+          deny-licenses: GPL-2.0, GPL-3.0, AGPL-1.0, AGPL-3.0

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   2. `Deploy to GitHub Pages` (`.github/workflows/deploy.yml`) runs automatically only after `CI` completes successfully on `main` (`workflow_run` trigger).
   3. Deploy workflow now performs only deployment-critical tasks (install deps, build artifact, upload, Pages deploy), with no duplicated quality gates.
   4. Manual deploy remains available through `workflow_dispatch` for maintainer-controlled re-deploys.
+  5. `Dependency Review` (`.github/workflows/dependency-review.yml`) runs on pull requests to protected branches and blocks dependency updates that introduce high/critical vulnerabilities or unacceptable license/policy changes.
 
 ## 📚 What's Inside
 


### PR DESCRIPTION
### Motivation
- Prevent unsafe dependency updates by blocking PRs that introduce high/critical vulnerabilities or unacceptable licenses when targeting protected branches. 
- Ensure the dependency review step runs as a dedicated, minimal-permission workflow so it can safely inspect PR metadata and repository contents. 
- Make the policy visible to contributors by documenting the gate in the README under CI/deployment notes.

### Description
- Add a new workflow file at ` .github/workflows/dependency-review.yml` that triggers on `pull_request` to `main` and sets explicit permissions `contents: read` and `pull-requests: read`.
- Use `actions/dependency-review-action@v4` with `fail-on-severity: high`, `vulnerability-check: true`, `license-check: true`, and `deny-licenses: GPL-2.0, GPL-3.0, AGPL-1.0, AGPL-3.0` to enforce policy gating.
- Update `README.md` to document the new `Dependency Review` gate in the CI/Promotion model so contributors know dependency updates are policy-gated.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff sanity, which passed. 
- Pre-commit hooks executed `prettier --check` on staged Markdown during commit and completed successfully. 
- Changes were committed (local commit completed) and the new workflow file and README update are present in the working tree.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad07db8688330ab06380635bc9f02)