### PR TITLE
Add checkout step before local node-bootstrap action in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -18,6 +18,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
 

--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
 


### PR DESCRIPTION
### Motivation
- CI runs were failing with errors like `Can't find 'action.yml' ... .github/actions/node-bootstrap` because the repository wasn't checked out before invoking a local action. 
- Ensure the local `./.github/actions/node-bootstrap` files are present on the runner before the action is used.

### Description
- Inserted an explicit `actions/checkout@v4` step before the local `./.github/actions/node-bootstrap` usage in `ci.yml`.
- Applied the same `actions/checkout@v4` insertion to the `build` job in `deploy.yml` so the Pages build can access local actions.
- Applied the same `actions/checkout@v4` insertion to `lighthouse.yml` and `nightly-smoke.yml` so those workflows also checkout before the local action.
- No application source code changed; this is limited to GitHub Actions workflow files under `.github/workflows/`.

### Testing
- Ran `npm run lint:ci` which completed successfully in this environment.
- Attempted to parse the modified YAML files with a Python script, but the check failed due to missing `PyYAML` in the environment (automated YAML validation could not run here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad8c0d94c833086f5a5dbc741b60d)