### PR TITLE
Improve semantic search responsiveness with progressive indexing

### DIFF
--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -24,7 +24,12 @@ import {
   search,
   type SearchResult,
 } from '../utils/searchIndex'
-import { semanticSearch, type SemanticResult } from '../utils/semanticSearch'
+import {
+  getSemanticIndexingStatus,
+  semanticSearch,
+  subscribeSemanticIndexing,
+  type SemanticResult,
+} from '../utils/semanticSearch'
 import { isGeminiAvailable } from '../utils/geminiClient'
 
 export default function SearchResults() {
@@ -37,6 +42,7 @@ export default function SearchResults() {
   const [isSemanticMode, setIsSemanticMode] = useState(false)
   const [semanticResults, setSemanticResults] = useState<SemanticResult[]>([])
   const [semanticLoading, setSemanticLoading] = useState(false)
+  const [indexingStatus, setIndexingStatus] = useState(getSemanticIndexingStatus)
 
   useEffect(() => {
     setQuery(queryFromUrl)
@@ -67,6 +73,14 @@ export default function SearchResults() {
     return () => window.removeEventListener('keydown', handler)
   }, [navigate])
 
+  useEffect(() => {
+    const unsubscribe = subscribeSemanticIndexing(() => {
+      setIndexingStatus(getSemanticIndexingStatus())
+    })
+    setIndexingStatus(getSemanticIndexingStatus())
+    return unsubscribe
+  }, [])
+
   const results: SearchResult[] = useMemo(() => {
     if (debouncedQuery.trim().length < 2) return []
     return search(debouncedQuery, 50)
@@ -88,7 +102,9 @@ export default function SearchResults() {
     }
     let cancelled = false
     setSemanticLoading(true)
-    semanticSearch(debouncedQuery, 15)
+    semanticSearch(debouncedQuery, 15, (progressResults) => {
+      if (!cancelled) setSemanticResults(progressResults)
+    })
       .then((res) => {
         if (!cancelled) setSemanticResults(res)
       })
@@ -135,7 +151,9 @@ export default function SearchResults() {
             <p className="search-page-summary">
               {isSemanticMode
                 ? semanticLoading
-                  ? 'Searching with AI...'
+                  ? indexingStatus.indexedLessons > 0
+                    ? `Showing best current matches (${indexingStatus.indexedLessons}/${indexingStatus.totalLessons} lessons indexed, improving results...)`
+                    : 'Searching with AI...'
                   : `${semanticResults.length} semantic result${semanticResults.length !== 1 ? 's' : ''} for \u201c${query}\u201d`
                 : `${results.length} result${results.length !== 1 ? 's' : ''} for \u201c${query}\u201d`}
             </p>

--- a/src/utils/semanticSearch.ts
+++ b/src/utils/semanticSearch.ts
@@ -9,124 +9,256 @@
 
 import { getAllLessons, type Lesson } from './contentLoader'
 import { embedText, isGeminiAvailable } from './geminiClient'
+import { search as lexicalSearch } from './searchIndex'
 
 interface EmbeddingCache {
-    version: number
-    embeddings: Record<string, number[]>
+  version: number
+  embeddings: Record<string, number[]>
+  metadata: {
+    nextLessonCursor: number
+    failedKeys: string[]
+    updatedAt: number
+  }
 }
 
 const CACHE_KEY = 'semantic-embeddings-v1'
 const CACHE_VERSION = 1
 
 export interface SemanticResult {
-    lesson: Lesson
-    score: number
+  lesson: Lesson
+  score: number
+}
+
+export interface SemanticIndexingStatus {
+  state: 'idle' | 'indexing' | 'complete'
+  indexedLessons: number
+  totalLessons: number
+  failedLessons: number
 }
 
 function loadCache(): EmbeddingCache {
-    try {
-        const raw = localStorage.getItem(CACHE_KEY)
-        if (!raw) return { version: CACHE_VERSION, embeddings: {} }
-        const parsed = JSON.parse(raw) as EmbeddingCache
-        if (parsed.version !== CACHE_VERSION) return { version: CACHE_VERSION, embeddings: {} }
-        return parsed
-    } catch {
-        return { version: CACHE_VERSION, embeddings: {} }
+  try {
+    const raw = localStorage.getItem(CACHE_KEY)
+    if (!raw) {
+      return {
+        version: CACHE_VERSION,
+        embeddings: {},
+        metadata: { nextLessonCursor: 0, failedKeys: [], updatedAt: Date.now() },
+      }
     }
+    const parsed = JSON.parse(raw) as Partial<EmbeddingCache>
+    if (parsed.version !== CACHE_VERSION) {
+      return {
+        version: CACHE_VERSION,
+        embeddings: {},
+        metadata: { nextLessonCursor: 0, failedKeys: [], updatedAt: Date.now() },
+      }
+    }
+    return {
+      version: CACHE_VERSION,
+      embeddings: parsed.embeddings ?? {},
+      metadata: {
+        nextLessonCursor: Math.max(0, parsed.metadata?.nextLessonCursor ?? 0),
+        failedKeys: parsed.metadata?.failedKeys ?? [],
+        updatedAt: parsed.metadata?.updatedAt ?? Date.now(),
+      },
+    }
+  } catch {
+    return {
+      version: CACHE_VERSION,
+      embeddings: {},
+      metadata: { nextLessonCursor: 0, failedKeys: [], updatedAt: Date.now() },
+    }
+  }
 }
 
 function saveCache(cache: EmbeddingCache): void {
-    try {
-        localStorage.setItem(CACHE_KEY, JSON.stringify(cache))
-    } catch {
-        // Silently fail if storage is full
-    }
+  try {
+    cache.metadata.updatedAt = Date.now()
+    localStorage.setItem(CACHE_KEY, JSON.stringify(cache))
+  } catch {
+    // Silently fail if storage is full
+  }
 }
 
 function cosineSimilarity(a: number[], b: number[]): number {
-    if (a.length !== b.length || a.length === 0) return 0
-    let dot = 0
-    let normA = 0
-    let normB = 0
-    for (let i = 0; i < a.length; i++) {
-        dot += a[i]! * b[i]!
-        normA += a[i]! * a[i]!
-        normB += b[i]! * b[i]!
-    }
-    const denom = Math.sqrt(normA) * Math.sqrt(normB)
-    return denom === 0 ? 0 : dot / denom
+  if (a.length !== b.length || a.length === 0) return 0
+  let dot = 0
+  let normA = 0
+  let normB = 0
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i]! * b[i]!
+    normA += a[i]! * a[i]!
+    normB += b[i]! * b[i]!
+  }
+  const denom = Math.sqrt(normA) * Math.sqrt(normB)
+  return denom === 0 ? 0 : dot / denom
 }
 
 function stripMarkdownForEmbed(md: string): string {
-    return md
-        .replace(/```[\s\S]*?```|`[^`]*`|!\[[^\]]*\]\([^)]+\)/g, ' ')
-        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-        .replace(/(^\s*\d+\.\s+|^\s*[-*+]\s+|[#_~>|]+)/gm, ' ')
-        .replace(/\s+/g, ' ')
-        .trim()
-        .slice(0, 500)
+  return md
+    .replace(/```[\s\S]*?```|`[^`]*`|!\[[^\]]*\]\([^)]+\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/(^\s*\d+\.\s+|^\s*[-*+]\s+|[#_~>|]+)/gm, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 500)
+}
+
+const inFlightEmbeddings = new Map<string, Promise<number[]>>()
+let indexingPromise: Promise<void> | null = null
+const indexingListeners = new Set<() => void>()
+
+function notifyIndexingListeners(): void {
+  indexingListeners.forEach((listener) => listener())
+}
+
+export function subscribeSemanticIndexing(listener: () => void): () => void {
+  indexingListeners.add(listener)
+  return () => {
+    indexingListeners.delete(listener)
+  }
 }
 
 async function getOrComputeEmbedding(
-    key: string,
-    text: string,
-    cache: EmbeddingCache,
+  key: string,
+  text: string,
+  cache: EmbeddingCache,
 ): Promise<number[]> {
-    if (cache.embeddings[key]) {
-        return cache.embeddings[key]
-    }
-    const embedding = await embedText(text)
-    cache.embeddings[key] = embedding
-    return embedding
+  if (cache.embeddings[key]) return cache.embeddings[key]
+  const inFlight = inFlightEmbeddings.get(key)
+  if (inFlight) return inFlight
+
+  const promise = embedText(text)
+    .then((embedding) => {
+      cache.embeddings[key] = embedding
+      return embedding
+    })
+    .finally(() => {
+      inFlightEmbeddings.delete(key)
+    })
+  inFlightEmbeddings.set(key, promise)
+  return promise
 }
 
-export async function semanticSearch(query: string, limit = 15): Promise<SemanticResult[]> {
-    if (!isGeminiAvailable()) {
-        throw new Error('Gemini API not available')
-    }
+function buildHybridResults(
+  lessons: readonly Lesson[],
+  query: string,
+  queryEmbedding: number[],
+  cache: EmbeddingCache,
+  limit: number,
+): SemanticResult[] {
+  const lexicalResults = lexicalSearch(query, lessons.length)
+  const lexicalScoreMap = new Map<string, number>()
+  lexicalResults.forEach((result, index) => {
+    const rankScore = 1 - index / Math.max(1, lexicalResults.length)
+    lexicalScoreMap.set(String(result.item.day), rankScore)
+  })
 
-    const cache = loadCache()
-    const lessons = getAllLessons()
+  return lessons
+    .map((lesson) => {
+      const key = String(lesson.day)
+      const embedding = cache.embeddings[key]
+      const lexicalFallback = lexicalScoreMap.get(key) ?? 0
+      const score = embedding
+        ? cosineSimilarity(queryEmbedding, embedding)
+        : Math.max(0.01, lexicalFallback * 0.7)
+      return { lesson, score }
+    })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+}
 
-    const queryEmbedding = await embedText(query)
+export function getSemanticIndexingStatus(): SemanticIndexingStatus {
+  const cache = loadCache()
+  const totalLessons = getAllLessons().length
+  const indexedLessons = Object.keys(cache.embeddings).length
+  const failedLessons = cache.metadata.failedKeys.length
+  const complete = cache.metadata.nextLessonCursor >= totalLessons
+  return {
+    state: complete ? 'complete' : indexingPromise ? 'indexing' : 'idle',
+    indexedLessons,
+    totalLessons,
+    failedLessons,
+  }
+}
 
-    const lessonTexts = lessons.map((l) => ({
-        key: String(l.day),
-        text: `${l.title}. ${stripMarkdownForEmbed(l.content)}`,
-        lesson: l,
-    }))
+function ensureBackgroundIndexing(
+  cache: EmbeddingCache,
+  lessons: readonly Lesson[],
+): Promise<void> {
+  if (indexingPromise) return indexingPromise
 
+  indexingPromise = (async () => {
     const CONCURRENCY = 3
-    for (let i = 0; i < lessonTexts.length; i += CONCURRENCY) {
-        const batch = lessonTexts.slice(i, i + CONCURRENCY)
-        await Promise.all(
-            batch
-                .filter((item) => !cache.embeddings[item.key])
-                .map((item) => getOrComputeEmbedding(item.key, item.text, cache)),
-        )
-        if (i % (CONCURRENCY * 5) === 0) {
-            saveCache(cache)
-        }
+    let cursor = Math.min(cache.metadata.nextLessonCursor, lessons.length)
+    while (cursor < lessons.length) {
+      const batch = lessons.slice(cursor, cursor + CONCURRENCY)
+      await Promise.all(
+        batch.map(async (lesson) => {
+          const key = String(lesson.day)
+          if (cache.embeddings[key]) return
+          try {
+            await getOrComputeEmbedding(
+              key,
+              `${lesson.title}. ${stripMarkdownForEmbed(lesson.content)}`,
+              cache,
+            )
+            cache.metadata.failedKeys = cache.metadata.failedKeys.filter((item) => item !== key)
+          } catch {
+            if (!cache.metadata.failedKeys.includes(key)) {
+              cache.metadata.failedKeys.push(key)
+            }
+          }
+        }),
+      )
+      cursor += batch.length
+      cache.metadata.nextLessonCursor = cursor
+      saveCache(cache)
+      notifyIndexingListeners()
     }
-    saveCache(cache)
+  })().finally(() => {
+    indexingPromise = null
+    notifyIndexingListeners()
+  })
 
-    const results: SemanticResult[] = lessonTexts
-        .map((item) => {
-            const embedding = cache.embeddings[item.key]
-            const score = embedding ? cosineSimilarity(queryEmbedding, embedding) : 0
-            return { lesson: item.lesson, score }
-        })
-        .sort((a, b) => b.score - a.score)
-        .slice(0, limit)
+  return indexingPromise
+}
 
-    return results
+export async function semanticSearch(
+  query: string,
+  limit = 15,
+  onProgress?: (results: SemanticResult[]) => void,
+): Promise<SemanticResult[]> {
+  if (!isGeminiAvailable()) {
+    throw new Error('Gemini API not available')
+  }
+
+  const cache = loadCache()
+  const lessons = getAllLessons()
+
+  if (cache.metadata.nextLessonCursor > lessons.length) {
+    cache.metadata.nextLessonCursor = 0
+  }
+
+  const queryEmbedding = await embedText(query)
+
+  const initialResults = buildHybridResults(lessons, query, queryEmbedding, cache, limit)
+  onProgress?.(initialResults)
+
+  await ensureBackgroundIndexing(cache, lessons)
+
+  const enrichedResults = buildHybridResults(lessons, query, queryEmbedding, cache, limit)
+  onProgress?.(enrichedResults)
+  return enrichedResults
 }
 
 export function clearEmbeddingCache(): void {
-    localStorage.removeItem(CACHE_KEY)
+  localStorage.removeItem(CACHE_KEY)
+  notifyIndexingListeners()
 }
 
 export function getEmbeddingCacheSize(): number {
-    const cache = loadCache()
-    return Object.keys(cache.embeddings).length
+  const cache = loadCache()
+  return Object.keys(cache.embeddings).length
 }


### PR DESCRIPTION
### Motivation
- Semantic search was blocking on computing embeddings for all lessons, leading to slow first queries and a poor UX.  
- The goal is to return useful results quickly using cached embeddings and a lexical fallback, then progressively improve rankings as embeddings are computed.  

### Description
- Refactored `src/utils/semanticSearch.ts` to produce fast initial hybrid results by combining cached embedding similarity with a lexical fallback (`lexicalSearch`) and to emit progressive updates via an `onProgress` callback.  
- Added a persistent indexing queue/state in cache metadata (`nextLessonCursor`, `failedKeys`, `updatedAt`) and an in-flight dedupe map to avoid recomputing lessons each session, plus `ensureBackgroundIndexing` to continue warming the cache in the background.  
- Exposed indexing observability via `getSemanticIndexingStatus()` and `subscribeSemanticIndexing()` so UI can react to progress, and updated `clearEmbeddingCache()` to notify subscribers.  
- Updated `src/pages/SearchResults.tsx` to subscribe to indexing status, consume progressive results from `semanticSearch`, and show a user-facing “improving results” message while indexing continues.  

### Testing
- Ran type checking with `npm run typecheck` and it succeeded.  
- Built the app with `npm run build` and the production build completed successfully.  
- Launched the dev server and exercised the search UI with an automated Playwright script to capture a screenshot of the semantic progress UI, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a782893c83308ab856c424ce8685)