### PR TITLE
Add AI assistant data-retention limits with pruning and migration

### DIFF
--- a/src/stores/__tests__/aiAssistantStore.test.ts
+++ b/src/stores/__tests__/aiAssistantStore.test.ts
@@ -1,0 +1,158 @@
+import { useAiAssistantStore } from '../aiAssistantStore'
+import type { ChatMessage, Flashcard } from '../../utils/geminiClient'
+
+const STORAGE_KEY = 'ai-assistant-store'
+
+function makeMessage(index: number): ChatMessage {
+  return {
+    role: index % 2 === 0 ? 'user' : 'model',
+    text: `message-${index}`,
+  }
+}
+
+function makeFlashcard(index: number): Flashcard {
+  return {
+    front: `front-${index}`,
+    back: `back-${index}`,
+  }
+}
+
+describe('aiAssistantStore', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    useAiAssistantStore.setState({
+      isOpen: false,
+      isLoading: false,
+      activeTab: 'chat',
+      messagesByDay: {},
+      flashcardsByDay: {},
+      hintLevelsByExercise: {},
+    })
+  })
+
+  it('prunes messages to max per day and max days during addMessage', () => {
+    const store = useAiAssistantStore.getState()
+
+    for (let day = 1; day <= 35; day += 1) {
+      const dayKey = `2026-01-${String(day).padStart(2, '0')}`
+      for (let i = 0; i < 105; i += 1) {
+        store.addMessage(dayKey, makeMessage(i))
+      }
+    }
+
+    const state = useAiAssistantStore.getState()
+
+    expect(Object.keys(state.messagesByDay)).toHaveLength(30)
+    expect(state.messagesByDay['2026-01-01']).toBeUndefined()
+    expect(state.messagesByDay['2026-01-06']).toBeDefined()
+    expect(state.messagesByDay['2026-01-35']).toBeDefined()
+
+    const latestDayMessages = state.messagesByDay['2026-01-35']
+    expect(latestDayMessages).toBeDefined()
+    expect(latestDayMessages!).toHaveLength(100)
+    expect(latestDayMessages?.[0]?.text).toBe('message-5')
+    expect(latestDayMessages?.[99]?.text).toBe('message-104')
+  })
+
+  it('prunes flashcards to max per day and max days during setFlashcards', () => {
+    const store = useAiAssistantStore.getState()
+
+    for (let day = 1; day <= 33; day += 1) {
+      const dayKey = `2026-02-${String(day).padStart(2, '0')}`
+      const cards = Array.from({ length: 60 }, (_, i) => makeFlashcard(i))
+      store.setFlashcards(dayKey, cards)
+    }
+
+    const state = useAiAssistantStore.getState()
+
+    expect(Object.keys(state.flashcardsByDay)).toHaveLength(30)
+    expect(state.flashcardsByDay['2026-02-01']).toBeUndefined()
+
+    const latestDayCards = state.flashcardsByDay['2026-02-33']
+    expect(latestDayCards).toBeDefined()
+    expect(latestDayCards!).toHaveLength(50)
+    expect(latestDayCards?.[0]?.front).toBe('front-10')
+    expect(latestDayCards?.[49]?.front).toBe('front-59')
+  })
+
+  it('persists pruned state and migrates oversized existing storage', async () => {
+    const oversizedMessages = Array.from({ length: 130 }, (_, i) => makeMessage(i))
+    const oversizedFlashcards = Array.from({ length: 80 }, (_, i) => makeFlashcard(i))
+
+    const oldState = {
+      state: {
+        messagesByDay: {
+          '2025-12-01': oversizedMessages,
+          '2025-12-02': oversizedMessages,
+          '2025-12-03': oversizedMessages,
+          '2025-12-04': oversizedMessages,
+          '2025-12-05': oversizedMessages,
+          '2025-12-06': oversizedMessages,
+          '2025-12-07': oversizedMessages,
+          '2025-12-08': oversizedMessages,
+          '2025-12-09': oversizedMessages,
+          '2025-12-10': oversizedMessages,
+          '2025-12-11': oversizedMessages,
+          '2025-12-12': oversizedMessages,
+          '2025-12-13': oversizedMessages,
+          '2025-12-14': oversizedMessages,
+          '2025-12-15': oversizedMessages,
+          '2025-12-16': oversizedMessages,
+          '2025-12-17': oversizedMessages,
+          '2025-12-18': oversizedMessages,
+          '2025-12-19': oversizedMessages,
+          '2025-12-20': oversizedMessages,
+          '2025-12-21': oversizedMessages,
+          '2025-12-22': oversizedMessages,
+          '2025-12-23': oversizedMessages,
+          '2025-12-24': oversizedMessages,
+          '2025-12-25': oversizedMessages,
+          '2025-12-26': oversizedMessages,
+          '2025-12-27': oversizedMessages,
+          '2025-12-28': oversizedMessages,
+          '2025-12-29': oversizedMessages,
+          '2025-12-30': oversizedMessages,
+          '2025-12-31': oversizedMessages,
+        },
+        flashcardsByDay: {
+          '2025-12-31': oversizedFlashcards,
+        },
+        hintLevelsByExercise: { ex1: 2 },
+      },
+      version: 0,
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(oldState))
+
+    await useAiAssistantStore.persist.rehydrate()
+
+    const state = useAiAssistantStore.getState()
+
+    expect(Object.keys(state.messagesByDay)).toHaveLength(30)
+    expect(state.messagesByDay['2025-12-01']).toBeUndefined()
+    expect(state.messagesByDay['2025-12-31']).toBeDefined()
+    expect(state.messagesByDay['2025-12-31']!).toHaveLength(100)
+    expect(state.messagesByDay['2025-12-31']?.[0]?.text).toBe('message-30')
+
+    expect(state.flashcardsByDay['2025-12-31']).toBeDefined()
+    expect(state.flashcardsByDay['2025-12-31']!).toHaveLength(50)
+    expect(state.flashcardsByDay['2025-12-31']?.[0]?.front).toBe('front-30')
+    expect(state.hintLevelsByExercise.ex1).toBe(2)
+
+    const rawPersisted = window.localStorage.getItem(STORAGE_KEY)
+    expect(rawPersisted).toBeTruthy()
+
+    const persisted = JSON.parse(rawPersisted as string) as {
+      state: {
+        messagesByDay: Record<string, ChatMessage[]>
+        flashcardsByDay: Record<string, Flashcard[]>
+      }
+      version: number
+    }
+
+    expect(Object.keys(persisted.state.messagesByDay)).toHaveLength(30)
+    expect(persisted.state.messagesByDay['2025-12-31']).toHaveLength(100)
+    expect(persisted.state.flashcardsByDay['2025-12-31']).toHaveLength(50)
+    expect(persisted.version).toBe(1)
+  })
+})

--- a/src/stores/aiAssistantStore.ts
+++ b/src/stores/aiAssistantStore.ts
@@ -11,6 +11,43 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { ChatMessage, Flashcard } from '../utils/geminiClient'
 
+const MAX_MESSAGES_PER_DAY = 100
+const MAX_FLASHCARDS_PER_DAY = 50
+const MAX_DAYS_RETAINED = 30
+
+type DayBuckets<T> = Record<string, T[]>
+
+function pruneDayBuckets<T>(
+  buckets: DayBuckets<T>,
+  maxItemsPerDay: number,
+  maxDaysRetained: number,
+): DayBuckets<T> {
+  const retainedDays = Object.keys(buckets)
+    .sort((a, b) => b.localeCompare(a))
+    .slice(0, maxDaysRetained)
+
+  return retainedDays.reduce<DayBuckets<T>>((acc, day) => {
+    const dayItems = buckets[day] || []
+    acc[day] = dayItems.slice(-maxItemsPerDay)
+    return acc
+  }, {})
+}
+
+function prunePersistedState(state: Pick<AiAssistantState, 'messagesByDay' | 'flashcardsByDay'>) {
+  return {
+    messagesByDay: pruneDayBuckets(
+      state.messagesByDay,
+      MAX_MESSAGES_PER_DAY,
+      MAX_DAYS_RETAINED,
+    ),
+    flashcardsByDay: pruneDayBuckets(
+      state.flashcardsByDay,
+      MAX_FLASHCARDS_PER_DAY,
+      MAX_DAYS_RETAINED,
+    ),
+  }
+}
+
 interface AiAssistantState {
     isOpen: boolean
     isLoading: boolean
@@ -49,12 +86,20 @@ export const useAiAssistantStore = create<AiAssistantState>()(
             setActiveTab: (tab) => set({ activeTab: tab }),
 
             addMessage: (day, message) =>
-                set((s) => ({
-                    messagesByDay: {
+                set((s) => {
+                    const nextMessagesByDay = {
                         ...s.messagesByDay,
                         [day]: [...(s.messagesByDay[day] || []), message],
-                    },
-                })),
+                    }
+
+                    return {
+                        messagesByDay: pruneDayBuckets(
+                            nextMessagesByDay,
+                            MAX_MESSAGES_PER_DAY,
+                            MAX_DAYS_RETAINED,
+                        ),
+                    }
+                }),
 
             clearMessages: (day) =>
                 set((s) => ({
@@ -62,9 +107,16 @@ export const useAiAssistantStore = create<AiAssistantState>()(
                 })),
 
             setFlashcards: (day, cards) =>
-                set((s) => ({
-                    flashcardsByDay: { ...s.flashcardsByDay, [day]: cards },
-                })),
+                set((s) => {
+                    const nextFlashcardsByDay = { ...s.flashcardsByDay, [day]: cards }
+                    return {
+                        flashcardsByDay: pruneDayBuckets(
+                            nextFlashcardsByDay,
+                            MAX_FLASHCARDS_PER_DAY,
+                            MAX_DAYS_RETAINED,
+                        ),
+                    }
+                }),
 
             getHintLevel: (exerciseId) => get().hintLevelsByExercise[exerciseId] || 0,
 
@@ -84,9 +136,22 @@ export const useAiAssistantStore = create<AiAssistantState>()(
         }),
         {
             name: 'ai-assistant-store',
+            version: 1,
+            migrate: (persistedState) => {
+                const raw = (persistedState || {}) as Partial<AiAssistantState>
+                const pruned = prunePersistedState({
+                    messagesByDay: raw.messagesByDay || {},
+                    flashcardsByDay: raw.flashcardsByDay || {},
+                })
+
+                return {
+                    ...raw,
+                    ...pruned,
+                    hintLevelsByExercise: raw.hintLevelsByExercise || {},
+                }
+            },
             partialize: (state) => ({
-                messagesByDay: state.messagesByDay,
-                flashcardsByDay: state.flashcardsByDay,
+                ...prunePersistedState(state),
                 hintLevelsByExercise: state.hintLevelsByExercise,
             }),
         },


### PR DESCRIPTION
### Motivation

- Prevent unbounded growth of the AI assistant store by capping messages and flashcards per day and limiting how many days are retained, which keeps the persisted payload small and predictable. 
- Ensure writes enforce the caps so oversized state is never persisted and add migration to clean up any existing oversized localStorage state.

### Description

- Introduce retention constants `MAX_MESSAGES_PER_DAY`, `MAX_FLASHCARDS_PER_DAY`, and `MAX_DAYS_RETAINED` and shared pruning helpers `pruneDayBuckets` and `prunePersistedState` in `src/stores/aiAssistantStore.ts`.
- Apply pruning at write-time in `addMessage` and `setFlashcards` so day-bucketed data is trimmed before it is stored. 
- Harden persistence by adding `version: 1`, a `migrate` function that prunes oversized legacy state on rehydrate, and update `partialize` to prune the persisted payload. 
- Add unit tests in `src/stores/__tests__/aiAssistantStore.test.ts` that verify message and flashcard pruning behavior and that migration/pruning trims oversized persisted state.

### Testing

- Ran the new test suite with `npm test -- src/stores/__tests__/aiAssistantStore.test.ts` and all tests passed (`3 tests` succeeded). 
- Ran type checking with `npm run typecheck` (`tsc -b`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a75c4c248330b4023ad75c76aa25)