### PR TITLE
Refactor CI workflows to use reusable Node bootstrap action

### DIFF
--- a/.github/actions/node-bootstrap/action.yml
+++ b/.github/actions/node-bootstrap/action.yml
@@ -1,0 +1,23 @@
+name: Node bootstrap
+description: Checkout repository, configure Node.js with npm cache, and install dependencies.
+inputs:
+  node-version:
+    description: Node.js version to install.
+    required: false
+    default: '20'
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm
+
+    - name: Install dependencies
+      shell: bash
+      run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,17 +18,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Bootstrap Node workspace
+        uses: ./.github/actions/node-bootstrap
 
       - name: Lint
         run: npm run lint:ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,17 +21,8 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Bootstrap Node workspace
+        uses: ./.github/actions/node-bootstrap
 
       - name: Build
         run: npm run build

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -18,17 +18,8 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Bootstrap Node workspace
+        uses: ./.github/actions/node-bootstrap
 
       - name: Build site
         run: VITE_BASE_PATH=/ npm run build

--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -25,17 +25,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Bootstrap Node workspace
+        uses: ./.github/actions/node-bootstrap
 
       - name: Validate content
         run: npm run validate-content


### PR DESCRIPTION
### Motivation
- Reduce duplication across CI workflows by centralizing the common Node workspace setup (checkout, `setup-node` with npm cache, and `npm ci`).
- Make it easier to update bootstrap behavior in one place while keeping workflow-specific steps (tests, Lighthouse, deploy, nightly issue handling) in each workflow.
- Preserve existing secret and permission boundaries by using a local composite action that runs in the same job context.

### Description
- Added a local composite action at `./.github/actions/node-bootstrap/action.yml` that performs `actions/checkout@v6`, `actions/setup-node@v6` (with `cache: npm`), and `npm ci`, and exposes a `node-version` input (default `20`).
- Replaced the repeated `Checkout` / `Setup Node` / `Install dependencies` steps in `./.github/workflows/ci.yml`, `./.github/workflows/lighthouse.yml`, `./.github/workflows/deploy.yml`, and `./.github/workflows/nightly-smoke.yml` with `uses: ./.github/actions/node-bootstrap`.
- Kept all workflow-specific steps unchanged (lint/typecheck/tests/artifacts in `ci.yml`, build/serve/LHCI in `lighthouse.yml`, Pages build/deploy in `deploy.yml`, and Playwright/issue automation in `nightly-smoke.yml`).
- No new secrets were introduced and workflow-level `permissions` scopes remain defined in their respective workflows.

### Testing
- Ran `npm run lint:ci` successfully, which includes the project typecheck (`tsc -b`) and exited with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad1bd086c8330b05d84832ab5a664)