### PR TITLE
Simplify CI to a single authoritative typecheck step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,8 @@ jobs:
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
 
-      - name: Lint
-        run: npm run lint:ci
-
       - name: Typecheck
-        run: npm run typecheck
+        run: npm run lint:ci
 
       - name: Validate content
         run: npm run validate-content


### PR DESCRIPTION
### Motivation
- Ensure CI runs typechecking exactly once and make workflow step names reflect the actual check being performed.

### Description
- Updated `.github/workflows/ci.yml` to remove the duplicate lint/typecheck entry and keep a single `Typecheck` step that runs `npm run lint:ci` (which performs the project typecheck).

### Testing
- Ran `npm run lint:ci` locally which invokes the underlying `tsc -b` typecheck and it completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a7746620833083367e5a7f3570fb)