### PR TITLE
fix: securely block Pyodide internal module imports

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -48,3 +48,8 @@
 ## 2025-06-12 - CSP Hardening
 **Vulnerability:** Missing `upgrade-insecure-requests` in Content Security Policy could allow mixed content issues if the site is served over HTTPS but requests HTTP resources.
 **Prevention:** Added `upgrade-insecure-requests` to the CSP meta tag to force all requests to HTTPS.
+
+## 2025-06-15 - Regex Bypass via Multiple Imports
+**Vulnerability:** The previous regex checks for internal module imports (like `\bimport\s+js\b`) could be bypassed by importing multiple modules in a single statement (e.g., `import math, js`), allowing dangerous module execution.
+**Learning:** Simple import regexes must account for comma-separated module lists and other valid Python import syntaxes.
+**Prevention:** Replaced literal regexes with a broader `\bimport\b[^;\n]*\b(js|pyodide|micropip)\b` and `\bfrom\b\s+(js|pyodide|micropip)\b` pattern to securely catch all occurrences of restricted modules in import statements.

--- a/src/utils/__tests__/codeSecurity.bypass.test.ts
+++ b/src/utils/__tests__/codeSecurity.bypass.test.ts
@@ -41,4 +41,41 @@ describe('validatePythonCode - Bypass Attempts', () => {
     expect(validatePythonCode('input = 1').valid).toBe(false)
     expect(validatePythonCode('def input(): pass').valid).toBe(false)
   })
+
+  it('should block import math, js', () => {
+    expect(validatePythonCode('import math, js').valid).toBe(false)
+  })
+
+  it('should block from builtins import *', () => {
+    expect(validatePythonCode('from builtins import *').valid).toBe(false)
+  })
+
+  it('should block import math, builtins', () => {
+    expect(validatePythonCode('import math, builtins').valid).toBe(false)
+  })
+
+  it('should block from js import eval', () => {
+    expect(validatePythonCode('from js import eval').valid).toBe(false)
+  })
+
+  it('should block import js.something', () => {
+    expect(validatePythonCode('import js.something').valid).toBe(false)
+  })
+
+  it('should block import js, math', () => {
+    expect(validatePythonCode('import js, math').valid).toBe(false)
+  })
+
+  it('should allow benign word that contains js', () => {
+    expect(validatePythonCode('import json').valid).toBe(true)
+    expect(validatePythonCode('from json import dumps').valid).toBe(true)
+  })
+
+  it('should allow variable named js if not imported', () => {
+    expect(validatePythonCode('js = 5').valid).toBe(true)
+  })
+
+  it('should not block from js import if js is a variable', () => {
+    expect(validatePythonCode('from some_module import json').valid).toBe(true)
+  })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -151,22 +151,25 @@ export function validatePythonCode(code: string): ValidationResult {
   }
 
   // 3. Import Deny Patterns (Specific module imports)
-  const importPatterns = [
-    /\bimport\s+js\b/,
-    /\bfrom\s+js\b/,
-    /\bimport\s+pyodide\b/,
-    /\bfrom\s+pyodide\b/,
-    /\bimport\s+micropip\b/,
-    /\bfrom\s+micropip\b/,
-  ]
+  // We need to catch these modules whether they are imported via 'import x', 'from x',
+  // or as part of a comma-separated list like 'import math, js'.
+  const dangerousModules = ['js', 'pyodide', 'micropip']
+  const dangerousModulesStr = dangerousModules.join('|')
 
-  for (const pattern of importPatterns) {
-    if (pattern.test(strippedCode)) {
-      return {
-        valid: false,
-        error:
-          'Security Error: Direct access to internal modules (js, pyodide, micropip) is restricted.',
-      }
+  // Pattern 1: `import ... module ...`
+  // Matches "import", then anything up to the module name, as long as it doesn't cross a newline or semicolon.
+  // We use `\b` to ensure we match the exact module name.
+  const importRegex = new RegExp(`\\bimport\\b[^;\\n]*\\b(${dangerousModulesStr})\\b`)
+
+  // Pattern 2: `from module ...`
+  // Matches "from", then the module name.
+  const fromRegex = new RegExp(`\\bfrom\\b\\s+(${dangerousModulesStr})\\b`)
+
+  if (importRegex.test(strippedCode) || fromRegex.test(strippedCode)) {
+    return {
+      valid: false,
+      error:
+        'Security Error: Direct access to internal modules (js, pyodide, micropip) is restricted.',
     }
   }
 


### PR DESCRIPTION
Fixes an issue where `import js` could be bypassed by formatting the code as `import math, js`. The regex in `validatePythonCode` was updated to securely block these modules across all valid Python import syntaxes.

---
*PR created automatically by Jules for task [12725188710811152772](https://jules.google.com/task/12725188710811152772) started by @saint2706*