### PR TITLE
⚡ Bolt: Optimize Sidebar progress calculation

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,9 +9,9 @@ import { useState, useMemo, useEffect, useRef } from 'react'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { Link, useLocation } from 'react-router-dom'
 import { getAllPhases, getLessonsByPhase, phaseIcons } from '../utils/contentLoader'
-import { isLessonComplete, getCompletedForPhase } from '../utils/progressTracker'
 import { getReviewDueCountByPhase, getReviewStreak } from '../utils/reviewTracker'
 import { dayTokenToProgressId, normalizeDayToken } from '../utils/dayToken'
+import { useProgressStore } from '../stores/progressStore'
 
 /**
  * Props for the Sidebar component.
@@ -60,6 +60,10 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
   const [manualOpen, setManualOpen] = useState<number | null>(null)
   const dueByPhase = useMemo(() => getReviewDueCountByPhase(), [])
   const reviewStreak = useMemo(() => getReviewStreak(), [])
+
+  // Reactive progress tracking
+  const completedLessons = useProgressStore((state) => state.completedLessons)
+  const completedSet = useMemo(() => new Set(completedLessons), [completedLessons])
 
   // Determines currently open phase: manual toggle takes precedence over auto-derived.
   const openPhase = manualOpen !== null ? manualOpen : derivedOpenPhase
@@ -167,8 +171,9 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
             const lessons = getLessonsByPhase(phase.phase)
             const isActive = openPhase === phase.phase
             const icon = phaseIcons[phase.phase - 1] || '📖'
-            const lessonDays = lessons.map((l) => l.day)
-            const completedInPhase = getCompletedForPhase(lessonDays)
+            const completedCount = lessons.filter((l) =>
+              completedSet.has(dayTokenToProgressId(l.day)),
+            ).length
 
             return (
               <div className="phase-group" key={phase.phase}>
@@ -186,10 +191,10 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                   </span>
                   <span className="phase-toggle-progress">
                     <span aria-hidden="true">
-                      {completedInPhase.length}/{lessons.length} · 🧠 {dueByPhase[phase.phase] || 0}
+                      {completedCount}/{lessons.length} · 🧠 {dueByPhase[phase.phase] || 0}
                     </span>
                     <span className="sr-only">
-                      {completedInPhase.length} of {lessons.length} completed,{' '}
+                      {completedCount} of {lessons.length} completed,{' '}
                       {dueByPhase[phase.phase] || 0} reviews due
                     </span>
                   </span>
@@ -263,7 +268,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                             className={`day-link ${location.pathname === `/lesson/${lesson.day}` ? 'active' : ''}`}
                             onClick={onClose}
                           >
-                            {isLessonComplete(dayTokenToProgressId(lesson.day)) && (
+                            {completedSet.has(dayTokenToProgressId(lesson.day)) && (
                               <span className="day-link-check" aria-label="Completed">
                                 ✓
                               </span>

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -4,7 +4,6 @@ import { createRoot } from 'react-dom/client'
 import Sidebar from '../Sidebar'
 import { MemoryRouter } from 'react-router-dom'
 import * as contentLoader from '../../utils/contentLoader'
-import * as progressTracker from '../../utils/progressTracker'
 import * as reviewTracker from '../../utils/reviewTracker'
 
 // Mock dependencies
@@ -14,9 +13,10 @@ vi.mock('../../utils/contentLoader', () => ({
   phaseIcons: ['A', 'B'],
 }))
 
-vi.mock('../../utils/progressTracker', () => ({
-  isLessonComplete: vi.fn(),
-  getCompletedForPhase: vi.fn(),
+// Mock store
+const useProgressStoreMock = vi.fn((selector) => selector({ completedLessons: [] }))
+vi.mock('../../stores/progressStore', () => ({
+  useProgressStore: (selector: any) => useProgressStoreMock(selector),
 }))
 
 vi.mock('../../utils/reviewTracker', () => ({
@@ -55,9 +55,10 @@ describe('Sidebar Accessibility', () => {
     vi.mocked(contentLoader.getLessonsByPhase).mockReturnValue(
       lessonsPhase1 as unknown as ReturnType<typeof contentLoader.getLessonsByPhase>,
     )
-    vi.mocked(progressTracker.getCompletedForPhase).mockReturnValue([1] as unknown as ReturnType<
-      typeof progressTracker.getCompletedForPhase
-    >) // 1 completed
+
+    // Mock 1 completed lesson (Day 1 -> ID 1)
+    useProgressStoreMock.mockImplementation((selector) => selector({ completedLessons: [1] }))
+
     vi.mocked(reviewTracker.getReviewDueCountByPhase).mockReturnValue({
       1: 5,
     } as unknown as ReturnType<typeof reviewTracker.getReviewDueCountByPhase>) // 5 reviews due

--- a/src/components/__tests__/SidebarPerf.test.tsx
+++ b/src/components/__tests__/SidebarPerf.test.tsx
@@ -12,9 +12,10 @@ vi.mock('../../utils/contentLoader', () => ({
   phaseIcons: ['A', 'B'],
 }))
 
-vi.mock('../../utils/progressTracker', () => ({
-  isLessonComplete: () => false,
-  getCompletedForPhase: () => [],
+// Mock store
+const useProgressStoreMock = vi.fn((selector) => selector({ completedLessons: [] }))
+vi.mock('../../stores/progressStore', () => ({
+  useProgressStore: (selector: any) => useProgressStoreMock(selector),
 }))
 
 vi.mock('../../utils/reviewTracker', () => ({


### PR DESCRIPTION
This change optimizes the `Sidebar` component by replacing repeated, expensive calls to `getCompletedForPhase` (which creates new Sets and iterates arrays) with a single, reactive subscription to `useProgressStore` and a memoized `Set` lookup. This reduces complexity from O(Phase * Lessons) to O(Total Lessons) per render and ensures the sidebar updates immediately when lessons are completed.

---
*PR created automatically by Jules for task [9966518460043791003](https://jules.google.com/task/9966518460043791003) started by @saint2706*