### PR TITLE
Prevent stale AI panel focus callbacks with timeout cleanup

### DIFF
--- a/src/components/AiStudyPanel.tsx
+++ b/src/components/AiStudyPanel.tsx
@@ -75,8 +75,16 @@ export default function AiStudyPanel({
     }, [messages.length, isLoading])
 
     useEffect(() => {
+        let focusTimeoutId: ReturnType<typeof setTimeout> | undefined
+
         if (isOpen && activeTab === 'chat') {
-            setTimeout(() => inputRef.current?.focus(), 200)
+            focusTimeoutId = setTimeout(() => inputRef.current?.focus(), 200)
+        }
+
+        return () => {
+            if (focusTimeoutId) {
+                clearTimeout(focusTimeoutId)
+            }
         }
     }, [isOpen, activeTab])
 


### PR DESCRIPTION
### Motivation
- Ensure the input focus callback scheduled when the AI panel opens does not run after the panel is closed or the component unmounts while preserving the current 200ms UX timing.

### Description
- In `src/components/AiStudyPanel.tsx` store the `setTimeout` return value in `focusTimeoutId` and add an effect cleanup that calls `clearTimeout(focusTimeoutId)`, keeping the existing 200ms delay intact.

### Testing
- Ran `npm run typecheck` (TypeScript build) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a7911d0483308dece2b2b42f1bf7)