### PR TITLE
Security Hardening: Block interactive functions and internal attributes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** `open()`, `compile()`, and `memoryview()` were allowed, presenting risks of file system access (virtual), code object creation (potential escape), and raw memory manipulation.
 **Learning:** Even in a virtualized environment, file access and low-level memory operations increase the attack surface for escapes or side-channel attacks.
 **Prevention:** Explicitly block `open`, `compile`, and `memoryview` in the validation layer, while ensuring method calls (e.g. `obj.open()`) remain valid.
+
+## 2025-06-05 - Interactive Help and Internal Attributes
+**Vulnerability:** Interactive functions like `copyright()`, `credits()`, and `license()` can trigger interactive prompts that hang the Pyodide environment. Additionally, access to internal attributes like `__loader__` and `__spec__` could expose system modules even after `del sys`.
+**Learning:** Standard Python interactive helpers are dangerous in non-interactive environments. Internal attributes can serve as bridges to deleted modules.
+**Prevention:** Explicitly block `copyright`, `credits`, `license` calls and global access to `__loader__` and `__spec__`.

--- a/src/utils/__tests__/codeSecurity.extra.test.ts
+++ b/src/utils/__tests__/codeSecurity.extra.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { validatePythonCode } from '../codeSecurity';
+
+describe('validatePythonCode Security Checks', () => {
+  const unsafeCodes = [
+    // Existing checks (should pass)
+    "eval('print(1)')",
+    "exec('print(1)')",
+    "__import__('os').system('ls')",
+    "import os",
+    "from os import system",
+    "import sys",
+    "import subprocess",
+    "open('/etc/passwd')",
+    "input('give me data')",
+    "breakpoint()",
+    "help()",
+    "exit()",
+    "quit()",
+    "f'{eval(1)}'",
+    "f'{__import__(\"os\")}'",
+    "getattr(builtins, 'eval')('print(1)')",
+    "[x for x in ().__class__.__base__.__subclasses__()]",
+
+    // New checks (should fail initially)
+    "copyright()",
+    "credits()",
+    "license()",
+    "__loader__",
+    "__spec__",
+  ];
+
+  const safeCodes = [
+    "print('hello')",
+    "x = 1 + 1",
+    "def my_func(): return 1",
+    "model.eval()",
+    "my_obj.exec = 1",
+    "df['eval']",
+    "df.eval('x + 1')"
+  ];
+
+  unsafeCodes.forEach((code) => {
+    it(`should block unsafe code: ${code}`, () => {
+      const result = validatePythonCode(code);
+      expect(result.valid, `Expected "${code}" to be invalid`).toBe(false);
+    });
+  });
+
+  safeCodes.forEach((code) => {
+    it(`should allow safe code: ${code}`, () => {
+      const result = validatePythonCode(code);
+      expect(result.valid, `Expected "${code}" to be valid`).toBe(true);
+    });
+  });
+});

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -97,7 +97,8 @@ export function validatePythonCode(code: string): ValidationResult {
     'globals', 'locals', '__import__',
     'subprocess', 'sys', 'os', 'importlib', 'builtins',
     '__builtins__', '__globals__', '__subclasses__', '__bases__',
-    '__mro__', '__getattribute__', '__code__', '__closure__'
+    '__mro__', '__getattribute__', '__code__', '__closure__',
+    '__loader__', '__spec__'
   ]
   const globalRegex = new RegExp(`\\b(${globalKeywords.join('|')})\\b`)
   if (globalRegex.test(strippedCode)) {
@@ -111,7 +112,8 @@ export function validatePythonCode(code: string): ValidationResult {
   const callKeywords = [
     'getattr', 'setattr', 'delattr', 'hasattr', 'vars', 'dir',
     'input', 'breakpoint', 'help', 'exit', 'quit',
-    'open', 'compile', 'memoryview'
+    'open', 'compile', 'memoryview',
+    'copyright', 'credits', 'license'
   ]
   const callRegex = new RegExp(`(?<!\\.)\\b(${callKeywords.join('|')})\\s*\\(`)
   if (callRegex.test(strippedCode)) {


### PR DESCRIPTION
This PR hardens the security of the Python execution environment by blocking interactive functions (`copyright`, `credits`, `license`) that can hang the browser, and internal attributes (`__loader__`, `__spec__`) that could potentially expose system internals.

Changes:
- Modified `src/utils/codeSecurity.ts` to add new keywords to blocklists.
- Added `src/utils/__tests__/codeSecurity.extra.test.ts` with comprehensive test cases.
- Updated `.jules/sentinel.md` with security learnings.

---
*PR created automatically by Jules for task [16341755971261127497](https://jules.google.com/task/16341755971261127497) started by @saint2706*