### PR TITLE
Sentinel: Security Enhancements for Python Execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,7 @@
-## 2025-05-18 - Client-Side DoS via Output\n**Vulnerability:** Unbounded Python stdout/stderr in Pyodide execution allowed browser hangs via large output (e.g. infinite loops).\n**Learning:** Client-side execution environments (WASM) still need resource constraints (output size, time) to prevent UI freezing.\n**Prevention:** Enforce strict output length limits in execution wrappers (hooks)
+## 2025-05-18 - Client-Side DoS via Output
+**Vulnerability:** Unbounded Python stdout/stderr in Pyodide execution allowed browser hangs via large output (e.g. infinite loops).
+**Learning:** Client-side execution environments (WASM) still need resource constraints (output size, time) to prevent UI freezing.
+**Prevention:** Enforce strict output length limits in execution wrappers (hooks)
 
 ## 2025-05-20 - Regex Validation Bypass in Python Runner
 **Vulnerability:** `validatePythonCode` regex checks for `exec(` or `eval(` allowed bypass via variable assignment (`e = exec; e(...)`), while blocking safe usage in strings.
@@ -14,3 +17,13 @@
 **Vulnerability:** The `pyodide` and `micropip` modules were not blocked, allowing access to `pyodide.code.run_js` (arbitrary JS execution) and package installation from external sources.
 **Learning:** Pyodide exposes powerful internals (like JS interop) via its own module, which must be explicitly blocked alongside the `js` module in sandboxed environments.
 **Prevention:** Add `pyodide` and `micropip` to the import blocklist in the code validation layer.
+
+## 2025-05-30 - Recursion Limit DoS
+**Vulnerability:** Default recursion limits in Python (usually 1000) combined with browser stack limits can cause browser tab crashes or hangs when users write deep recursion.
+**Learning:** Client-side WASM runs on the main thread's stack. Deep recursion can exceed browser limits before Python's limit is hit, or simply freeze the UI.
+**Prevention:** Enforce a lower recursion limit (e.g., 500) by prepending `sys.setrecursionlimit(500)` to user code execution.
+
+## 2025-05-30 - Dangerous Built-ins Access
+**Vulnerability:** `open()`, `compile()`, and `memoryview()` were allowed, presenting risks of file system access (virtual), code object creation (potential escape), and raw memory manipulation.
+**Learning:** Even in a virtualized environment, file access and low-level memory operations increase the attack surface for escapes or side-channel attacks.
+**Prevention:** Explicitly block `open`, `compile`, and `memoryview` in the validation layer, while ensuring method calls (e.g. `obj.open()`) remain valid.

--- a/src/hooks/__tests__/usePyodide.test.tsx
+++ b/src/hooks/__tests__/usePyodide.test.tsx
@@ -40,7 +40,7 @@ describe('usePyodide Output Limit', () => {
           window.loadPyodide = vi.fn().mockResolvedValue({
             runPythonAsync: vi.fn().mockImplementation(async (code) => {
               // Simulate output larger than 50KB limit
-              if (code === 'print_large') {
+              if (code.includes('print_large')) {
                 const chunk1 = 'a'.repeat(30000)
                 const chunk2 = 'b'.repeat(30000)
                 // Use the captured callback

--- a/src/hooks/usePyodide.ts
+++ b/src/hooks/usePyodide.ts
@@ -241,7 +241,14 @@ export function usePyodide() {
           },
         })
 
-        const pythonExecutionPromise = pyodide.runPythonAsync(code)
+        // Prepend recursion limit to prevent stack overflow DoS
+        const protectedCode = `
+import sys
+sys.setrecursionlimit(500)
+del sys
+${code}
+`
+        const pythonExecutionPromise = pyodide.runPythonAsync(protectedCode)
 
         // NOTE: Timeout/abort cannot preempt Python code already running in Pyodide.
         // We resolve early so UI can recover, but the underlying execution may continue

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -215,9 +215,14 @@ print("bad")
     expect(validatePythonCode('dir(obj)').valid).toBe(false)
   })
 
-  it('should allow compile and open (Usability Fix)', () => {
-    expect(validatePythonCode('compile("code", "filename", "exec")').valid).toBe(true)
-    expect(validatePythonCode('open("file.txt")').valid).toBe(true)
+  it('should block compile and open (Security Fix)', () => {
+    expect(validatePythonCode('compile("code", "filename", "exec")').valid).toBe(false)
+    expect(validatePythonCode('open("file.txt")').valid).toBe(false)
+  })
+
+  it('should block memoryview (Security Fix)', () => {
+    expect(validatePythonCode('memoryview(b"123")').valid).toBe(false)
+    expect(validatePythonCode('m = memoryview(data)').valid).toBe(false)
   })
 
   it('should allow method calls for introspection functions', () => {

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -110,7 +110,8 @@ export function validatePythonCode(code: string): ValidationResult {
   // 3. Call Deny Patterns (Keywords banned ONLY when called)
   const callKeywords = [
     'getattr', 'setattr', 'delattr', 'hasattr', 'vars', 'dir',
-    'input', 'breakpoint', 'help', 'exit', 'quit'
+    'input', 'breakpoint', 'help', 'exit', 'quit',
+    'open', 'compile', 'memoryview'
   ]
   const callRegex = new RegExp(`(?<!\\.)\\b(${callKeywords.join('|')})\\s*\\(`)
   if (callRegex.test(strippedCode)) {


### PR DESCRIPTION
Sentinel Security Fixes:
- Added `open`, `compile`, and `memoryview` to the blocked keywords list in `src/utils/codeSecurity.ts`.
- Enforced a recursion limit of 500 in `src/hooks/usePyodide.ts` by injecting setup code.
- Updated tests to verify these restrictions and fix regressions in `usePyodide` tests.
- Updated `.jules/sentinel.md` with learnings about client-side DoS and built-in function vulnerabilities.

---
*PR created automatically by Jules for task [6362308559620678477](https://jules.google.com/task/6362308559620678477) started by @saint2706*