### PR TITLE
Fix Dependabot on-demand workflow dispatch input handling

### DIFF
--- a/.github/workflows/dependabot-on-demand.yml
+++ b/.github/workflows/dependabot-on-demand.yml
@@ -34,19 +34,26 @@ jobs:
         with:
           github-token: ${{ env.DEPENDABOT_TOKEN != '' && env.DEPENDABOT_TOKEN || github.token }}
           script: |
+            const inputs = context.payload.inputs ?? {};
+            const isTrue = (value, fallback = false) => {
+              if (value === undefined) return fallback;
+              return String(value).toLowerCase() === 'true';
+            };
+            const valueOrDefault = (value, fallback) => value ?? fallback;
+
             const updates = [];
 
-            if (core.getInput('run_npm') === 'true') {
+            if (isTrue(inputs.run_npm, true)) {
               updates.push({
                 package_ecosystem: 'npm',
-                directory: core.getInput('npm_directory'),
+                directory: valueOrDefault(inputs.npm_directory, '/'),
               });
             }
 
-            if (core.getInput('run_github_actions') === 'true') {
+            if (isTrue(inputs.run_github_actions, true)) {
               updates.push({
                 package_ecosystem: 'github-actions',
-                directory: core.getInput('github_actions_directory'),
+                directory: valueOrDefault(inputs.github_actions_directory, '/'),
               });
             }
 


### PR DESCRIPTION
### Motivation
- The `dependabot-on-demand` workflow was not correctly reading `workflow_dispatch` inputs inside the `actions/github-script` step, causing user-selected ecosystems to be ignored. 
- Ensure manual runs can enable npm and GitHub Actions updates and accept optional directory inputs with sensible defaults.

### Description
- Read dispatch inputs from `context.payload.inputs` inside the `actions/github-script` script instead of using `core.getInput` which does not surface `workflow_dispatch` values in this context. 
- Added helper `isTrue` to normalize boolean-like input strings and `valueOrDefault` to apply safe defaults for directory inputs. 
- Kept existing behavior that fails when no ecosystems are selected and preserved the Dependabot API request loop that triggers updates per selected ecosystem.

### Testing
- Inspected the workflow file diff and confirmed the payload-based input usage and helper functions exist in `.github/workflows/dependabot-on-demand.yml` (reviewed via `git diff -- .github/workflows/dependabot-on-demand.yml`).
- Attempted to parse the YAML with `python` + `PyYAML`, which failed due to `PyYAML` not being installed in the environment. 
- Created PR metadata via repository tooling and verified the modified workflow file is ready for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fd584684c83308d579da6c1857578)