### PR TITLE
Security Hardening: Python Sandbox & URL Validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,10 @@
 **Vulnerability:** Interactive functions like `copyright()`, `credits()`, and `license()` can trigger interactive prompts that hang the Pyodide environment. Additionally, access to internal attributes like `__loader__` and `__spec__` could expose system modules even after `del sys`.
 **Learning:** Standard Python interactive helpers are dangerous in non-interactive environments. Internal attributes can serve as bridges to deleted modules.
 **Prevention:** Explicitly block `copyright`, `credits`, `license` calls and global access to `__loader__` and `__spec__`.
+
+## 2025-06-10 - Regex Bypass via Control Characters and Obfuscated Schemes
+**Vulnerability:** Simple regex checks for schemes (`^[a-z]+:`) could be bypassed by inserting control characters (e.g., `jav\nscript:`) or using schemes not in the whitelist that browsers might execute or treat unpredictably. Also, broad regexes could flag relative URLs with colons (e.g., `search?q=filter:value`) as unsafe schemes.
+**Learning:** URL validation must robustly handle obfuscation (stripping control characters) and strictly define what constitutes a scheme to avoid false positives on valid relative paths.
+**Prevention:**
+1.  Strip all control characters (ASCII 0-31, 127) before validation.
+2.  Use a strict regex `^[a-zA-Z][^:/?#]*:` to identify schemes, ensuring that characters like `/`, `?`, `#` terminate the scheme detection (preventing relative paths from being misidentified).

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -300,4 +300,13 @@ print("bad")
       expect(validatePythonCode('import micropip.transactions').valid).toBe(false)
     })
   })
+
+  it('should block __getattribute__ on objects', () => {
+    expect(validatePythonCode('obj.__getattribute__("name")').valid).toBe(false)
+  })
+
+  it('should handle complex f-strings', () => {
+    expect(validatePythonCode('f"{1+1}"').valid).toBe(true)
+    expect(validatePythonCode('f"{eval(1)} "').valid).toBe(false)
+  })
 })

--- a/src/utils/__tests__/linkSafety.test.ts
+++ b/src/utils/__tests__/linkSafety.test.ts
@@ -106,4 +106,44 @@ describe('normalizeAndValidateHref', () => {
       isSafe: true,
     })
   })
+
+  it('rejects javascript URLs with newlines', () => {
+    expect(normalizeAndValidateHref('j\navascript:alert(1)')).toEqual({
+      normalizedHref: null,
+      isExternal: false,
+      isSafe: false,
+    })
+  })
+
+  it('rejects javascript URLs with null bytes', () => {
+    expect(normalizeAndValidateHref('jav\0ascript:alert(1)')).toEqual({
+      normalizedHref: null,
+      isExternal: false,
+      isSafe: false,
+    })
+  })
+
+  it('rejects vbscript URLs', () => {
+    expect(normalizeAndValidateHref('vbscript:alert(1)')).toEqual({
+      normalizedHref: null,
+      isExternal: false,
+      isSafe: false,
+    })
+  })
+
+  it('allows complex safe URLs', () => {
+    expect(normalizeAndValidateHref('https://example.com/path?query=1#hash')).toEqual({
+      normalizedHref: 'https://example.com/path?query=1#hash',
+      isExternal: true,
+      isSafe: true,
+    })
+  })
+
+  it('allows relative URLs containing colons in query parameters', () => {
+    expect(normalizeAndValidateHref('search?q=filter:value')).toEqual({
+      normalizedHref: 'search?q=filter:value',
+      isExternal: false,
+      isSafe: true,
+    })
+  })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -20,9 +20,18 @@ export interface ValidationResult {
  * This allows for stricter security checks on the remaining code structure
  * without flagging keywords inside strings or comments.
  *
- * CRITICAL SECURITY NOTE:
- * f-strings (e.g. f"{exec()}") are NOT stripped because they can contain executable code.
- * Any string literal prefixed with 'f' or 'F' is preserved to ensure dangerous keywords inside are detected.
+ * SECURITY MODEL:
+ * 1. Safe Strings (e.g. "hello", 'world', b"bytes", u"unicode"):
+ *    - These are replaced with empty strings ("") or prefix + "" (u"").
+ *    - Content is removed because keywords inside a string literal (e.g. print("import os")) are harmless.
+ *
+ * 2. Unsafe Strings (f-strings, e.g. f"{exec()}", F"Dangerous"):
+ *    - These are PRESERVED (content is kept).
+ *    - This is because f-strings allow code execution within the curly braces {}.
+ *    - By preserving them, the subsequent validation logic can scan the code inside the f-string.
+ *
+ * 3. Comments (# ...):
+ *    - Removed entirely as they are not executable.
  *
  * @param code - The Python code to process
  * @returns The code with SAFE strings and comments removed
@@ -81,6 +90,7 @@ export function validatePythonCode(code: string): ValidationResult {
 
   // 1. Property-Safe Deny Patterns (Keywords banned as references/assignments UNLESS properties)
   // e.g. eval() is banned, but model.eval() is allowed.
+  // Note: __getattribute__ is in strict deny, so obj.__getattribute__ is also banned.
   const propertySafeKeywords = ['eval', 'exec']
   const propertySafeRegex = new RegExp(`(?<!\\.)\\b(${propertySafeKeywords.join('|')})\\b`)
   if (propertySafeRegex.test(strippedCode)) {
@@ -111,11 +121,6 @@ export function validatePythonCode(code: string): ValidationResult {
     '__closure__',
     '__loader__',
     '__spec__',
-    'globals', 'locals', '__import__',
-    'subprocess', 'sys', 'os', 'importlib', 'builtins',
-    '__builtins__', '__globals__', '__subclasses__', '__bases__',
-    '__mro__', '__getattribute__', '__code__', '__closure__',
-    '__loader__', '__spec__'
   ]
   const globalRegex = new RegExp(`\\b(${globalKeywords.join('|')})\\b`)
   if (globalRegex.test(strippedCode)) {
@@ -144,10 +149,6 @@ export function validatePythonCode(code: string): ValidationResult {
     'copyright',
     'credits',
     'license',
-    'getattr', 'setattr', 'delattr', 'hasattr', 'vars', 'dir',
-    'input', 'breakpoint', 'help', 'exit', 'quit',
-    'open', 'compile', 'memoryview',
-    'copyright', 'credits', 'license'
   ]
   const callRegex = new RegExp(`(?<!\\.)\\b(${callKeywords.join('|')})\\s*\\(`)
   if (callRegex.test(strippedCode)) {

--- a/src/utils/linkSafety.ts
+++ b/src/utils/linkSafety.ts
@@ -11,7 +11,13 @@
  */
 
 const SAFE_SCHEMES = new Set(['http:', 'https:', 'mailto:'])
-const URL_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z\d+.-]*:/
+
+// Matches anything that looks like a scheme: starts with a letter,
+// followed by any characters EXCEPT colon, slash, question mark, or hash,
+// and ends with a colon.
+// This prevents relative URLs like "search?q=filter:value" from being treated as schemes,
+// while still catching valid schemes and obfuscated ones (if they don't contain /?#).
+const URL_SCHEME_PATTERN = /^[a-zA-Z][^:/?#]*:/
 
 /**
  * Validates and normalizes a URL string.
@@ -25,12 +31,16 @@ export const normalizeAndValidateHref = (href?: string | null) => {
     return { normalizedHref: null, isExternal: false, isSafe: false }
   }
 
-  const normalizedHref = href.trim()
+  // Remove control characters (ASCII 0-31, 127) and trim whitespace.
+  // This neutralizes obfuscation attempts like "j\navascript:" or "jav\0ascript:".
+  const normalizedHref = href.replace(/[\x00-\x1F\x7F]/g, '').trim()
 
   if (!normalizedHref || normalizedHref.startsWith('//')) {
     return { normalizedHref: null, isExternal: false, isSafe: false }
   }
 
+  // If it doesn't look like a URL with a scheme, treat it as a relative path.
+  // We check specific prefixes to be sure, or fallback to the regex check.
   if (
     normalizedHref.startsWith('#') ||
     normalizedHref.startsWith('/') ||
@@ -43,6 +53,7 @@ export const normalizeAndValidateHref = (href?: string | null) => {
 
   try {
     const url = new URL(normalizedHref)
+    // Validate protocol against allowlist
     if (!SAFE_SCHEMES.has(url.protocol)) {
       return { normalizedHref: null, isExternal: false, isSafe: false }
     }
@@ -53,6 +64,7 @@ export const normalizeAndValidateHref = (href?: string | null) => {
       isSafe: true,
     }
   } catch {
+    // If it looks like a URL (has scheme) but fails parsing, it's unsafe.
     return { normalizedHref: null, isExternal: false, isSafe: false }
   }
 }


### PR DESCRIPTION
Hardened the application against security vulnerabilities:
1.  **Python Sandbox**: Cleaned up keyword blocklists and documented the f-string preservation strategy in `stripPythonCommentsAndStrings`.
2.  **URL Safety**: Improved `normalizeAndValidateHref` to strip control characters (preventing obfuscation attacks) and used a stricter regex (`^[a-zA-Z][^:/?#]*:`) to identify schemes, ensuring relative URLs with colons are not falsely flagged.
3.  **Testing**: Added regression tests for `codeSecurity` and `linkSafety` covering edge cases like `__getattribute__`, f-strings, control characters in URLs, and relative URLs with query parameters.

---
*PR created automatically by Jules for task [9439474644797230541](https://jules.google.com/task/9439474644797230541) started by @saint2706*