### PR TITLE
Audit completed TODO items and reopen incomplete tasks

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -10,6 +10,8 @@
 
 ## ✅ Completed
 
+> **Audit update (2026-02-28):** Re-validated items marked complete against current codebase and in-app surfacing. Tasks found partially implemented have been moved back to incomplete with notes.
+
 <details>
 <summary>Click to expand completed items</summary>
 
@@ -95,7 +97,7 @@
 - [x] `Day_130_Cost_Engineering` — query optimisation for $/TB, slot management
 - [x] `Day_131_Platform_Engineering` — Terraform for data infrastructure
 - [x] `Day_132_Capstone_Cloud_Data_Pipeline` — end-to-end cloud pipeline project
-- [x] Phase 11 Overview (300+ lines)
+- [ ] Phase 11 Overview (300+ lines) _(audit: current overview is 135 lines; content exists and is surfaced, but depth target not yet met)_
 
 ### Phase 12 — Analytics Engineering & Data Products (Days 133–140) ✅ Complete
 
@@ -124,8 +126,8 @@
 
 ### AI-Powered Study Assistant
 
-- [x] "Ask about this lesson" — LLM API integration (OpenAI / Gemini)
-- [x] Auto-generate flashcards from lesson markdown
+- [ ] "Ask about this lesson" — LLM API integration (OpenAI / Gemini) _(audit: Gemini implementation exists and is surfaced in `AiStudyPanel`, but OpenAI path is not implemented)_
+- [ ] Auto-generate flashcards from lesson markdown _(audit: generation flow exists, but flashcard cards are mouse-only `div` click targets with no keyboard interaction semantics; accessibility pass still needed)_
 - [x] Smart exercise hint system (3-level progressive hints)
 - [x] Semantic search across all lesson content (embeddings + cosine similarity)
 


### PR DESCRIPTION
### Motivation
- Re-validate items listed as completed in `docs/todo.md` against the actual codebase and in-app surfacing to keep the roadmap accurate, since some tasks were partially implemented.

### Description
- Add an audit note to the top of the ✅ Completed section in `docs/todo.md` documenting the re-validation pass.
- Move three items back to incomplete with inline rationale in `docs/todo.md`: `Phase 11 Overview (300+ lines)` (current overview is 135 lines), `"Ask about this lesson"` (Gemini-only present; OpenAI path not implemented), and `Auto-generate flashcards from lesson markdown` (flashcards render as clickable divs with missing keyboard/accessibility semantics).
- No source behavior changes were made; this PR updates planning/coverage information only.

### Testing
- Ran `npm run typecheck` (TypeScript build/typecheck) which completed successfully.
- Verified Phase 11 overview length using `wc -l content/lessons/Phase_11_Cloud_Data_Engineering/Phase_Overview.md` and confirmed it is 135 lines.
- Inspected AI assistant and flashcard implementation with `rg` and file reads (checked `src/components/AiStudyPanel.tsx` and `src/utils/geminiClient.ts`) to confirm Gemini-only path and flashcard DOM structure; findings matched updated TODO annotations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a279a577ec833082e68edae3a9e0a4)