### PR TITLE
Route Gemini usage through backend API with validation & rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,44 @@ scripts/               # Build and validation scripts
 - Ranking prioritizes **title > concepts > tags > body** and returns highlighted snippets.
 - The index is built on the client and cached after initial load, so it works offline once assets are cached.
 
+
+## 🤖 Gemini Backend Setup
+
+The frontend no longer calls Google Gemini APIs directly. It now calls backend endpoints:
+
+- `POST /api/gemini/generate`
+- `POST /api/gemini/embed`
+
+### Environment Variables
+
+- `GEMINI_API_KEY` (**server only**): real Gemini key used by backend handlers.
+- `VITE_GEMINI_API_BASE` (optional, frontend): base URL for backend API if it is hosted separately. Leave empty for same-origin (`/api/...`).
+
+### Local Development
+
+1. Create `.env.local` in the project root with:
+
+   ```bash
+   GEMINI_API_KEY=your_real_gemini_key
+   # Optional when API is on another origin
+   # VITE_GEMINI_API_BASE=http://localhost:3000
+   ```
+
+2. Start Vite as usual:
+
+   ```bash
+   npm run dev
+   ```
+
+3. In development, `vite.config.ts` mounts local backend middleware for `/api/gemini/*`.
+
+### Security Controls
+
+- Gemini key is never exposed to browser bundles.
+- Backend validates request shape and max input sizes.
+- Backend applies per-IP/per-user in-memory rate limits before calling Gemini.
+- Backend returns minimal fields only (`text` for generation, `embedding` for embeddings).
+
 ## 📜 Available Scripts
 
 | Script | Description |

--- a/api/gemini/_shared.d.ts
+++ b/api/gemini/_shared.d.ts
@@ -1,0 +1,9 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+export function handleGenerate(req: IncomingMessage, res: ServerResponse): Promise<void>
+export function handleEmbed(req: IncomingMessage, res: ServerResponse): Promise<void>
+export function withErrorHandling(
+  handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void>

--- a/api/gemini/_shared.js
+++ b/api/gemini/_shared.js
@@ -1,0 +1,214 @@
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY
+
+const GENERATE_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent'
+const EMBED_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent'
+
+const rateLimitStore = globalThis.__geminiRateLimitStore ?? new Map()
+globalThis.__geminiRateLimitStore = rateLimitStore
+
+function getClientIp(req) {
+  const forwarded = req.headers['x-forwarded-for']
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    return forwarded.split(',')[0].trim()
+  }
+
+  if (Array.isArray(forwarded) && forwarded.length > 0) {
+    return forwarded[0].split(',')[0].trim()
+  }
+
+  return req.socket?.remoteAddress ?? 'unknown'
+}
+
+function getClientKey(req) {
+  const ip = getClientIp(req)
+  const userIdHeader = req.headers['x-user-id']
+  const userId = typeof userIdHeader === 'string' ? userIdHeader.slice(0, 64) : 'anonymous'
+  return `${ip}:${userId}`
+}
+
+function checkRateLimit(req, endpoint, maxRequests, windowMs) {
+  const now = Date.now()
+  const clientKey = `${endpoint}:${getClientKey(req)}`
+  const entry = rateLimitStore.get(clientKey)
+
+  if (!entry || now > entry.resetAt) {
+    rateLimitStore.set(clientKey, { count: 1, resetAt: now + windowMs })
+    return { allowed: true, retryAfterSeconds: 0 }
+  }
+
+  if (entry.count >= maxRequests) {
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(1, Math.ceil((entry.resetAt - now) / 1000)),
+    }
+  }
+
+  entry.count += 1
+  rateLimitStore.set(clientKey, entry)
+  return { allowed: true, retryAfterSeconds: 0 }
+}
+
+function validateMessages(history) {
+  if (!Array.isArray(history) || history.length > 30) {
+    return { valid: false, error: 'history must be an array with at most 30 messages' }
+  }
+
+  for (const item of history) {
+    const role = item?.role
+    const text = item?.text
+    if ((role !== 'user' && role !== 'model') || typeof text !== 'string' || text.length > 4000) {
+      return { valid: false, error: 'each history message must include role (user|model) and text' }
+    }
+  }
+
+  return { valid: true }
+}
+
+export function validateGeneratePayload(payload) {
+  const { systemInstruction, userMessage, history = [] } = payload ?? {}
+  if (typeof systemInstruction !== 'string' || systemInstruction.trim().length === 0) {
+    return { valid: false, error: 'systemInstruction is required' }
+  }
+  if (systemInstruction.length > 16_000) {
+    return { valid: false, error: 'systemInstruction exceeds max length' }
+  }
+  if (typeof userMessage !== 'string' || userMessage.trim().length === 0) {
+    return { valid: false, error: 'userMessage is required' }
+  }
+  if (userMessage.length > 8_000) {
+    return { valid: false, error: 'userMessage exceeds max length' }
+  }
+
+  return validateMessages(history)
+}
+
+export function validateEmbedPayload(payload) {
+  const text = payload?.text
+  if (typeof text !== 'string' || text.trim().length === 0) {
+    return { valid: false, error: 'text is required' }
+  }
+  if (text.length > 4_096) {
+    return { valid: false, error: 'text exceeds max length' }
+  }
+  return { valid: true }
+}
+
+export function parseJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = ''
+    req.on('data', (chunk) => {
+      body += chunk
+      if (body.length > 100_000) {
+        reject(new Error('Payload too large'))
+      }
+    })
+    req.on('end', () => {
+      try {
+        resolve(body ? JSON.parse(body) : {})
+      } catch {
+        reject(new Error('Invalid JSON payload'))
+      }
+    })
+    req.on('error', reject)
+  })
+}
+
+export function sendJson(res, status, body) {
+  res.statusCode = status
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify(body))
+}
+
+async function callGemini(url, body) {
+  if (!GEMINI_API_KEY) {
+    throw new Error('Server missing GEMINI_API_KEY')
+  }
+
+  const response = await fetch(`${url}?key=${GEMINI_API_KEY}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}))
+    const message = error?.error?.message || response.statusText
+    throw new Error(message)
+  }
+
+  return response.json()
+}
+
+export async function handleGenerate(req, res) {
+  const limit = checkRateLimit(req, 'generate', 30, 60_000)
+  if (!limit.allowed) {
+    res.setHeader('Retry-After', String(limit.retryAfterSeconds))
+    return sendJson(res, 429, { error: 'Rate limit exceeded' })
+  }
+
+  const payload = await parseJsonBody(req)
+  const validation = validateGeneratePayload(payload)
+  if (!validation.valid) {
+    return sendJson(res, 400, { error: validation.error })
+  }
+
+  const { systemInstruction, userMessage, history = [] } = payload
+  const contents = [
+    ...history.map((msg) => ({ role: msg.role, parts: [{ text: msg.text }] })),
+    { role: 'user', parts: [{ text: userMessage }] },
+  ]
+
+  const data = await callGemini(GENERATE_URL, {
+    system_instruction: { parts: [{ text: systemInstruction }] },
+    contents,
+    generationConfig: {
+      temperature: 0.7,
+      maxOutputTokens: 2048,
+      topP: 0.95,
+    },
+  })
+
+  const text = data?.candidates?.[0]?.content?.parts?.[0]?.text
+  if (!text) {
+    throw new Error('No response from Gemini')
+  }
+
+  return sendJson(res, 200, { text })
+}
+
+export async function handleEmbed(req, res) {
+  const limit = checkRateLimit(req, 'embed', 300, 60_000)
+  if (!limit.allowed) {
+    res.setHeader('Retry-After', String(limit.retryAfterSeconds))
+    return sendJson(res, 429, { error: 'Rate limit exceeded' })
+  }
+
+  const payload = await parseJsonBody(req)
+  const validation = validateEmbedPayload(payload)
+  if (!validation.valid) {
+    return sendJson(res, 400, { error: validation.error })
+  }
+
+  const data = await callGemini(EMBED_URL, {
+    content: { parts: [{ text: payload.text.slice(0, 2048) }] },
+  })
+
+  const embedding = data?.embedding?.values
+  if (!Array.isArray(embedding) || embedding.length === 0) {
+    throw new Error('No embedding returned')
+  }
+
+  return sendJson(res, 200, { embedding })
+}
+
+export async function withErrorHandling(handler, req, res) {
+  try {
+    await handler(req, res)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected server error'
+    const status = message.startsWith('Server missing') ? 503 : 500
+    sendJson(res, status, { error: message })
+  }
+}

--- a/api/gemini/embed.js
+++ b/api/gemini/embed.js
@@ -1,0 +1,12 @@
+import { handleEmbed, withErrorHandling } from './_shared.js'
+
+export default async function embed(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.statusCode = 405
+    res.end('Method Not Allowed')
+    return
+  }
+
+  await withErrorHandling(handleEmbed, req, res)
+}

--- a/api/gemini/generate.js
+++ b/api/gemini/generate.js
@@ -1,0 +1,12 @@
+import { handleGenerate, withErrorHandling } from './_shared.js'
+
+export default async function generate(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    res.statusCode = 405
+    res.end('Method Not Allowed')
+    return
+  }
+
+  await withErrorHandling(handleGenerate, req, res)
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,6 +55,18 @@ We use **Zustand** to manage user progress and application state.
 - **Sidebar**: The `Sidebar` component dynamically generates navigation based on the loaded phases and lessons.
 - **Day Tokens**: Lessons are identified by "Day Tokens" (e.g., `1`, `36B`) allowing for flexible curriculum expansion without renumbering everything.
 
+
+### 6. AI Backend Gateway (`/api/gemini/*`)
+
+Gemini access is routed through backend endpoints (`/api/gemini/generate` and `/api/gemini/embed`) instead of direct browser-to-Google API calls.
+
+- **Secret management**: the real key is stored in `GEMINI_API_KEY` on the server runtime only.
+- **Validation**: backend checks payload shape, required fields, and input size limits before upstream calls.
+- **Rate limiting**: per-IP/per-user in-memory limits are applied to generation and embedding routes.
+- **Response minimization**: backend strips Gemini responses down to the fields the frontend needs (`text` or `embedding`).
+- **Local dev**: Vite mounts middleware for these endpoints in `vite.config.ts` so `npm run dev` works with the same API contract.
+
+
 ## 📂 Directory Structure
 
 See `CONTRIBUTING.md` for a breakdown of the project structure.

--- a/src/utils/geminiClient.ts
+++ b/src/utils/geminiClient.ts
@@ -1,82 +1,60 @@
 /**
  * Gemini API Client
  *
- * Thin wrapper around the Gemini REST API for the AI Study Assistant.
- * No SDK dependency — direct fetch calls to keep bundle small.
+ * Thin wrapper around backend Gemini endpoints for the AI Study Assistant.
+ * Keeps Gemini API keys on the server side.
  *
  * @module utils/geminiClient
  */
 
-const GEMINI_API_KEY = import.meta.env.VITE_GEMINI_API_KEY as string | undefined
-
-const GENERATE_URL =
-    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent'
-const EMBED_URL =
-    'https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent'
+const GEMINI_API_BASE = (import.meta.env.VITE_GEMINI_API_BASE as string | undefined) || ''
+const GENERATE_URL = `${GEMINI_API_BASE}/api/gemini/generate`
+const EMBED_URL = `${GEMINI_API_BASE}/api/gemini/embed`
 
 export interface ChatMessage {
-    role: 'user' | 'model'
-    text: string
+  role: 'user' | 'model'
+  text: string
 }
 
 export interface Flashcard {
-    front: string
-    back: string
+  front: string
+  back: string
 }
 
 export function isGeminiAvailable(): boolean {
-    return Boolean(GEMINI_API_KEY)
+  return true
 }
 
 async function callGemini(
-    systemInstruction: string,
-    userMessage: string,
-    history: ChatMessage[] = [],
+  systemInstruction: string,
+  userMessage: string,
+  history: ChatMessage[] = [],
 ): Promise<string> {
-    if (!GEMINI_API_KEY) {
-        throw new Error('Gemini API key not configured. Add VITE_GEMINI_API_KEY to .env')
-    }
+  const response = await fetch(GENERATE_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      systemInstruction,
+      userMessage,
+      history,
+    }),
+  })
 
-    const contents = [
-        ...history.map((msg) => ({
-            role: msg.role,
-            parts: [{ text: msg.text }],
-        })),
-        { role: 'user' as const, parts: [{ text: userMessage }] },
-    ]
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}))
+    const message = (error as { error?: string }).error || response.statusText
+    throw new Error(`Gemini API error: ${message}`)
+  }
 
-    const response = await fetch(`${GENERATE_URL}?key=${GEMINI_API_KEY}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            system_instruction: { parts: [{ text: systemInstruction }] },
-            contents,
-            generationConfig: {
-                temperature: 0.7,
-                maxOutputTokens: 2048,
-                topP: 0.95,
-            },
-        }),
-    })
-
-    if (!response.ok) {
-        const error = await response.json().catch(() => ({}))
-        const message =
-            (error as { error?: { message?: string } }).error?.message || response.statusText
-        throw new Error(`Gemini API error: ${message}`)
-    }
-
-    const data = (await response.json()) as {
-        candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>
-    }
-    const text = data.candidates?.[0]?.content?.parts?.[0]?.text
-    if (!text) throw new Error('No response from Gemini')
-    return text
+  const data = (await response.json()) as { text?: string }
+  const text = data.text
+  if (!text) throw new Error('No response from Gemini')
+  return text
 }
 
 function truncateContent(content: string, maxChars = 12_000): string {
-    if (content.length <= maxChars) return content
-    return content.slice(0, maxChars) + '\n\n[...content truncated for context window...]'
+  if (content.length <= maxChars) return content
+  return content.slice(0, maxChars) + '\n\n[...content truncated for context window...]'
 }
 
 // ─── Feature 1: Lesson Q&A ──────────────────────────────────────────────────
@@ -93,12 +71,12 @@ Rules:
 - Use bullet points for multi-part answers.`
 
 export async function askAboutLesson(
-    lessonContent: string,
-    question: string,
-    history: ChatMessage[] = [],
+  lessonContent: string,
+  question: string,
+  history: ChatMessage[] = [],
 ): Promise<string> {
-    const system = `${LESSON_QA_SYSTEM}\n\n--- LESSON CONTENT ---\n${truncateContent(lessonContent)}\n--- END LESSON ---`
-    return callGemini(system, question, history)
+  const system = `${LESSON_QA_SYSTEM}\n\n--- LESSON CONTENT ---\n${truncateContent(lessonContent)}\n--- END LESSON ---`
+  return callGemini(system, question, history)
 }
 
 // ─── Feature 2: Flashcard Generation ─────────────────────────────────────────
@@ -116,76 +94,70 @@ Rules:
 Format: [{"front": "question", "back": "answer"}, ...]`
 
 export async function generateFlashcards(lessonContent: string): Promise<Flashcard[]> {
-    const system = `${FLASHCARD_SYSTEM}\n\n--- LESSON CONTENT ---\n${truncateContent(lessonContent)}\n--- END LESSON ---`
-    const raw = await callGemini(system, 'Generate 8 flashcards from this lesson.')
+  const system = `${FLASHCARD_SYSTEM}\n\n--- LESSON CONTENT ---\n${truncateContent(lessonContent)}\n--- END LESSON ---`
+  const raw = await callGemini(system, 'Generate 8 flashcards from this lesson.')
 
-    const cleaned = raw.replace(/^```(?:json)?\s*\n?/m, '').replace(/\n?```\s*$/m, '')
+  const cleaned = raw.replace(/^```(?:json)?\s*\n?/m, '').replace(/\n?```\s*$/m, '')
 
-    try {
-        const parsed = JSON.parse(cleaned) as unknown
-        if (!Array.isArray(parsed)) throw new Error('Not an array')
-        return parsed.map((card: { front?: string; back?: string }) => ({
-            front: card.front || 'No question',
-            back: card.back || 'No answer',
-        }))
-    } catch {
-        throw new Error('Failed to parse flashcards. Please try again.')
-    }
+  try {
+    const parsed = JSON.parse(cleaned) as unknown
+    if (!Array.isArray(parsed)) throw new Error('Not an array')
+    return parsed.map((card: { front?: string; back?: string }) => ({
+      front: card.front || 'No question',
+      back: card.back || 'No answer',
+    }))
+  } catch {
+    throw new Error('Failed to parse flashcards. Please try again.')
+  }
 }
 
 // ─── Feature 3: Progressive Exercise Hints ───────────────────────────────────
 
 const HINT_SYSTEMS: Record<1 | 2 | 3, string> = {
-    1: `You are a gentle coding tutor. Give a LEVEL 1 hint (nudge only).
+  1: `You are a gentle coding tutor. Give a LEVEL 1 hint (nudge only).
 - DO NOT reveal the solution or approach.
 - Ask a guiding question or point to a relevant concept.
 - Keep it to 1-2 sentences.`,
 
-    2: `You are a coding tutor. Give a LEVEL 2 hint (approach outline).
+  2: `You are a coding tutor. Give a LEVEL 2 hint (approach outline).
 - Describe the general approach in 2-3 steps.
 - Mention relevant functions or patterns by name.
 - DO NOT write the actual code.`,
 
-    3: `You are a coding tutor. Give a LEVEL 3 hint (near-solution).
+  3: `You are a coding tutor. Give a LEVEL 3 hint (near-solution).
 - Provide a code skeleton with key parts replaced by comments.
 - Show the structure but leave the core logic as TODO.
 - Include which specific methods to use.`,
 }
 
 export async function getExerciseHint(
-    exerciseTitle: string,
-    exerciseGoal: string,
-    starterCode: string,
-    level: 1 | 2 | 3,
+  exerciseTitle: string,
+  exerciseGoal: string,
+  starterCode: string,
+  level: 1 | 2 | 3,
 ): Promise<string> {
-    const system = HINT_SYSTEMS[level]
-    const prompt = `Exercise: ${exerciseTitle}\nGoal: ${exerciseGoal}\nStarter code:\n${starterCode || '(no starter code)'}\n\nGive a level ${level} hint.`
-    return callGemini(system, prompt)
+  const system = HINT_SYSTEMS[level]
+  const prompt = `Exercise: ${exerciseTitle}\nGoal: ${exerciseGoal}\nStarter code:\n${starterCode || '(no starter code)'}\n\nGive a level ${level} hint.`
+  return callGemini(system, prompt)
 }
 
 // ─── Feature 4: Text Embeddings ──────────────────────────────────────────────
 
 export async function embedText(text: string): Promise<number[]> {
-    if (!GEMINI_API_KEY) {
-        throw new Error('Gemini API key not configured')
-    }
+  const response = await fetch(EMBED_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      text,
+    }),
+  })
 
-    const response = await fetch(`${EMBED_URL}?key=${GEMINI_API_KEY}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            content: { parts: [{ text: text.slice(0, 2048) }] },
-        }),
-    })
+  if (!response.ok) {
+    throw new Error(`Embedding API error: ${response.statusText}`)
+  }
 
-    if (!response.ok) {
-        throw new Error(`Embedding API error: ${response.statusText}`)
-    }
-
-    const data = (await response.json()) as {
-        embedding?: { values?: number[] }
-    }
-    const values = data.embedding?.values
-    if (!values || values.length === 0) throw new Error('No embedding returned')
-    return values
+  const data = (await response.json()) as { embedding?: number[] }
+  const values = data.embedding
+  if (!values || values.length === 0) throw new Error('No embedding returned')
+  return values
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,21 +14,22 @@
 import { defineConfig, type HtmlTagDescriptor, type PluginOption, type UserConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import criticalCss from './scripts/vite-plugin-critical-css'
+import { handleEmbed, handleGenerate, withErrorHandling } from './api/gemini/_shared.js'
 
 // https://vite.dev/config/
 export default defineConfig(async ({ mode }) => {
   const analyzePlugin: PluginOption = (
     mode === 'analyze'
       ? await import('rollup-plugin-visualizer' as string)
-        .then((mod) =>
-          (mod as { visualizer: (options: Record<string, unknown>) => unknown }).visualizer({
-            filename: 'dist/stats.html',
-            gzipSize: true,
-            brotliSize: true,
-            template: 'treemap',
-          }),
-        )
-        .catch(() => null)
+          .then((mod) =>
+            (mod as { visualizer: (options: Record<string, unknown>) => unknown }).visualizer({
+              filename: 'dist/stats.html',
+              gzipSize: true,
+              brotliSize: true,
+              template: 'treemap',
+            }),
+          )
+          .catch(() => null)
       : null
   ) as PluginOption
 
@@ -37,6 +38,27 @@ export default defineConfig(async ({ mode }) => {
       react(),
       criticalCss(),
       analyzePlugin,
+      {
+        name: 'gemini-backend-api',
+        apply: 'serve',
+        configureServer(server) {
+          server.middlewares.use('/api/gemini/generate', async (req, res, next) => {
+            if (req.method !== 'POST') {
+              return next()
+            }
+
+            await withErrorHandling(handleGenerate, req, res)
+          })
+
+          server.middlewares.use('/api/gemini/embed', async (req, res, next) => {
+            if (req.method !== 'POST') {
+              return next()
+            }
+
+            await withErrorHandling(handleEmbed, req, res)
+          })
+        },
+      },
       {
         name: 'dev-csp-relaxation',
         transformIndexHtml: {


### PR DESCRIPTION
### Motivation

- Prevent exposing the real Gemini API key in browser bundles by moving all Gemini calls to a server-side gateway. 
- Add basic request validation and per-IP/user rate limiting to protect the upstream Gemini quota and enforce input limits. 
- Keep the frontend surface small by returning only the fields it needs (`text` for generation, `embedding` for embeddings). 

### Description

- Replaced direct browser-to-Google Gemini calls in `src/utils/geminiClient.ts` to call backend endpoints instead (`POST /api/gemini/generate` and `POST /api/gemini/embed`) and added optional frontend config `VITE_GEMINI_API_BASE`. 
- Added server-side handlers under `api/gemini/` (`_shared.js`, `generate.js`, `embed.js`) that read `GEMINI_API_KEY` only on the server, validate payloads, enforce simple in-memory per-IP/user rate limits, and return minimal shaped responses. 
- Wired Vite dev middleware in `vite.config.ts` to mount the same `/api/gemini/*` handlers during `npm run dev` so local development matches the backend contract. 
- Updated documentation in `README.md` and `docs/ARCHITECTURE.md` to describe the new `GEMINI_API_KEY` (server-only), `VITE_GEMINI_API_BASE` (optional frontend base), local dev steps, and security controls. 

### Testing

- Ran TypeScript checks with `npm run typecheck` and it succeeded. 
- Ran unit tests with `npm test` (Vitest) and all tests passed (293 tests). 
- Ran Prettier checks (`npx prettier --check`) and formatting matched after applying fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a59fd07c833095c25fe234c05371)