### PR TITLE
Make lint-staged typecheck command cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:report": "playwright show-report",
     "prepare": "husky",
-    "lint:ci": "npm run typecheck"
+    "lint:ci": "npm run typecheck",
+    "typecheck:staged": "node -e \"require('child_process').spawnSync('npm',['run','typecheck'],{stdio:'inherit',shell:true})\""
   },
   "dependencies": {
     "@dr.pogodin/react-helmet": "^3.0.6",
@@ -72,7 +73,7 @@
       "prettier --write"
     ],
     "*.{ts,tsx}": [
-      "cmd /c npm run typecheck"
+      "npm run typecheck:staged"
     ]
   }
 }


### PR DESCRIPTION
### Motivation
- Replace a Windows-only `lint-staged` entry (`cmd /c npm run typecheck`) with a cross-platform approach so developers on non-Windows systems can run pre-commit checks.
- Prevent `lint-staged` from passing staged file paths to `tsc -b`, which makes `tsc` try to read a per-file `tsconfig.json` and fail.
- Keep the `lint-staged` command quoting/style consistent with other entries in `package.json`.

### Description
- Replaced the `lint-staged` entry for `*.{ts,tsx}` from `"cmd /c npm run typecheck"` to `"npm run typecheck:staged"` in `package.json`.
- Added a new npm script `typecheck:staged` that runs `npm run typecheck` via Node's `child_process` (`node -e "require('child_process').spawnSync('npm',['run','typecheck'],{stdio:'inherit',shell:true})"`) so file arguments appended by `lint-staged` do not get forwarded to `tsc -b`.
- Preserved existing `lint:ci` and `typecheck` scripts; only added the wrapper script and updated the lint-staged mapping.

### Testing
- Ran `npm run lint:ci` which invokes `npm run typecheck`, and it completed successfully (no typecheck errors).
- Simulated pre-commit behavior by staging a `.tsx` change and running `npx lint-staged --config package.json --verbose`, and `lint-staged` completed successfully after the change; previously `tsc -b` failed with `TS5083` when file paths were forwarded.
- Verified the husky pre-commit flow by executing the `lint-staged` check under the pre-commit scenario and observed that `typecheck:staged` ran and returned success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a76c383c8330a783c9a9f18beb63)