### PR TITLE
🛡️ Sentinel: [CRITICAL] Block Pyodide internal modules to prevent XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,8 @@
 **Vulnerability:** Unrestricted use of `input()`, `help()`, and `breakpoint()` in client-side Python (Pyodide) caused UI freezes (waiting for prompt) or unexpected runtime states.
 **Learning:** Functions that block execution or require user interaction are denial-of-service vectors in synchronous WASM environments.
 **Prevention:** Explicitly block interactive keywords (`input`, `breakpoint`, `help`, `quit`, `exit`) in the validation layer.
+
+## 2025-05-25 - Pyodide Internals Exposure
+**Vulnerability:** The `pyodide` and `micropip` modules were not blocked, allowing access to `pyodide.code.run_js` (arbitrary JS execution) and package installation from external sources.
+**Learning:** Pyodide exposes powerful internals (like JS interop) via its own module, which must be explicitly blocked alongside the `js` module in sandboxed environments.
+**Prevention:** Add `pyodide` and `micropip` to the import blocklist in the code validation layer.

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -272,4 +272,27 @@ print("bad")
       expect(validatePythonCode('quit()').valid).toBe(false);
     });
   });
+
+  describe('Pyodide Internals', () => {
+    it('should block import pyodide', () => {
+      expect(validatePythonCode('import pyodide').valid).toBe(false)
+      expect(validatePythonCode('import   pyodide').valid).toBe(false)
+      expect(validatePythonCode('import pyodide as p').valid).toBe(false)
+    })
+
+    it('should block from pyodide import', () => {
+      expect(validatePythonCode('from pyodide import code').valid).toBe(false)
+      expect(validatePythonCode('from pyodide.code import run_js').valid).toBe(false)
+    })
+
+    it('should block import micropip', () => {
+      expect(validatePythonCode('import micropip').valid).toBe(false)
+      expect(validatePythonCode('from micropip import install').valid).toBe(false)
+    })
+
+    it('should block submodules', () => {
+      expect(validatePythonCode('import pyodide.code').valid).toBe(false)
+      expect(validatePythonCode('import micropip.transactions').valid).toBe(false)
+    })
+  })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -123,14 +123,18 @@ export function validatePythonCode(code: string): ValidationResult {
   // 4. Import Deny Patterns (Specific module imports)
   const importPatterns = [
     /\bimport\s+js\b/,
-    /\bfrom\s+js\b/
+    /\bfrom\s+js\b/,
+    /\bimport\s+pyodide\b/,
+    /\bfrom\s+pyodide\b/,
+    /\bimport\s+micropip\b/,
+    /\bfrom\s+micropip\b/
   ]
 
   for (const pattern of importPatterns) {
     if (pattern.test(strippedCode)) {
       return {
         valid: false,
-        error: "Security Error: Direct access to browser APIs via 'js' module is restricted.",
+        error: "Security Error: Direct access to internal modules (js, pyodide, micropip) is restricted.",
       }
     }
   }


### PR DESCRIPTION
Sentinel 🛡️ identified a critical security vulnerability where the `pyodide` module was accessible in the client-side Python environment. This module exposes internals like `run_js`, which allows arbitrary JavaScript execution, bypassing the existing block on the `js` module.

This PR:
1.  Updates `validatePythonCode` in `src/utils/codeSecurity.ts` to explicitly block imports of `pyodide` and `micropip`.
2.  Adds a new suite of tests in `src/utils/__tests__/codeSecurity.test.ts` to verify that `import pyodide`, `from pyodide`, and submodules like `pyodide.code` are correctly rejected.
3.  Updates `.jules/sentinel.md` with the finding and prevention strategy.

This ensures a safer sandbox for the Python learning environment.

---
*PR created automatically by Jules for task [13323239698002042198](https://jules.google.com/task/13323239698002042198) started by @saint2706*