### PR TITLE
fix(ci): pin node-bootstrap actions to released versions

### DIFF
--- a/.github/actions/node-bootstrap/action.yml
+++ b/.github/actions/node-bootstrap/action.yml
@@ -10,10 +10,10 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v4
 
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: npm

--- a/.github/workflows/deploy-surge.yml
+++ b/.github/workflows/deploy-surge.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
### Motivation
- The Node bootstrap composite action referenced non-existent major versions `actions/checkout@v6` and `actions/setup-node@v6`, causing CI bootstrap failures so the workflow needs to use released action versions to restore CI.

### Description
- Update `.github/actions/node-bootstrap/action.yml` to use `actions/checkout@v4` and `actions/setup-node@v4` instead of the invalid `@v6` entries.

### Testing
- Ran `npm run typecheck`, `npm run lint:ci`, `npm run validate-content`, and the full `npm run test:coverage` suite and all commands completed successfully with tests passing and coverage generated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad6740da883308f91793821303da1)