### PR TITLE
Debounce search computations in SearchResults

### DIFF
--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -16,6 +16,7 @@ import { useReducedMotion } from 'motion/react'
 import SEOHead from '../components/SEOHead'
 import { difficultyConfig } from '../utils/contentLoader'
 import Breadcrumb from '../components/Breadcrumb'
+import { useDebounce } from '../hooks/useDebounce'
 import { highlightText } from '../utils/searchHighlight'
 import {
   extractMatchedTerms,
@@ -75,6 +76,7 @@ export default function SearchResults() {
   const navigate = useNavigate()
   const queryFromUrl = searchParams.get('q') ?? ''
   const [query, setQuery] = useState(queryFromUrl)
+  const debouncedQuery = useDebounce(query, 250, (value) => value.trim() === '')
   const inputRef = useRef<HTMLInputElement>(null)
   const prefersReducedMotion = !!useReducedMotion()
 
@@ -108,11 +110,11 @@ export default function SearchResults() {
   }, [navigate])
 
   const results: SearchResult[] = useMemo(() => {
-    if (query.trim().length < 2) return []
-    return search(query, 50)
-  }, [query])
+    if (debouncedQuery.trim().length < 2) return []
+    return search(debouncedQuery, 50)
+  }, [debouncedQuery])
 
-  const terms = useMemo(() => extractMatchedTerms(query), [query])
+  const terms = useMemo(() => extractMatchedTerms(debouncedQuery), [debouncedQuery])
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -180,7 +182,7 @@ export default function SearchResults() {
                 </div>
 
                 <p className="search-result-card-snippet">
-                  {highlightText(getSearchSnippet(result.item.plainContent, query), terms)}
+                  {highlightText(getSearchSnippet(result.item.plainContent, debouncedQuery), terms)}
                 </p>
 
                 <div className="search-result-card-tags">
@@ -200,7 +202,7 @@ export default function SearchResults() {
             )
           })}
         </div>
-      ) : query.trim().length >= 2 ? (
+      ) : debouncedQuery.trim().length >= 2 ? (
         <div className="search-empty-page glass-card">
           <SearchEmptyIllustration reducedMotion={prefersReducedMotion} />
           <p>No lessons matched your search.</p>


### PR DESCRIPTION
### Motivation

- Reduce repeated expensive search computations while keeping the input responsive by debouncing the query used for searching and highlighting.
- Keep UI behavior identical on form submit so navigated URLs remain based on the immediate input.
- Use the project's existing debounce utility to avoid reimplementing timing logic.

### Description

- Imported the existing `useDebounce` hook from `src/hooks/useDebounce` and created a `debouncedQuery` (`250ms`, with immediate reset for empty strings) in `src/pages/SearchResults.tsx`.
- Switched search computation to use `debouncedQuery` for `results` (the `search` call) and for matched-term extraction via `extractMatchedTerms`.
- Updated snippet generation (`getSearchSnippet`) and the empty-state threshold check to use `debouncedQuery`, while preserving form submit behavior that still uses the immediate `query` value and navigates to `/search?q=...`.

### Testing

- Ran TypeScript type checks with `npm run typecheck`, which completed successfully.
- Pre-commit hooks ran `npm run typecheck` and `prettier --check` on staged files and passed during commit preparation.
- No unit/e2e tests were modified by this change and no test failures were observed during validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b1782beb08330955294b975ae119c)