### PR TITLE
Fix React DOM warnings in motion component tests

### DIFF
--- a/src/components/__tests__/ExerciseCard.test.tsx
+++ b/src/components/__tests__/ExerciseCard.test.tsx
@@ -7,11 +7,25 @@ import ExerciseCard from '../ExerciseCard'
 // Mock motion to avoid animation issues
 vi.mock('motion/react', () => ({
   motion: {
-    div: ({ children, className, ...props }: any) => (
-      <div className={className} {...props}>
-        {children}
-      </div>
-    ),
+    div: ({ children, className, ...props }: any) => {
+      const {
+        layout: _layout,
+        whileHover: _whileHover,
+        whileTap: _whileTap,
+        transition: _transition,
+        ...safeProps
+      } = props
+      void _layout
+      void _whileHover
+      void _whileTap
+      void _transition
+
+      return (
+        <div className={className} {...safeProps}>
+          {children}
+        </div>
+      )
+    },
   },
 }))
 

--- a/src/components/__tests__/ProgressBar.test.tsx
+++ b/src/components/__tests__/ProgressBar.test.tsx
@@ -6,11 +6,23 @@ import ProgressBar from '../ProgressBar'
 // Mock motion to avoid animation issues in tests
 vi.mock('motion/react', () => ({
   motion: {
-    div: ({ children, className, ...props }: any) => (
-      <div className={className} {...props}>
-        {children}
-      </div>
-    ),
+    div: ({ children, className, ...props }: any) => {
+      const {
+        initial: _initial,
+        animate: _animate,
+        transition: _transition,
+        ...safeProps
+      } = props
+      void _initial
+      void _animate
+      void _transition
+
+      return (
+        <div className={className} {...safeProps}>
+          {children}
+        </div>
+      )
+    },
   },
   useReducedMotion: () => false,
 }))


### PR DESCRIPTION
### Motivation
- Remove noisy React warnings in CI caused by animation-only props (e.g. `layout`, `initial`) being forwarded to native DOM elements from mocked `motion` components.
- Ensure the test suite and TypeScript checks run cleanly without spurious warnings that can mask real CI issues.

### Description
- Updated `motion/react` mocks in `src/components/__tests__/ExerciseCard.test.tsx` to strip animation props (`layout`, `whileHover`, `whileTap`, `transition`) before spreading props onto a native `<div>`.
- Updated `motion/react` mocks in `src/components/__tests__/ProgressBar.test.tsx` to strip animation props (`initial`, `animate`, `transition`) before forwarding DOM props to `<div>`.
- These changes prevent non-boolean/unknown attribute warnings from appearing in test output.

### Testing
- Ran `npm run typecheck` which completed successfully and reported no TypeScript errors.
- Ran the modified tests with `npm run test -- src/components/__tests__/ExerciseCard.test.tsx src/components/__tests__/ProgressBar.test.tsx` and both test files passed.
- Ran full CI-equivalent commands `npm run lint:ci && npm run validate-content && npm run test:coverage -- --reporter=default --coverage.reporter=text` and the test suite completed successfully (`284 tests passed`) and content validation passed (`152/152`).
- Noted an environment-level `npm` warning `Unknown env config "http-proxy"` during runs which is external to the repository code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1de52c02c8330ab508ef19fe4c49b)