### PR TITLE
Add unit tests for UI components and hooks

### DIFF
--- a/src/components/__tests__/BackToTop.test.tsx
+++ b/src/components/__tests__/BackToTop.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import BackToTop from '../BackToTop'
+
+describe('BackToTop', () => {
+  let container: HTMLDivElement
+  let root: ReturnType<typeof createRoot> | undefined
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    // Spy on scrollTo
+    vi.spyOn(window, 'scrollTo')
+
+    // Mock scrollY
+    Object.defineProperty(window, 'scrollY', { value: 0, writable: true, configurable: true })
+  })
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount()
+    })
+    document.body.removeChild(container)
+    vi.restoreAllMocks()
+  })
+
+  it('is initially hidden', () => {
+    act(() => {
+      root?.render(<BackToTop />)
+    })
+
+    const button = container.querySelector('button')
+    expect(button).toBeNull()
+  })
+
+  it('becomes visible after scrolling', () => {
+    act(() => {
+      root?.render(<BackToTop />)
+    })
+
+    // Simulate scroll
+    act(() => {
+        (window as any).scrollY = 500
+        window.dispatchEvent(new Event('scroll'))
+    })
+
+    // We might need to wait for re-render
+    const button = container.querySelector('button')
+    expect(button).toBeTruthy()
+    expect(button?.classList.contains('back-to-top')).toBe(true)
+  })
+
+  it('scrolls to top when clicked', () => {
+    act(() => {
+      root?.render(<BackToTop />)
+    })
+
+    // Scroll down to make it visible
+    act(() => {
+        (window as any).scrollY = 500
+        window.dispatchEvent(new Event('scroll'))
+    })
+
+    const button = container.querySelector('button')
+    expect(button).toBeTruthy()
+
+    act(() => {
+        button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' })
+  })
+})

--- a/src/components/__tests__/Breadcrumb.test.tsx
+++ b/src/components/__tests__/Breadcrumb.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { MemoryRouter } from 'react-router-dom'
+import Breadcrumb from '../Breadcrumb'
+
+describe('Breadcrumb', () => {
+  let container: HTMLDivElement
+  let root: ReturnType<typeof createRoot> | undefined
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount()
+    })
+    document.body.removeChild(container)
+  })
+
+  it('renders a list of items', () => {
+    const items = [
+      { label: 'Home', to: '/' },
+      { label: 'Phase 1', to: '/phase/1' },
+      { label: 'Current Page' },
+    ]
+
+    act(() => {
+      root?.render(
+        <MemoryRouter>
+          <Breadcrumb items={items} />
+        </MemoryRouter>
+      )
+    })
+
+    const listItems = container.querySelectorAll('li.breadcrumb-item')
+    expect(listItems.length).toBe(3)
+
+    expect(listItems[0].textContent).toContain('Home')
+    expect(listItems[1].textContent).toContain('Phase 1')
+    expect(listItems[2].textContent).toContain('Current Page')
+  })
+
+  it('renders links for items with "to" prop', () => {
+    const items = [{ label: 'Home', to: '/' }]
+
+    act(() => {
+      root?.render(
+        <MemoryRouter>
+          <Breadcrumb items={items} />
+        </MemoryRouter>
+      )
+    })
+
+    const link = container.querySelector('a')
+    expect(link).toBeTruthy()
+    expect(link?.getAttribute('href')).toBe('/')
+  })
+
+  it('renders text for items without "to" prop', () => {
+    const items = [{ label: 'Current Page' }]
+
+    act(() => {
+      root?.render(
+        <MemoryRouter>
+          <Breadcrumb items={items} />
+        </MemoryRouter>
+      )
+    })
+
+    const link = container.querySelector('a')
+    expect(link).toBeNull()
+    const span = container.querySelector('span[aria-current="page"]')
+    expect(span).toBeTruthy()
+    expect(span?.textContent).toBe('Current Page')
+  })
+
+  it('renders separators between items', () => {
+    const items = [
+      { label: 'Home', to: '/' },
+      { label: 'Page' },
+    ]
+
+    act(() => {
+      root?.render(
+        <MemoryRouter>
+          <Breadcrumb items={items} />
+        </MemoryRouter>
+      )
+    })
+
+    const separators = container.querySelectorAll('.sep')
+    expect(separators.length).toBe(1)
+    expect(separators[0].textContent).toBe('/')
+  })
+})

--- a/src/components/__tests__/Breadcrumb.test.tsx
+++ b/src/components/__tests__/Breadcrumb.test.tsx
@@ -39,9 +39,9 @@ describe('Breadcrumb', () => {
     const listItems = container.querySelectorAll('li.breadcrumb-item')
     expect(listItems.length).toBe(3)
 
-    expect(listItems[0].textContent).toContain('Home')
-    expect(listItems[1].textContent).toContain('Phase 1')
-    expect(listItems[2].textContent).toContain('Current Page')
+    expect(listItems[0]?.textContent).toContain('Home')
+    expect(listItems[1]?.textContent).toContain('Phase 1')
+    expect(listItems[2]?.textContent).toContain('Current Page')
   })
 
   it('renders links for items with "to" prop', () => {
@@ -94,6 +94,6 @@ describe('Breadcrumb', () => {
 
     const separators = container.querySelectorAll('.sep')
     expect(separators.length).toBe(1)
-    expect(separators[0].textContent).toBe('/')
+    expect(separators[0]?.textContent).toBe('/')
   })
 })

--- a/src/components/__tests__/CopyButton.test.tsx
+++ b/src/components/__tests__/CopyButton.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import CopyButton from '../CopyButton'
+
+describe('CopyButton', () => {
+  let container: HTMLDivElement
+  let root: ReturnType<typeof createRoot> | undefined
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    vi.useFakeTimers()
+
+    // Mock navigator.clipboard
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+  })
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount()
+    })
+    document.body.removeChild(container)
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('renders correctly', () => {
+    act(() => {
+      root?.render(<CopyButton text="some code" />)
+    })
+
+    const button = container.querySelector('button')
+    expect(button).toBeTruthy()
+    expect(button?.textContent).toContain('Copy')
+  })
+
+  it('copies text to clipboard on click', async () => {
+    act(() => {
+      root?.render(<CopyButton text="some code" />)
+    })
+
+    const button = container.querySelector('button')
+
+    await act(async () => {
+        button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('some code')
+  })
+
+  it('shows feedback after copying', async () => {
+    act(() => {
+      root?.render(<CopyButton text="some code" />)
+    })
+
+    const button = container.querySelector('button')
+
+    await act(async () => {
+        button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(button?.textContent).toContain('✓ Copied')
+
+    // Check timeout resets state
+    act(() => {
+        vi.advanceTimersByTime(2000)
+    })
+
+    expect(button?.textContent).toContain('Copy')
+  })
+
+  it('clears timeout on unmount', async () => {
+      act(() => {
+      root?.render(<CopyButton text="some code" />)
+    })
+
+    const button = container.querySelector('button')
+
+    await act(async () => {
+        button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(button?.textContent).toContain('✓ Copied')
+
+    // Unmount before timeout finishes
+    act(() => {
+        root?.unmount()
+        root = undefined // Prevent double unmount in afterEach
+    })
+
+    // Ensure no errors or state updates on unmounted component
+    act(() => {
+        vi.advanceTimersByTime(2000)
+    })
+  })
+
+  it('handles multiple clicks by clearing previous timeout', async () => {
+    act(() => {
+      root?.render(<CopyButton text="some code" />)
+    })
+
+    const button = container.querySelector('button')
+
+    // First click
+    await act(async () => {
+        button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(button?.textContent).toContain('✓ Copied')
+
+    // Advance time slightly
+    act(() => {
+        vi.advanceTimersByTime(1000)
+    })
+
+    // Second click
+    await act(async () => {
+        button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    // Should still be copied
+    expect(button?.textContent).toContain('✓ Copied')
+
+    // Advance 1500ms (total 2500ms from start, but only 1500ms from second click)
+    act(() => {
+        vi.advanceTimersByTime(1500)
+    })
+
+    // Should NOT have reset yet because timeout was reset
+    expect(button?.textContent).toContain('✓ Copied')
+
+    // Advance remaining 500ms
+    act(() => {
+        vi.advanceTimersByTime(500)
+    })
+
+    expect(button?.textContent).toContain('Copy')
+  })
+
+  it('logs error when copy fails', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(navigator.clipboard.writeText).mockRejectedValueOnce(new Error('Copy failed'))
+
+    act(() => {
+      root?.render(<CopyButton text="some code" />)
+    })
+
+    const button = container.querySelector('button')
+
+    await act(async () => {
+        button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to copy text to clipboard', expect.any(Error))
+    consoleSpy.mockRestore()
+  })
+})

--- a/src/components/__tests__/ReadingTime.test.tsx
+++ b/src/components/__tests__/ReadingTime.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import ReadingTime from '../ReadingTime'
+import { getReadingTime } from '../../utils/contentLoader'
+
+// Mock the utility
+vi.mock('../../utils/contentLoader', () => ({
+  getReadingTime: vi.fn(),
+}))
+
+describe('ReadingTime', () => {
+  let container: HTMLDivElement
+  let root: ReturnType<typeof createRoot> | undefined
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount()
+    })
+    document.body.removeChild(container)
+    vi.clearAllMocks()
+  })
+
+  it('renders correctly with 1 minute', () => {
+    vi.mocked(getReadingTime).mockReturnValue(1)
+
+    act(() => {
+      root?.render(<ReadingTime content="some short content" />)
+    })
+
+    expect(getReadingTime).toHaveBeenCalledWith('some short content')
+    const span = container.querySelector('.reading-time')
+    expect(span).toBeTruthy()
+    expect(span?.textContent).toContain('1 min read')
+    expect(span?.getAttribute('title')).toContain('1 minute')
+  })
+
+  it('renders correctly with multiple minutes', () => {
+    vi.mocked(getReadingTime).mockReturnValue(5)
+
+    act(() => {
+      root?.render(<ReadingTime content="some long content" />)
+    })
+
+    expect(container.textContent).toContain('5 min read')
+    const span = container.querySelector('.reading-time')
+    expect(span?.getAttribute('title')).toContain('5 minutes')
+  })
+})

--- a/src/hooks/__tests__/useDebounce.test.tsx
+++ b/src/hooks/__tests__/useDebounce.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { useDebounce } from '../useDebounce'
+
+describe('useDebounce', () => {
+  let container: HTMLDivElement
+  let root: ReturnType<typeof createRoot> | undefined
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount()
+    })
+    document.body.removeChild(container)
+    vi.useRealTimers()
+  })
+
+  it('should return initial value immediately', () => {
+    let debouncedValue: string | undefined
+
+    function TestComponent({ value, delay }: { value: string; delay: number }) {
+      debouncedValue = useDebounce(value, delay)
+      return null
+    }
+
+    act(() => {
+      root?.render(<TestComponent value="test" delay={500} />)
+    })
+
+    expect(debouncedValue).toBe('test')
+  })
+
+  it('should debounce value updates', () => {
+    let debouncedValue: string | undefined
+
+    function TestComponent({ value, delay }: { value: string; delay: number }) {
+      debouncedValue = useDebounce(value, delay)
+      return null
+    }
+
+    // Initial render
+    act(() => {
+      root?.render(<TestComponent value="initial" delay={500} />)
+    })
+    expect(debouncedValue).toBe('initial')
+
+    // Update value
+    act(() => {
+      root?.render(<TestComponent value="updated" delay={500} />)
+    })
+    // Should still be initial
+    expect(debouncedValue).toBe('initial')
+
+    // Advance timers partly
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    expect(debouncedValue).toBe('initial')
+
+    // Advance timers to complete delay
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+    expect(debouncedValue).toBe('updated')
+  })
+
+  it('should reset immediately if condition is met', () => {
+    let debouncedValue: string | undefined
+
+    function TestComponent({ value, delay }: { value: string; delay: number }) {
+      debouncedValue = useDebounce(value, delay, (val) => val === '')
+      return null
+    }
+
+    // Initial render
+    act(() => {
+      root?.render(<TestComponent value="initial" delay={500} />)
+    })
+    expect(debouncedValue).toBe('initial')
+
+    // Update to empty string (should reset immediately)
+    act(() => {
+      root?.render(<TestComponent value="" delay={500} />)
+    })
+
+    // Since delay is 0, we still need to advance timers to let the loop run
+    act(() => {
+        vi.runAllTimers()
+    })
+    expect(debouncedValue).toBe('')
+  })
+
+  it('should cancel previous timeout on new update', () => {
+     let debouncedValue: string | undefined
+
+    function TestComponent({ value, delay }: { value: string; delay: number }) {
+      debouncedValue = useDebounce(value, delay)
+      return null
+    }
+
+    // Initial render
+    act(() => {
+      root?.render(<TestComponent value="initial" delay={500} />)
+    })
+
+    // Update to 'update1'
+    act(() => {
+      root?.render(<TestComponent value="update1" delay={500} />)
+    })
+
+    // Advance 200ms
+    act(() => {
+        vi.advanceTimersByTime(200)
+    })
+
+    // Update to 'update2' before 'update1' resolves
+    act(() => {
+      root?.render(<TestComponent value="update2" delay={500} />)
+    })
+
+    // Advance another 300ms (total 500ms since start, but only 300ms since update2)
+    act(() => {
+        vi.advanceTimersByTime(300)
+    })
+
+    // Should NOT be update1
+    expect(debouncedValue).toBe('initial') // Still initial because update2 reset the timer
+
+    // Advance another 200ms (total 500ms since update2)
+    act(() => {
+        vi.advanceTimersByTime(200)
+    })
+
+    expect(debouncedValue).toBe('update2')
+  })
+})


### PR DESCRIPTION
Added unit tests for `useDebounce`, `CopyButton`, `Breadcrumb`, `BackToTop`, and `ReadingTime` to increase code coverage. All new tests pass and adhere to the project's testing conventions (using `vitest` and `react-dom/client`). verified via `npm test` and `npm run test:coverage`.

---
*PR created automatically by Jules for task [5337032951530015974](https://jules.google.com/task/5337032951530015974) started by @saint2706*