### PR TITLE
Align tel protocol handling between sanitizer and link safety utils

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -126,9 +126,8 @@ const TableComponent = ({ children }: { children?: React.ReactNode }) => {
 const ImageComponent = (props: JSX.IntrinsicElements['img'] & ExtraProps) => {
   // Respect fetchpriority for LCP (Hero) optimization
   // If fetchpriority="high", we should not lazy load.
-  const isHighPriority =
-    (props as any).fetchpriority === 'high' || props.fetchPriority === 'high';
-  return <img loading={isHighPriority ? "eager" : "lazy"} decoding="async" {...props} />
+  const isHighPriority = (props as any).fetchpriority === 'high' || props.fetchPriority === 'high'
+  return <img loading={isHighPriority ? 'eager' : 'lazy'} decoding="async" {...props} />
 }
 
 const LinkComponent = ({ href, children, ...props }: JSX.IntrinsicElements['a'] & ExtraProps) => {
@@ -408,7 +407,7 @@ const lessonSanitizerSchema: RehypeSanitizeOptions = {
     '*': ['id'],
   },
   protocols: {
-    href: ['http', 'https', 'mailto', 'tel'],
+    href: ['http', 'https', 'mailto'],
     src: ['http', 'https'],
   },
 }

--- a/src/components/__tests__/MarkdownRenderer.test.tsx
+++ b/src/components/__tests__/MarkdownRenderer.test.tsx
@@ -162,6 +162,26 @@ It is a test.
     expect(container.innerHTML).not.toContain('alert("xss")')
   })
 
+  it('renders tel markdown links as plain text when disallowed by sanitizer', () => {
+    const content = '[Call us](tel:1234567890)'
+    act(() => {
+      root.render(<MarkdownRenderer content={content} />)
+    })
+
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.querySelector('span')?.textContent).toContain('Call us')
+  })
+
+  it('renders unsafe markdown links as plain text spans', () => {
+    const content = '[Bad Link](javascript:alert(1))'
+    act(() => {
+      root.render(<MarkdownRenderer content={content} />)
+    })
+
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.querySelector('span')?.textContent).toContain('Bad Link')
+  })
+
   it('injects glossary tooltips', () => {
     const content = 'This is a function.'
     act(() => {

--- a/src/utils/__tests__/linkSafety.test.ts
+++ b/src/utils/__tests__/linkSafety.test.ts
@@ -60,6 +60,11 @@ describe('getSecureLinkAttributes', () => {
     expect(result).toBeNull()
   })
 
+  it('should reject tel links when protocol is not allowlisted', () => {
+    const result = getSecureLinkAttributes('tel:+1234567890')
+    expect(result).toBeNull()
+  })
+
   it('should not duplicate noopener noreferrer', () => {
     const result = getSecureLinkAttributes('https://example.com', { rel: 'noopener' })
     expect(result?.rel).toBe('noopener noreferrer')
@@ -144,6 +149,14 @@ describe('normalizeAndValidateHref', () => {
       normalizedHref: 'search?q=filter:value',
       isExternal: false,
       isSafe: true,
+    })
+  })
+
+  it('rejects tel links when protocol is not allowlisted', () => {
+    expect(normalizeAndValidateHref('tel:+1234567890')).toEqual({
+      normalizedHref: null,
+      isExternal: false,
+      isSafe: false,
     })
   })
 })


### PR DESCRIPTION
### Motivation
- Ensure consistent handling of `tel:` links between the markdown sanitizer and the link-safety utilities so markdown rendering and URL validation have the same allowlist semantics.
- Add coverage for `tel:` behavior so changes in either sanitizer or safety utils are detected by tests.

### Description
- Removed `tel` from the `href` protocol allowlist in the markdown sanitizer schema in `src/components/MarkdownRenderer.tsx` so only `http`, `https`, and `mailto` are allowed.
- Extended `src/utils/__tests__/linkSafety.test.ts` to assert `tel:` links are rejected by both `getSecureLinkAttributes` and `normalizeAndValidateHref`.
- Added tests to `src/components/__tests__/MarkdownRenderer.test.tsx` to verify that disallowed `tel:` and `javascript:` markdown links render as safe plain text (no `<a>` tag).
- Kept link safety logic consistent with the sanitizer (no change to production allowlist beyond the sanitizer edit; tests drive the expected behavior).

### Testing
- Ran the targeted unit tests with `npm test -- src/utils/__tests__/linkSafety.test.ts src/components/__tests__/MarkdownRenderer.test.tsx` and all tests passed (30/30).
- Verified code formatting with `npx prettier --check` on the modified files and it passed after formatting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a7664228833088242a3be4696f77)