### PR TITLE
Upload CI JUnit & coverage artifacts; add Playwright failure uploads and retention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,35 @@ jobs:
         run: npm run validate-content
 
       - name: Test with coverage threshold
-        run: npm run test:coverage
+        run: |
+          mkdir -p test-results coverage
+          npm run test:coverage -- \
+            --reporter=default \
+            --reporter=junit \
+            --outputFile.junit=./test-results/vitest-junit.xml \
+            --coverage.reporter=text \
+            --coverage.reporter=html \
+            --coverage.reporter=lcov \
+            --coverage.reporter=cobertura
+
+      - name: Upload unit test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results
+          path: test-results/vitest-junit.xml
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage/lcov.info
+            coverage/cobertura-coverage.xml
+            coverage/index.html
+            coverage/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -48,3 +48,4 @@ jobs:
           name: lighthouse-report
           path: .lighthouseci
           if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -54,6 +54,24 @@ jobs:
         if: ${{ github.event.inputs.run_playwright_smoke == 'true' || vars.RUN_NIGHTLY_PLAYWRIGHT_SMOKE == 'true' }}
         run: npm run test:e2e -- --project=chromium --grep '@smoke' --pass-with-no-tests
 
+      - name: Upload Playwright HTML report
+        if: ${{ failure() && (github.event.inputs.run_playwright_smoke == 'true' || vars.RUN_NIGHTLY_PLAYWRIGHT_SMOKE == 'true') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-playwright-html-report
+          path: playwright-report
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Playwright traces
+        if: ${{ failure() && (github.event.inputs.run_playwright_smoke == 'true' || vars.RUN_NIGHTLY_PLAYWRIGHT_SMOKE == 'true') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-playwright-traces
+          path: test-results
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Create or update failure issue
         if: ${{ failure() && github.event_name != 'pull_request' }}
         uses: actions/github-script@v8

--- a/README.md
+++ b/README.md
@@ -121,6 +121,24 @@ content/lessons/       # 108 lesson markdown files
 npm run test:e2e -- --project=chromium tests/e2e/visual-smoke.spec.ts --update-snapshots
 ```
 
+## 🧾 CI Artifacts (for maintainers)
+
+GitHub Actions uploads machine-readable test and diagnostics artifacts to support debugging and historical comparisons:
+
+- **CI workflow (`.github/workflows/ci.yml`)**
+  - `unit-test-results`: Vitest JUnit XML at `test-results/vitest-junit.xml`.
+  - `coverage-report`: coverage outputs from `coverage/` (including `lcov.info`, `cobertura-coverage.xml`, and HTML report files).
+  - Retention: **14 days**.
+- **Nightly Smoke workflow (`.github/workflows/nightly-smoke.yml`)**
+  - On Playwright failures only: `nightly-playwright-html-report` from `playwright-report/`.
+  - On Playwright failures only: `nightly-playwright-traces` from `test-results/` (trace bundles and related outputs).
+  - Retention: **7 days**.
+- **Lighthouse CI workflow (`.github/workflows/lighthouse.yml`)**
+  - `lighthouse-report` from `.lighthouseci/`.
+  - Retention: **7 days**.
+
+You can download artifacts from the corresponding workflow run page in the **Actions** tab.
+
 ## ⚡ Build & Performance Notes
 
 - **Bundle analysis**: run `npm run analyze` to generate a visual treemap report at `dist/stats.html` (powered by `rollup-plugin-visualizer`).


### PR DESCRIPTION
### Motivation
- Emit machine-readable test and coverage outputs from CI so test results and coverage can be consumed by dashboards and external tools.
- Preserve diagnostic artifacts from failing runs (unit tests, coverage, Playwright) to make debugging easier for maintainers.
- Limit artifact storage growth by adding retention policies for uploaded artifacts.

### Description
- Update `.github/workflows/ci.yml` to run Vitest with JUnit and multiple coverage reporters and to create `test-results/` and `coverage/` output directories before test execution.
- Add `actions/upload-artifact@v4` steps in `ci.yml` with `if: always()` to upload `test-results/vitest-junit.xml` and coverage outputs (lcov, Cobertura, HTML) with `retention-days: 14`.
- Add failure-scoped Playwright artifact uploads to `.github/workflows/nightly-smoke.yml` to upload the HTML report (`playwright-report`) and traces/results (`test-results`) only on Playwright failures with `retention-days: 7`.
- Add `retention-days: 7` to the existing Lighthouse artifact upload in `.github/workflows/lighthouse.yml` and document artifact names, paths, and retention in `README.md` under a new "CI Artifacts (for maintainers)" section.

### Testing
- Ran `npx prettier --check .github/workflows/ci.yml .github/workflows/nightly-smoke.yml .github/workflows/lighthouse.yml README.md` which passed for the modified files.
- Ran `npm run format:check` which reported pre-existing formatting issues in unrelated files under `src/utils` but did not affect the workflow or README changes.
- Confirmed updated workflow YAML files include the new reporter/upload steps and `retention-days` entries via local diffs inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad097172c8330bec0a636593f3c52)