### PR TITLE
Fix reduced-motion E2E tests

### DIFF
--- a/src/styles/ux-features.css
+++ b/src/styles/ux-features.css
@@ -127,7 +127,7 @@
 
 @media (prefers-reduced-motion: reduce) {
   .skeleton::after {
-    animation: none;
+    animation: none !important;
   }
 }
 
@@ -693,6 +693,6 @@
 @media (prefers-reduced-motion: reduce) {
   .empty-state-line,
   .empty-state-dot {
-    animation: none;
+    animation: none !important;
   }
 }

--- a/tests/e2e/reduced-motion.spec.ts
+++ b/tests/e2e/reduced-motion.spec.ts
@@ -72,7 +72,7 @@ test.describe('prefers-reduced-motion: reduce', () => {
       const animDuration = await skeleton.evaluate((el) => {
         return window.getComputedStyle(el, '::after').animationDuration
       })
-      expect(['0s', '0ms', '']).toContain(animDuration)
+      expect(animDuration).toMatch(/^(0s|0ms||0s, 0s|none)$/)
     }
   })
 
@@ -87,7 +87,7 @@ test.describe('prefers-reduced-motion: reduce', () => {
       const animDuration = await dot.evaluate((el) => {
         return window.getComputedStyle(el).animationDuration
       })
-      expect(['0s', '0ms', '']).toContain(animDuration)
+      expect(animDuration).toMatch(/^(0s|0ms||0s, 0s|none)$/)
     }
   })
 


### PR DESCRIPTION
Fix failing E2E tests related to `prefers-reduced-motion: reduce`. Tests were asserting animations were disabled, but CSS specificity allowed the animations to persist. Added `!important` to CSS overrides and relaxed the assertions to match various valid empty values for `animationDuration`.

---
*PR created automatically by Jules for task [4369383973578489506](https://jules.google.com/task/4369383973578489506) started by @saint2706*