### PR TITLE
Document Dependabot manual-trigger limitation and replace unsupported on-demand trigger with explanatory warning

### DIFF
--- a/.github/workflows/dependabot-on-demand.yml
+++ b/.github/workflows/dependabot-on-demand.yml
@@ -2,74 +2,29 @@ name: Dependabot On-Demand
 
 on:
   workflow_dispatch:
-    inputs:
-      run_npm:
-        description: Trigger npm ecosystem updates
-        type: boolean
-        default: true
-      npm_directory:
-        description: npm directory to update
-        type: string
-        default: "/"
-      run_github_actions:
-        description: Trigger GitHub Actions ecosystem updates
-        type: boolean
-        default: true
-      github_actions_directory:
-        description: GitHub Actions directory to update
-        type: string
-        default: "/"
 
 permissions:
   contents: read
 
 jobs:
-  trigger-dependabot:
+  explain-manual-trigger-support:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Dependabot updates
+      - name: Explain Dependabot manual trigger limitations
         uses: actions/github-script@v8
-        env:
-          DEPENDABOT_TOKEN: ${{ secrets.DEPENDABOT_TRIGGER_TOKEN }}
         with:
-          github-token: ${{ env.DEPENDABOT_TOKEN != '' && env.DEPENDABOT_TOKEN || github.token }}
           script: |
-            const inputs = context.payload.inputs ?? {};
-            const isTrue = (value, fallback = false) => {
-              if (value === undefined) return fallback;
-              return String(value).toLowerCase() === 'true';
-            };
-            const valueOrDefault = (value, fallback) => value ?? fallback;
+            const message = [
+              'Dependabot version updates cannot currently be triggered via public GitHub REST/GraphQL APIs from Actions workflows.',
+              'The previously used endpoint `POST /repos/{owner}/{repo}/dependabot/updates` is not publicly available and returns 404 on GitHub.com repos.',
+              '',
+              'How to run updates now:',
+              '1) Use the normal schedule configured in `.github/dependabot.yml`.',
+              '2) In the GitHub UI, open **Insights → Dependency graph → Dependabot** and use **Check for updates**.',
+              '3) If urgent, push a commit changing dependencies; Dependabot will evaluate on its next run.',
+            ].join('\n');
 
-            const updates = [];
-
-            if (isTrue(inputs.run_npm, true)) {
-              updates.push({
-                package_ecosystem: 'npm',
-                directory: valueOrDefault(inputs.npm_directory, '/'),
-              });
-            }
-
-            if (isTrue(inputs.run_github_actions, true)) {
-              updates.push({
-                package_ecosystem: 'github-actions',
-                directory: valueOrDefault(inputs.github_actions_directory, '/'),
-              });
-            }
-
-            if (updates.length === 0) {
-              core.setFailed('No ecosystems selected. Enable at least one ecosystem input.');
-              return;
-            }
-
-            for (const update of updates) {
-              core.info(`Triggering Dependabot update for ${update.package_ecosystem} at ${update.directory}`);
-              await github.request('POST /repos/{owner}/{repo}/dependabot/updates', {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                package_ecosystem: update.package_ecosystem,
-                directory: update.directory,
-              });
-            }
-
-            core.info(`Triggered ${updates.length} Dependabot update request(s).`);
+            core.warning(message);
+            core.setFailed(
+              'Manual Dependabot trigger via workflow is not supported by public GitHub APIs. See logs for supported alternatives.'
+            );

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ For more details, please see:
 ## 🤖 Dependabot Updates
 
 - **Automatic schedule:** Dependabot checks both `npm` and `github-actions` every **Thursday at 1:00 PM IST** via `.github/dependabot.yml`.
-- **Manual on-demand run:** Maintainers can trigger **Actions → "Dependabot On-Demand" → Run workflow** and choose which ecosystem/directory to update.
-- **Required permissions/token:** Configure a repository secret named `DEPENDABOT_TRIGGER_TOKEN` with scopes/permissions that allow Dependabot update triggers (for example, a fine-grained PAT with Dependabot write access to this repo). Without this secret, the workflow falls back to `GITHUB_TOKEN`, which may not have sufficient privileges depending on repository settings.
+- **Manual on-demand run:** GitHub does not currently provide a public API to trigger Dependabot version updates from a workflow. The `Dependabot On-Demand` workflow documents this limitation and points maintainers to supported alternatives.
+- **Manual alternatives:** Use the GitHub UI **Insights → Dependency graph → Dependabot → Check for updates**, or rely on the weekly schedule in `.github/dependabot.yml`.
 
 ## 🧪 Visual Snapshot Testing
 


### PR DESCRIPTION
### Motivation
- The previous on-demand workflow attempted to call the private `POST /repos/{owner}/{repo}/dependabot/updates` endpoint to trigger version updates, which is not available via public GitHub APIs and can return 404 on GitHub.com repositories.
- Prevent maintainers from relying on a workflow that silently fails or requires an unsupported token by surfacing the limitation and describing supported alternatives in-code and in documentation.

### Description
- Replaced the `trigger-dependabot` job in `.github/workflows/dependabot-on-demand.yml` with `explain-manual-trigger-support` that emits a clear warning and fails with a message explaining the API limitation instead of attempting API calls.
- Removed workflow inputs and all code that attempted to POST Dependabot update requests and removed usage of a `DEPENDABOT_TRIGGER_TOKEN` in the workflow.
- Updated `README.md` Dependabot section to remove instructions about configuring a `DEPENDABOT_TRIGGER_TOKEN` and to document supported alternatives (weekly schedule and the UI "Check for updates" flow).

### Testing
- No automated tests were run for this change since it is a docs/workflow behavior update and does not modify production code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fd64a6dbc8330b4e9354457f587b6)