### PR TITLE
Fix Dependabot on-demand workflow 404 handling and token permissions

### DIFF
--- a/.github/workflows/dependabot-on-demand.yml
+++ b/.github/workflows/dependabot-on-demand.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   trigger-dependabot:
@@ -64,12 +65,27 @@ jobs:
 
             for (const update of updates) {
               core.info(`Triggering Dependabot update for ${update.package_ecosystem} at ${update.directory}`);
-              await github.request('POST /repos/{owner}/{repo}/dependabot/updates', {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                package_ecosystem: update.package_ecosystem,
-                directory: update.directory,
-              });
+              try {
+                await github.request('POST /repos/{owner}/{repo}/dependabot/updates', {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  package_ecosystem: update.package_ecosystem,
+                  directory: update.directory,
+                  headers: {
+                    'X-GitHub-Api-Version': '2022-11-28',
+                  },
+                });
+              } catch (error) {
+                if (error.status === 404) {
+                  core.setFailed(
+                    `Dependabot update trigger endpoint returned 404 for ${update.package_ecosystem} at ${update.directory}. ` +
+                    'Verify Dependabot is enabled and that DEPENDABOT_TRIGGER_TOKEN (or GITHUB_TOKEN fallback) has Dependabot/security-events write access.'
+                  );
+                  return;
+                }
+
+                throw error;
+              }
             }
 
             core.info(`Triggered ${updates.length} Dependabot update request(s).`);


### PR DESCRIPTION
### Motivation

- Dependabot on-demand triggers were returning `404` when called from the workflow and surfaced an unhandled stack trace instead of a clear actionable message. 
- The workflow needed the proper permission scope so the `GITHUB_TOKEN` fallback (when `DEPENDABOT_TRIGGER_TOKEN` is not provided) can call the Dependabot updates API.

### Description

- Grant `security-events: write` permission in the workflow by adding `security-events: write` under `permissions` so token fallback has Dependabot access.
- Wrap the `github.request('POST /repos/{owner}/{repo}/dependabot/updates', ...)` call in a `try/catch` and surface a clear failure via `core.setFailed` when the API returns `404` with guidance about Dependabot and token permissions.
- Add an explicit `X-GitHub-Api-Version: '2022-11-28'` header to the API request for compatibility/stability.
- Preserve existing behavior by re-throwing non-404 errors after the catch so unexpected failures still surface.

### Testing

- Parsed `.github/workflows/dependabot-on-demand.yml` with Ruby's YAML loader using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/dependabot-on-demand.yml'); puts 'ok'"`, which succeeded.
- Attempted to parse the workflow with Python's `PyYAML` in `python - <<'PY' ...`, which failed because `PyYAML` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fd64a6dbc8330b4e9354457f587b6)