### PR TITLE
Use day-token map for O(1) lesson lookups

### DIFF
--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -127,7 +127,7 @@ export function getAllLessons(): readonly ImmutableLesson[] {
 /** Return a lesson by day number. */
 export function getLesson(dayNum: string | number): ImmutableLesson | undefined {
   const dayToken = normalizeDayToken(dayNum)
-  return immutableLessons.find((l) => l.day === dayToken)
+  return immutableLessonByDay.get(dayToken)
 }
 
 /** Return all lessons in a phase. */
@@ -322,6 +322,9 @@ function buildReviewCardsFromLesson(lesson: Lesson): ReviewCardSeed[] {
 
 const immutableLessons = Object.freeze(lessons.map(freezeLesson))
 const immutablePhases = Object.freeze(phases.map(freezePhase))
+const immutableLessonByDay: Map<DayToken, ImmutableLesson> = new Map(
+  immutableLessons.map((lesson) => [lesson.day, lesson]),
+)
 
 let immutableLessonsByPhase: Record<number, readonly ImmutableLesson[]> | null = null
 let immutableExercises: readonly ImmutableExercise[] | null = null
@@ -502,7 +505,7 @@ export function getPrerequisiteLessons(lesson: Readonly<Lesson>): readonly Immut
   if (!prereqs || !Array.isArray(prereqs) || prereqs.length === 0) return []
   return prereqs
     .map((day) => dayTokenFromReference(day))
-    .map((day) => (day ? immutableLessons.find((l) => l.day === day) : undefined))
+    .map((day) => (day ? immutableLessonByDay.get(day) : undefined))
     .filter((l): l is ImmutableLesson => l !== undefined)
 }
 


### PR DESCRIPTION
### Motivation
- Lesson lookups and prerequisite resolution previously scanned the frozen `immutableLessons` array with `find`, which is suboptimal for repeated lookups and can be simplified with a map for constant-time resolution.

### Description
- Added a module-level `immutableLessonByDay: Map<DayToken, ImmutableLesson>` built from `immutableLessons` to provide O(1) lesson resolution.
- Updated `getLesson(...)` to use `immutableLessonByDay.get(...)` instead of `immutableLessons.find(...)`.
- Updated `getPrerequisiteLessons(...)` to resolve prerequisite day tokens via `immutableLessonByDay.get(...)` instead of array `find` calls.
- Kept public function signatures and immutable return behavior unchanged.

### Testing
- Ran `npm run typecheck` which completed successfully.
- Pre-commit hooks ran `prettier --check` and `npm run typecheck` during commit and both passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b16ea98a883309000712750ad2f34)