### PR TITLE
🎨 Picasso: Add button types and aria labels

### DIFF
--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -40,6 +40,7 @@ export default function BackToTop() {
     <AnimatePresence>
       {visible && (
         <motion.button
+          type="button"
           className="back-to-top visible"
           onClick={scrollToTop}
           aria-label="Back to top"

--- a/src/components/CodePlayground.tsx
+++ b/src/components/CodePlayground.tsx
@@ -225,8 +225,9 @@ const CodePlayground = forwardRef<CodePlaygroundHandle, CodePlaygroundProps>(
         <div className="code-playground__toolbar">
           <span className="code-playground__label">🐍 Python Playground</span>
           <div className="code-playground__actions">
-            <CopyButton text={code} className="code-playground__btn" showEmoji={true} />
+            <CopyButton text={code} className="code-playground__btn" showEmoji={true} ariaLabel="Copy code" />
             <button
+              type="button"
               className={`code-playground__btn code-playground__btn--reset ${isConfirmingReset ? 'code-playground__btn--confirm' : ''}`}
               onClick={handleResetClick}
               aria-label={

--- a/src/components/ExerciseWidget.tsx
+++ b/src/components/ExerciseWidget.tsx
@@ -232,6 +232,7 @@ export default function ExerciseWidget({
       {solution && (
         <div className="exercise-widget__solution">
           <button
+            type="button"
             className="exercise-widget__solution-btn"
             onClick={handleToggleSolution}
             aria-expanded={showSolution}
@@ -273,6 +274,7 @@ export default function ExerciseWidget({
                       }}
                     >
                       <button
+                        type="button"
                         className={`code-block-copy ${isConfirmingSolution ? 'confirm-destructive' : ''}`}
                         onClick={handleTrySolution}
                         aria-label={

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -62,6 +62,7 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
         <div style={{ display: 'flex', gap: '0.4rem', alignItems: 'center' }}>
           {isPython && (
             <button
+              type="button"
               className="code-block-try-btn"
               onClick={() => setShowPlayground((p) => !p)}
               aria-label={showPlayground ? 'Close playground' : 'Try this code'}

--- a/src/components/MasteryCheck.tsx
+++ b/src/components/MasteryCheck.tsx
@@ -51,6 +51,7 @@ export default function MasteryCheck({
       )}
 
       <button
+        type="button"
         className={`mastery-check__check-btn ${revealed ? 'mastery-check__check-btn--revealed' : ''}`}
         onClick={() => setRevealed((r) => !r)}
         aria-expanded={revealed}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -80,6 +80,7 @@ export default function Navbar({ onToggleSidebar }: NavbarProps) {
     <nav className="navbar" role="navigation" aria-label="Main navigation">
       <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
         <button
+          type="button"
           className="navbar-hamburger"
           onClick={onToggleSidebar}
           aria-label="Toggle sidebar menu"
@@ -128,6 +129,7 @@ export default function Navbar({ onToggleSidebar }: NavbarProps) {
           )}
         </form>
         <button
+          type="button"
           className="theme-toggle"
           onClick={handleThemeToggle}
           aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}

--- a/src/components/PythonRunner.tsx
+++ b/src/components/PythonRunner.tsx
@@ -113,6 +113,7 @@ const PythonRunner = forwardRef<PythonRunnerHandle, PythonRunnerProps>(
       <div className={`python-runner ${compact ? 'python-runner--compact' : ''}`}>
         <div className="python-runner__controls">
           <button
+            type="button"
             className="python-runner__btn"
             onClick={handleRun}
             disabled={isLoading}
@@ -155,6 +156,7 @@ const PythonRunner = forwardRef<PythonRunnerHandle, PythonRunnerProps>(
 
           {running && (
             <button
+              type="button"
               className="python-runner__btn python-runner__btn--cancel"
               onClick={cancelRun}
               aria-label="Cancel current Python execution"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -114,7 +114,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
             Coding for MBA
             <small>108-Day Curriculum</small>
           </div>
-          <button className="sidebar-close" onClick={onClose} aria-label="Close sidebar">
+          <button type="button" className="sidebar-close" onClick={onClose} aria-label="Close sidebar">
             <svg
               width="20"
               height="20"

--- a/src/components/SidebarPhaseGroup.tsx
+++ b/src/components/SidebarPhaseGroup.tsx
@@ -39,6 +39,7 @@ function SidebarPhaseGroup({
   return (
     <div className="phase-group">
       <button
+        type="button"
         className={`phase-toggle ${isActive ? 'open active' : ''}`}
         onClick={() => onToggle(phase.phase)}
         aria-expanded={isActive}

--- a/src/pages/ConceptGraphPage.tsx
+++ b/src/pages/ConceptGraphPage.tsx
@@ -112,6 +112,7 @@ export default function ConceptGraphPage() {
         <div className="concept-graph-legend">
           {PHASE_NAMES.map((name, i) => (
             <button
+              type="button"
               key={i}
               className="legend-item"
               onClick={() => handlePhaseClick(i + 1)}

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -246,6 +246,7 @@ export default function Lesson() {
           </div>
 
           <button
+            type="button"
             className={`lesson-complete-btn ${completed ? 'completed' : ''}`}
             onClick={handleToggleComplete}
             aria-pressed={completed}

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -427,7 +427,7 @@ export default function ProgressDashboard() {
 
       {/* Clear progress */}
       <div style={{ marginTop: '3rem', textAlign: 'center' }}>
-        <button className="progress-clear-btn" onClick={handleClearProgress}>
+        <button type="button" className="progress-clear-btn" onClick={handleClearProgress}>
           Clear All Progress
         </button>
       </div>


### PR DESCRIPTION
Adds `type="button"` to all `<button>` elements to prevent unintended form submissions and resolve React ESLint warnings. Adds `aria-label` to icon-only `CopyButton` instances in the `CodePlayground` component to improve screen reader accessibility. Ensures a fully compliant, warning-free build.

---
*PR created automatically by Jules for task [12656129406158535876](https://jules.google.com/task/12656129406158535876) started by @saint2706*