### PR TITLE
🎨 Picasso: Improve ExerciseWidget safety and ConceptGraph a11y

### DIFF
--- a/src/components/ConceptGraph.tsx
+++ b/src/components/ConceptGraph.tsx
@@ -407,7 +407,13 @@ export default function ConceptGraph({ search = '', highlightPhase = null }: Con
         onMouseMove={handleMouseMove}
         onMouseLeave={handleMouseLeave}
         onClick={handleClick}
+        role="img"
+        aria-label="Concept dependency graph showing lesson relationships"
       />
+      <div className="sr-only">
+        This interactive graph visualizes connections between lessons. It is optimized for mouse
+        interaction. Please use the Sidebar or Curriculum page for an accessible list of lessons.
+      </div>
 
       {tooltip && (
         <div className="graph-tooltip visible" style={{ left: tooltip.x, top: tooltip.y }}>

--- a/src/components/ExerciseWidget.tsx
+++ b/src/components/ExerciseWidget.tsx
@@ -18,7 +18,7 @@
  * - Provide a collapsible solution panel with syntax highlighting.
  */
 
-import { useState, useId, useRef, useMemo, useCallback } from 'react'
+import { useState, useId, useRef, useMemo, useCallback, useEffect } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
@@ -77,8 +77,10 @@ export default function ExerciseWidget({
   const [showSolution, setShowSolution] = useState(false)
   const [hasRevealed, setHasRevealed] = useState(false)
   const [hasSubmitted, setHasSubmitted] = useState(false)
+  const [isConfirmingSolution, setIsConfirmingSolution] = useState(false)
   const solutionId = useId()
   const playgroundRef = useRef<CodePlaygroundHandle>(null)
+  const confirmTimeoutRef = useRef<number | null>(null)
   const prefersReducedMotion = useReducedMotion()
 
   const location = useLocation()
@@ -159,6 +161,28 @@ export default function ExerciseWidget({
     }
     setShowSolution((s) => !s)
   }
+
+  const handleTrySolution = useCallback(() => {
+    if (!solution) return
+    if (isConfirmingSolution) {
+      playgroundRef.current?.setCode(solution)
+      setIsConfirmingSolution(false)
+      if (confirmTimeoutRef.current) clearTimeout(confirmTimeoutRef.current)
+      toastSuccess('Solution loaded into editor')
+    } else {
+      setIsConfirmingSolution(true)
+      if (confirmTimeoutRef.current) clearTimeout(confirmTimeoutRef.current)
+      confirmTimeoutRef.current = window.setTimeout(() => {
+        setIsConfirmingSolution(false)
+      }, 3000)
+    }
+  }, [isConfirmingSolution, solution])
+
+  useEffect(() => {
+    return () => {
+      if (confirmTimeoutRef.current) clearTimeout(confirmTimeoutRef.current)
+    }
+  }, [])
 
   return (
     <div className="exercise-widget">
@@ -249,17 +273,24 @@ export default function ExerciseWidget({
                       }}
                     >
                       <button
-                        className="code-block-copy"
-                        onClick={() => playgroundRef.current?.setCode(solution)}
-                        aria-label="Load solution into playground"
-                        title="Try Solution"
+                        className={`code-block-copy ${isConfirmingSolution ? 'confirm-destructive' : ''}`}
+                        onClick={handleTrySolution}
+                        aria-label={
+                          isConfirmingSolution
+                            ? 'Confirm overwriting code with solution?'
+                            : 'Load solution into playground'
+                        }
+                        title={isConfirmingSolution ? 'Click again to confirm' : 'Try Solution'}
                         style={{
                           display: 'flex',
                           alignItems: 'center',
                           gap: '0.35rem',
+                          ...(isConfirmingSolution
+                            ? { color: 'var(--color-danger, #ef4444)' }
+                            : {}),
                         }}
                       >
-                        🚀 Try Solution
+                        {isConfirmingSolution ? '⚠️ Confirm?' : '🚀 Try Solution'}
                       </button>
                       <CopyButton text={solution} className="code-block-copy" showEmoji={true} />
                     </div>

--- a/src/components/__tests__/ExerciseWidget.test.tsx
+++ b/src/components/__tests__/ExerciseWidget.test.tsx
@@ -22,13 +22,19 @@ vi.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({
 // Mock CodePlayground to capture props
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let capturedCodePlaygroundProps: any
+const mockSetCode = vi.fn()
 
 vi.mock('../CodePlayground', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  default: (props: any) => {
+  default: React.forwardRef((props: any, ref: any) => {
     capturedCodePlaygroundProps = props
+    React.useImperativeHandle(ref, () => ({
+      setCode: mockSetCode,
+      run: vi.fn(),
+      reset: vi.fn(),
+    }))
     return <div className="code-playground-mock" />
-  },
+  }),
 }))
 
 // Mock CopyButton
@@ -239,5 +245,43 @@ describe('ExerciseWidget', () => {
     // Solution code should be unmounted after closing the panel
     const solutionCodeHidden = container.querySelector('.syntax-highlighter')
     expect(solutionCodeHidden).toBeNull()
+  })
+
+  it('requires confirmation before loading solution', async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter>
+          <ExerciseWidget {...defaultProps} />
+        </MemoryRouter>,
+      )
+    })
+
+    // Open solution
+    const showButton = container.querySelector('.exercise-widget__solution-btn') as HTMLButtonElement
+    await act(async () => {
+      showButton.click()
+    })
+
+    const tryButton = container.querySelector(
+      'button[aria-label="Load solution into playground"]',
+    ) as HTMLButtonElement
+    expect(tryButton).not.toBeNull()
+    expect(tryButton.textContent).toContain('Try Solution')
+
+    // Click 1: Confirm state
+    await act(async () => {
+      tryButton.click()
+    })
+    expect(tryButton.textContent).toContain('Confirm')
+    expect(mockSetCode).not.toHaveBeenCalled()
+
+    // Click 2: Load solution
+    await act(async () => {
+      tryButton.click()
+    })
+    expect(mockSetCode).toHaveBeenCalledWith('def solution(): return True')
+
+    // Should reset after click
+    expect(tryButton.textContent).toContain('Try Solution')
   })
 })


### PR DESCRIPTION
Implemented UX and accessibility improvements as 'Picasso':
1.  **ExerciseWidget Safety:** Added a two-step confirmation for the "Try Solution" button to prevent accidental code overwrites. The button now changes state to "⚠️ Confirm?" for 3 seconds before resetting.
2.  **ConceptGraph Accessibility:** Added `role="img"` and a visually hidden description to the D3 graph, informing screen reader users about the visualization and directing them to the accessible Sidebar/Curriculum page.
3.  **Testing:** Added a new unit test case in `ExerciseWidget.test.tsx` to verify the confirmation flow and updated the `CodePlayground` mock to support `ref` interactions.
4.  **Verification:** Verified frontend changes with a Playwright script confirming the button state change.

---
*PR created automatically by Jules for task [4345673689802845687](https://jules.google.com/task/4345673689802845687) started by @saint2706*