### PR TITLE
Fix CI content validation for Phase 11 & 12 overviews

### DIFF
--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Phase_Overview.md
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Phase_Overview.md
@@ -1,11 +1,9 @@
 ---
 phase: 11
 title: "Cloud Data Engineering"
-description: "Master cloud infrastructure, data lakes, warehouses, orchestration, streaming, and production pipeline operations."
-duration: "12 days"
-difficulty: "intermediate-advanced"
-totalDays: 12
-dayRange: "121-132"
+days: [121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132]
+totalDuration: 720
+difficulty: "advanced"
 tags:
   - cloud
   - aws

--- a/content/lessons/Phase_12_Analytics_Engineering_Data_Products/Phase_Overview.md
+++ b/content/lessons/Phase_12_Analytics_Engineering_Data_Products/Phase_Overview.md
@@ -1,11 +1,9 @@
 ---
 phase: 12
 title: "Analytics Engineering & Data Products"
-description: "Master the business side of data: semantic layers, self-serve analytics, data mesh, product analytics, A/B testing, and data monetization."
-duration: "8 days"
-difficulty: "intermediate-advanced"
-totalDays: 8
-dayRange: "133-140"
+days: [133, 134, 135, 136, 137, 138, 139, 140]
+totalDuration: 480
+difficulty: "advanced"
 tags:
   - analytics-engineering
   - data-products


### PR DESCRIPTION
### Motivation
- CI `validate-content` was failing because two phase overview files used legacy frontmatter keys and an unsupported `difficulty` value that don't match the schema in `scripts/content-schemas.js`.
- Aligning the phase metadata to the expected schema ensures content validation succeeds and keeps downstream tooling (indexers, site build) consistent.

### Description
- Updated `content/lessons/Phase_11_Cloud_Data_Engineering/Phase_Overview.md` to use `days` (array) and `totalDuration` (number) and set `difficulty` to a supported enum value.
- Updated `content/lessons/Phase_12_Analytics_Engineering_Data_Products/Phase_Overview.md` with the same schema-compliant `days`, `totalDuration`, and normalized `difficulty` field.
- Removed legacy frontmatter fields (`description`, `duration`, `totalDays`, `dayRange`) while leaving tags and body content intact.

### Testing
- Ran `npm run validate-content` and it passed with `✅ Passed: 174/174`.
- Ran `npm run lint:ci` (which runs typechecking) and `npm run typecheck` and both completed successfully.
- Ran `npm run test:coverage` and the full test suite passed (all tests succeeded and coverage was generated).
- Note: invoking `npm run test:coverage -- --runInBand` previously errored because Vitest does not accept the `--runInBand` flag, so the plain `npm run test:coverage` command was used successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2772021788330b26290dea798c422)