### PR TITLE
chore(ci): run Dependabot Thursdays at 1:00 PM IST + add on-demand workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
-      time: "22:00"
+      time: "13:00"
       timezone: "Asia/Kolkata"
     open-pull-requests-limit: 10
     labels: ["dependencies"]
@@ -22,6 +22,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
-      time: "22:15"
+      time: "13:00"
       timezone: "Asia/Kolkata"
     labels: ["dependencies", "github-actions"]

--- a/.github/workflows/dependabot-on-demand.yml
+++ b/.github/workflows/dependabot-on-demand.yml
@@ -1,0 +1,68 @@
+name: Dependabot On-Demand
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_npm:
+        description: Trigger npm ecosystem updates
+        type: boolean
+        default: true
+      npm_directory:
+        description: npm directory to update
+        type: string
+        default: "/"
+      run_github_actions:
+        description: Trigger GitHub Actions ecosystem updates
+        type: boolean
+        default: true
+      github_actions_directory:
+        description: GitHub Actions directory to update
+        type: string
+        default: "/"
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-dependabot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Dependabot updates
+        uses: actions/github-script@v8
+        env:
+          DEPENDABOT_TOKEN: ${{ secrets.DEPENDABOT_TRIGGER_TOKEN }}
+        with:
+          github-token: ${{ env.DEPENDABOT_TOKEN != '' && env.DEPENDABOT_TOKEN || github.token }}
+          script: |
+            const updates = [];
+
+            if (core.getInput('run_npm') === 'true') {
+              updates.push({
+                package_ecosystem: 'npm',
+                directory: core.getInput('npm_directory'),
+              });
+            }
+
+            if (core.getInput('run_github_actions') === 'true') {
+              updates.push({
+                package_ecosystem: 'github-actions',
+                directory: core.getInput('github_actions_directory'),
+              });
+            }
+
+            if (updates.length === 0) {
+              core.setFailed('No ecosystems selected. Enable at least one ecosystem input.');
+              return;
+            }
+
+            for (const update of updates) {
+              core.info(`Triggering Dependabot update for ${update.package_ecosystem} at ${update.directory}`);
+              await github.request('POST /repos/{owner}/{repo}/dependabot/updates', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                package_ecosystem: update.package_ecosystem,
+                directory: update.directory,
+              });
+            }
+
+            core.info(`Triggered ${updates.length} Dependabot update request(s).`);

--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ content/lessons/       # 108 lesson markdown files
 | `npm run test:e2e`     | Run Playwright end-to-end tests |
 | `npm run deploy`       | Deploy to GitHub Pages        |
 
+
+## 🤖 Dependabot Updates
+
+- **Automatic schedule:** Dependabot checks both `npm` and `github-actions` every **Thursday at 1:00 PM IST** via `.github/dependabot.yml`.
+- **Manual on-demand run:** Maintainers can trigger **Actions → "Dependabot On-Demand" → Run workflow** and choose which ecosystem/directory to update.
+- **Required permissions/token:** Configure a repository secret named `DEPENDABOT_TRIGGER_TOKEN` with scopes/permissions that allow Dependabot update triggers (for example, a fine-grained PAT with Dependabot write access to this repo). Without this secret, the workflow falls back to `GITHUB_TOKEN`, which may not have sufficient privileges depending on repository settings.
+
 ## 🧪 Visual Snapshot Testing
 
 - Visual smoke tests live in `tests/e2e/visual-smoke.spec.ts` and capture snapshots for: home, curriculum, phase 1, lesson 1, progress, and search routes.


### PR DESCRIPTION
### Motivation
- Ensure Dependabot updates run at an explicit IST time (Thursday 1:00 PM) for predictable maintenance windows. 
- Provide maintainers a safe manual trigger to request Dependabot updates on-demand for selected ecosystems or directories. 
- Document the schedule and required token/permission guidance for repo maintainers.

### Description
- Updated ` .github/dependabot.yml` to set the `time` to `"13:00"` and `timezone: "Asia/Kolkata"` for both the `npm` and `github-actions` ecosystems. 
- Added `.github/workflows/dependabot-on-demand.yml` with `on: workflow_dispatch` inputs to choose ecosystems/directories and a job that calls the Dependabot update API (`POST /repos/{owner}/{repo}/dependabot/updates`). 
- The on-demand workflow uses a repo secret named `DEPENDABOT_TRIGGER_TOKEN` when present and falls back to `GITHUB_TOKEN` otherwise, and fails early if no ecosystem is selected. 
- Documented the automatic schedule and manual workflow usage (including token/permission notes) in `README.md` under a new "Dependabot Updates" section.

### Testing
- Parsed and validated YAML for ` .github/dependabot.yml` and ` .github/workflows/dependabot-on-demand.yml` using `ruby -e "require 'yaml'; YAML.load_file(...)"`, which succeeded. 
- Verified the new workflow file is present in `.github/workflows/` via `rg --files .github/workflows` and listed contents, confirming the `workflow_dispatch` trigger. 
- Confirmed repository changes were staged and committed; UI validation in the Actions tab (manual run) must be done after push to the remote to verify runnability and token behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad507c0a08330be6be2624465f854)