### PR TITLE
Refactor validation summary to use a unified failure source

### DIFF
--- a/scripts/validate-content.js
+++ b/scripts/validate-content.js
@@ -117,9 +117,8 @@ export function validateLessonContent(rawContent, fileName = 'README.md') {
 export function runValidation(lessonsDir = LESSONS_DIR) {
   const files = findReadmes(lessonsDir, lessonsDir).sort()
   const totalFiles = files.length
-  let passCount = 0
-  let failCount = 0
-  const errors = []
+  const fileResults = new Map()
+  const crossCheckFailures = []
 
   console.log(`\n📋 Validating ${totalFiles} lesson files...\n`)
 
@@ -150,12 +149,7 @@ export function runValidation(lessonsDir = LESSONS_DIR) {
       }
     }
 
-    if (fileErrors.length > 0) {
-      failCount++
-      errors.push({ file: relativePath, issues: fileErrors })
-    } else {
-      passCount++
-    }
+    fileResults.set(relativePath, [...fileErrors])
   }
 
   // Cross-check phase metadata against lesson files in each phase directory
@@ -193,23 +187,44 @@ export function runValidation(lessonsDir = LESSONS_DIR) {
       )
     }
     if (phaseIssues.length > 0) {
-      failCount++
       const relativePath = path.relative(lessonsDir, overviewPath)
-      errors.push({ file: relativePath, issues: phaseIssues })
+      const existingIssues = fileResults.get(relativePath) ?? []
+      fileResults.set(relativePath, [...existingIssues, ...phaseIssues])
+      crossCheckFailures.push({ file: relativePath, issues: phaseIssues })
     }
   }
 
-  console.log(`✅ Passed: ${passCount}/${totalFiles}`)
+  const failedFiles = [...fileResults.entries()]
+    .filter(([, issues]) => issues.length > 0)
+    .map(([file, issues]) => ({ file, issues }))
+  const failCount = failedFiles.length
+  const passCount = totalFiles - failCount
+
+  console.log(`✅ Passed files: ${passCount}/${totalFiles}`)
+  console.log(`❌ Failed files: ${failCount}/${totalFiles}`)
+  console.log(`🔎 Cross-check failures: ${crossCheckFailures.length}`)
 
   if (failCount > 0) {
-    console.log(`❌ Failed: ${failCount} issues\n`)
-    for (const { file, issues } of errors) {
+    console.log('\n📄 File-level failures:\n')
+    for (const { file, issues } of failedFiles) {
       console.log(`  📄 ${file}`)
       for (const issue of issues) {
         console.log(`     ⚠ ${issue}`)
       }
       console.log()
     }
+
+    if (crossCheckFailures.length > 0) {
+      console.log('🔎 Cross-check failures:\n')
+      for (const { file, issues } of crossCheckFailures) {
+        console.log(`  📄 ${file}`)
+        for (const issue of issues) {
+          console.log(`     ⚠ ${issue}`)
+        }
+        console.log()
+      }
+    }
+
     return 1
   }
 


### PR DESCRIPTION
### Motivation

- Ensure final pass/fail totals are computed from a single source of truth after all validation phases, including phase cross-checks.  
- Prevent contradictory counts between per-file validation and later cross-checks and make the summary output clear about file-level vs cross-check failures.

### Description

- Replace ad-hoc `passCount`/`failCount` increments with a single `fileResults` Map that stores per-file issue lists for all validation phases.  
- Append phase cross-check issues back into `fileResults` and also record `crossCheckFailures` for dedicated reporting.  
- Recompute `passCount` and `failCount` after all validations complete and update console output to show passed files, failed files, and cross-check failure counts.  
- Update failure printing to explicitly separate file-level failures from cross-check failure details; change only `scripts/validate-content.js`.

### Testing

- Ran the validation script with `node scripts/validate-content.js` and it completed with exit code `0`.  
- The script printed summary counts and the "All lessons have valid frontmatter and metadata" message when no failures were present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a77a95b08330acb96a259e93ccd0)