### PR TITLE
docs: Clean up broken links and add missing JSDoc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,5 @@ We use **Vitest** for unit testing and **Playwright** for end-to-end testing.
 - **User Documentation**: Located in `README.md`.
 - **Architecture**: See `docs/ARCHITECTURE.md`.
 - **Roadmap**: See `docs/todo.md`.
-- **Content Strategy**: See `docs/content-expansion.md`.
 
 Thank you for contributing!

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ For more details, please see:
 - **[Contributing Guide](CONTRIBUTING.md)**: How to set up and contribute.
 - **[Architecture](docs/ARCHITECTURE.md)**: Technical overview of the project.
 - **[Roadmap](docs/todo.md)**: Upcoming features and improvements.
-- **[Content Strategy](docs/content-expansion.md)**: Plan for curriculum expansion.
 
 ## 🤖 Dependabot Updates
 

--- a/src/utils/dayToken-core.d.ts
+++ b/src/utils/dayToken-core.d.ts
@@ -1,9 +1,65 @@
+/**
+ * Normalizes a raw day token input into a standard format.
+ * Strips whitespace, forces uppercase suffix, and defaults numeric part to '0'.
+ *
+ * @param value - The raw day token input (string or number).
+ * @returns The normalized day token (e.g., "1", "36B").
+ */
 export function normalizeDayToken(value: any): string
+
+/**
+ * Parses a day token into its constituent numeric and suffix parts.
+ * Uses a module-level Map cache to avoid redundant regex operations.
+ *
+ * @param value - The raw day token input.
+ * @returns The parsed token object, or null if invalid.
+ */
 export function parseDayToken(
   value: any,
 ): { token: string; number: number; suffix: string; sortKey: string } | null
+
+/**
+ * Compares two day tokens for sorting purposes.
+ * Sorts primarily by day number, then by suffix alphabetically.
+ *
+ * @param a - The first day token.
+ * @param b - The second day token.
+ * @returns A negative number if a < b, positive if a > b, or 0 if equal.
+ */
 export function compareDayTokens(a: any, b: any): number
+
+/**
+ * Extracts a normalized day token from a given file path.
+ * Looks for the parent directory name matching the pattern "Day_X".
+ *
+ * @param path - The file path (e.g., "content/lessons/Phase_1/Day_1/lesson.md").
+ * @returns The normalized day token, or null if not found.
+ */
 export function dayTokenFromPath(path: any): string | null
+
+/**
+ * Safely extracts and normalizes a day token from a string or number value.
+ * Useful for extracting tokens from markdown frontmatter.
+ *
+ * @param value - The value to extract from.
+ * @returns The normalized day token, or null if invalid.
+ */
 export function extractDayToken(value: any): string | null
+
+/**
+ * Extracts a normalized day token from a cross-reference string.
+ * Handles explicit tokens (e.g., "36B") or prefixed references (e.g., "Day 36B").
+ *
+ * @param value - The reference string or number.
+ * @returns The normalized day token, or null if not found.
+ */
 export function dayTokenFromReference(value: any): string | null
+
+/**
+ * Converts a day token into a unique numeric progress ID.
+ * Numeric parts are multiplied by 10000; alphabetic suffixes are converted to a numeric offset.
+ *
+ * @param value - The day token input.
+ * @returns The numeric progress ID, or NaN if invalid.
+ */
 export function dayTokenToProgressId(value: any): number

--- a/src/utils/dayToken-core.js
+++ b/src/utils/dayToken-core.js
@@ -3,6 +3,13 @@ const DAY_TOKEN_PATTERN = /^(\d+)([A-Za-z]*)$/
 const parseCache = new Map()
 const progressIdCache = new Map()
 
+/**
+ * Normalizes a raw day token input into a standard format.
+ * Strips whitespace, forces uppercase suffix, and defaults numeric part to '0'.
+ *
+ * @param {any} value - The raw day token input (string or number).
+ * @returns {string} The normalized day token (e.g., "1", "36B").
+ */
 export function normalizeDayToken(value) {
   const raw = String(value ?? '').trim()
   const match = raw.match(DAY_TOKEN_PATTERN)
@@ -15,6 +22,13 @@ export function normalizeDayToken(value) {
   return `${dayNumber}${suffix}`
 }
 
+/**
+ * Parses a day token into its constituent numeric and suffix parts.
+ * Uses a module-level Map cache to avoid redundant regex operations.
+ *
+ * @param {any} value - The raw day token input.
+ * @returns {{ token: string, number: number, suffix: string, sortKey: string } | null} The parsed token object, or null if invalid.
+ */
 export function parseDayToken(value) {
   const token = normalizeDayToken(value)
   if (parseCache.has(token)) {
@@ -40,6 +54,14 @@ export function parseDayToken(value) {
   return result
 }
 
+/**
+ * Compares two day tokens for sorting purposes.
+ * Sorts primarily by day number, then by suffix alphabetically.
+ *
+ * @param {any} a - The first day token.
+ * @param {any} b - The second day token.
+ * @returns {number} A negative number if a < b, positive if a > b, or 0 if equal.
+ */
 export function compareDayTokens(a, b) {
   const aa = parseDayToken(a)
   const bb = parseDayToken(b)
@@ -54,6 +76,13 @@ export function compareDayTokens(a, b) {
   return aa.suffix < bb.suffix ? -1 : 1
 }
 
+/**
+ * Extracts a normalized day token from a given file path.
+ * Looks for the parent directory name matching the pattern "Day_X".
+ *
+ * @param {string} path - The file path (e.g., "content/lessons/Phase_1/Day_1/lesson.md").
+ * @returns {string | null} The normalized day token, or null if not found.
+ */
 export function dayTokenFromPath(path) {
   const segments = String(path).split(/[\\/]/)
   const lessonDir = segments[segments.length - 2] || ''
@@ -61,12 +90,26 @@ export function dayTokenFromPath(path) {
   return match && match[1] ? normalizeDayToken(match[1]) : null
 }
 
+/**
+ * Safely extracts and normalizes a day token from a string or number value.
+ * Useful for extracting tokens from markdown frontmatter.
+ *
+ * @param {any} value - The value to extract from.
+ * @returns {string | null} The normalized day token, or null if invalid.
+ */
 export function extractDayToken(value) {
   if (typeof value !== 'string' && typeof value !== 'number') return null
   const parsed = parseDayToken(value)
   return parsed ? parsed.token : null
 }
 
+/**
+ * Extracts a normalized day token from a cross-reference string.
+ * Handles explicit tokens (e.g., "36B") or prefixed references (e.g., "Day 36B").
+ *
+ * @param {any} value - The reference string or number.
+ * @returns {string | null} The normalized day token, or null if not found.
+ */
 export function dayTokenFromReference(value) {
   if (typeof value === 'number' || typeof value === 'string') {
     const raw = String(value).trim()
@@ -78,6 +121,13 @@ export function dayTokenFromReference(value) {
   return null
 }
 
+/**
+ * Converts a day token into a unique numeric progress ID.
+ * Numeric parts are multiplied by 10000; alphabetic suffixes are converted to a numeric offset.
+ *
+ * @param {any} value - The day token input.
+ * @returns {number} The numeric progress ID, or NaN if invalid.
+ */
 export function dayTokenToProgressId(value) {
   const normalizedKey = String(value)
   if (progressIdCache.has(normalizedKey)) {

--- a/src/utils/exercise-extractor-core.d.ts
+++ b/src/utils/exercise-extractor-core.d.ts
@@ -6,4 +6,11 @@ export interface ExtractedExercise {
   tags: string[]
 }
 
+/**
+ * Parses markdown content to extract exercise definitions.
+ * The caller is responsible for adding lesson metadata (day, phase, difficulty, lessonTitle).
+ *
+ * @param content - The markdown content to parse.
+ * @returns An array of partial exercise objects.
+ */
 export function extractExercisesFromContent(content: string): ExtractedExercise[]

--- a/src/utils/exercise-extractor-core.js
+++ b/src/utils/exercise-extractor-core.js
@@ -1,13 +1,9 @@
 /**
  * Parses markdown content to extract exercise definitions.
- * Returns an array of partial exercise objects containing:
- * - title
- * - goal
- * - starterCode
- * - expectedOutput
- * - tags (empty array)
- *
  * The caller is responsible for adding lesson metadata (day, phase, difficulty, lessonTitle).
+ *
+ * @param {string} content - The markdown content to parse.
+ * @returns {Array<{ title: string, goal: string, starterCode: string, expectedOutput: string | undefined, tags: string[] }>} An array of partial exercise objects.
  */
 export function extractExercisesFromContent(content) {
   const exercises = []

--- a/src/utils/frontmatter-core.d.ts
+++ b/src/utils/frontmatter-core.d.ts
@@ -7,6 +7,30 @@ export interface ParsedMarkdown {
   content: string
 }
 
+/**
+ * Normalizes line endings in a markdown string to Unix style (LF).
+ * This ensures consistent processing regardless of the OS (Windows CRLF vs Unix LF).
+ *
+ * @param raw - The raw markdown content.
+ * @returns The markdown content with all line endings converted to `\n`.
+ */
 export function normalizeMarkdownLineEndings(raw: string): string
+
+/**
+ * Parses frontmatter from a normalized markdown string.
+ * Supports basic YAML-like syntax including scalars, arrays, and inline arrays.
+ * Blocks unsafe keys like `__proto__`.
+ *
+ * @param normalized - The markdown content with normalized line endings.
+ * @returns An object containing the parsed frontmatter fields and the remaining markdown content.
+ */
 export function parseNormalizedMarkdown(normalized: string): ParsedMarkdown
+
+/**
+ * Parses markdown frontmatter and content from a raw markdown string.
+ * Normalizes line endings internally before parsing.
+ *
+ * @param raw - The raw markdown content.
+ * @returns An object containing the parsed frontmatter fields and the remaining markdown content.
+ */
 export function parseMarkdown(raw: string): ParsedMarkdown

--- a/src/utils/frontmatter-core.js
+++ b/src/utils/frontmatter-core.js
@@ -108,6 +108,13 @@ export function parseNormalizedMarkdown(normalized) {
   return { frontmatter, content }
 }
 
+/**
+ * Parses markdown frontmatter and content from a raw markdown string.
+ * Normalizes line endings internally before parsing.
+ *
+ * @param {string} raw - The raw markdown content.
+ * @returns {{ frontmatter: Record<string, any>, content: string }} An object containing the parsed frontmatter fields and the remaining markdown content.
+ */
 export function parseMarkdown(raw) {
   return parseNormalizedMarkdown(normalizeMarkdownLineEndings(raw))
 }


### PR DESCRIPTION
Cleaned up documentation by removing broken links, and added missing JSDoc/TSDoc comments to exported core utility functions per project standards.

---
*PR created automatically by Jules for task [17137395120632574834](https://jules.google.com/task/17137395120632574834) started by @saint2706*