### PR TITLE
Add nightly smoke success handler to close failure issues

### DIFF
--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -92,3 +92,51 @@ jobs:
                 labels: ['ci', 'nightly-smoke'],
               });
             }
+
+      - name: Close matching failure issues on success
+        if: ${{ success() && github.event_name != 'pull_request' }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const title = '🚨 Nightly smoke workflow failed';
+            const marker = '<!-- nightly-smoke-failure -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const closeComment = `Nightly smoke workflow succeeded: ${runUrl}`;
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'ci,nightly-smoke',
+              per_page: 100,
+            });
+
+            const matches = issues.filter((issue) =>
+              issue.title === title || (issue.body && issue.body.includes(marker))
+            );
+
+            for (const issue of matches) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+
+              const hasCloseComment = comments.some((comment) => comment.body === closeComment);
+              if (!hasCloseComment) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: closeComment,
+                });
+              }
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+            }


### PR DESCRIPTION
### Motivation
- Ensure transient failure issues created by the nightly smoke workflow are closed when a subsequent run succeeds to avoid stale alerts and noisy issue churn.
- Reuse the existing failure marker and labels so open/close flows are consistent and reversible.

### Description
- Add a final success-only step with `if: success() && github.event_name != 'pull_request'` that runs `actions/github-script@v8` to handle successful recovery.
- Reuse the same `title` and `<!-- nightly-smoke-failure -->` marker and filter by labels `ci,nightly-smoke` when locating matching open issues.
- For each match, post a single success comment containing the run URL if not already present and then close the issue to keep the close flow idempotent.
- Preserve existing failure-path behavior of creating an issue only when none match and appending failure comments to existing issues to avoid duplicates.

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff errors, and it succeeded.
- Ran `git diff -- .github/workflows/nightly-smoke.yml` to review the exact changes to the workflow file, and it succeeded.
- Ran `git show --stat --oneline HEAD` to confirm the commit containing the change was created, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad0994ad4833086d5b4aae0a80a44)