### PR TITLE
Handle semantic search failures with lexical fallback and inline error state

### DIFF
--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -36,7 +36,9 @@ export default function SearchResults() {
   const inputRef = useRef<HTMLInputElement>(null)
   const [isSemanticMode, setIsSemanticMode] = useState(false)
   const [semanticResults, setSemanticResults] = useState<SemanticResult[]>([])
+  const [semanticFallbackResults, setSemanticFallbackResults] = useState<SearchResult[]>([])
   const [semanticLoading, setSemanticLoading] = useState(false)
+  const [semanticError, setSemanticError] = useState<string | null>(null)
 
   useEffect(() => {
     setQuery(queryFromUrl)
@@ -84,16 +86,26 @@ export default function SearchResults() {
   useEffect(() => {
     if (!isSemanticMode || debouncedQuery.trim().length < 2) {
       setSemanticResults([])
+      setSemanticFallbackResults([])
+      setSemanticError(null)
       return
     }
     let cancelled = false
     setSemanticLoading(true)
+    setSemanticError(null)
     semanticSearch(debouncedQuery, 15)
       .then((res) => {
-        if (!cancelled) setSemanticResults(res)
+        if (!cancelled) {
+          setSemanticResults(res)
+          setSemanticFallbackResults([])
+        }
       })
       .catch(() => {
-        if (!cancelled) setSemanticResults([])
+        if (!cancelled) {
+          setSemanticResults([])
+          setSemanticFallbackResults(search(debouncedQuery, 50))
+          setSemanticError('AI search is temporarily unavailable. Showing keyword results instead.')
+        }
       })
       .finally(() => {
         if (!cancelled) setSemanticLoading(false)
@@ -150,6 +162,11 @@ export default function SearchResults() {
             </button>
           )}
         </div>
+        {semanticError && (
+          <p role="status" className="search-semantic-error" style={{ marginTop: '0.5rem' }}>
+            {semanticError}
+          </p>
+        )}
       </div>
 
       {isSemanticMode && semanticResults.length > 0 ? (
@@ -175,6 +192,52 @@ export default function SearchResults() {
                   </span>
                 </div>
                 <span className="search-result-card-phase">Phase {result.lesson.phase}</span>
+              </Link>
+            )
+          })}
+        </div>
+      ) : isSemanticMode && semanticFallbackResults.length > 0 ? (
+        <div className="search-results-list">
+          {semanticFallbackResults.map((result) => {
+            const diff =
+              difficultyConfig[result.item.difficulty || 'beginner'] ?? difficultyConfig.beginner!
+
+            return (
+              <Link
+                key={result.item.day}
+                to={`/lesson/${result.item.day}`}
+                className="search-result-card"
+              >
+                <div className="search-result-card-header">
+                  <span className="search-result-card-day">Day {result.item.day}</span>
+                  <h3 className="search-result-card-title">
+                    {highlightText(result.item.title, terms)}
+                  </h3>
+                  <span
+                    className="difficulty-badge"
+                    style={{ color: diff.color, background: diff.bg }}
+                  >
+                    {diff.label}
+                  </span>
+                </div>
+
+                <p className="search-result-card-snippet">
+                  {highlightText(getSearchSnippet(result.item.plainContent, debouncedQuery), terms)}
+                </p>
+
+                <div className="search-result-card-tags">
+                  {(result.item.concepts ?? []).slice(0, 3).map((concept) => (
+                    <span key={concept} className="search-result-tag">
+                      {highlightText(concept, terms)}
+                    </span>
+                  ))}
+                  {(result.item.tags ?? []).slice(0, 3).map((tag) => (
+                    <span key={tag} className="search-result-tag">
+                      {highlightText(tag, terms)}
+                    </span>
+                  ))}
+                </div>
+                <span className="search-result-card-phase">Phase {result.item.phase}</span>
               </Link>
             )
           })}

--- a/src/pages/__tests__/SearchResults.test.tsx
+++ b/src/pages/__tests__/SearchResults.test.tsx
@@ -1,5 +1,53 @@
-import { isValidElement, type ReactElement } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, isValidElement, type ReactElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
 import { highlightText } from '../../utils/searchHighlight'
+import SearchResults from '../SearchResults'
+
+const { mockSemanticSearch, mockSearch } = vi.hoisted(() => ({
+  mockSemanticSearch: vi.fn(),
+  mockSearch: vi.fn(),
+}))
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+  useNavigate: () => vi.fn(),
+  useSearchParams: () => [new URLSearchParams('q=data')],
+}))
+
+vi.mock('../../hooks/useDebounce', () => ({
+  useDebounce: (value: string) => value,
+}))
+
+vi.mock('../../utils/searchIndex', () => ({
+  extractMatchedTerms: (query: string) => query,
+  getSearchSnippet: () => 'Keyword fallback snippet',
+  search: mockSearch,
+}))
+
+vi.mock('../../utils/semanticSearch', () => ({
+  semanticSearch: mockSemanticSearch,
+}))
+
+vi.mock('../../utils/geminiClient', () => ({
+  isGeminiAvailable: () => true,
+}))
+
+vi.mock('../../utils/contentLoader', () => ({
+  difficultyConfig: {
+    beginner: { label: 'Beginner', color: '#000', bg: '#fff' },
+  },
+}))
+
+vi.mock('../../components/SEOHead', () => ({ default: () => null }))
+vi.mock('../../components/Breadcrumb', () => ({ default: () => null }))
+vi.mock('../../components/EmptyStateIllustrations', () => ({
+  SearchEmptyIllustration: () => null,
+}))
 
 describe('highlightText', () => {
   it('highlights repeated matching terms', () => {
@@ -25,5 +73,66 @@ describe('highlightText', () => {
         isValidElement(part) ? (part as ReactElement<{ children: string }>).props.children : part,
       ),
     ).toEqual(['Python', 'pyThOn'])
+  })
+})
+
+describe('SearchResults semantic failure UX', () => {
+  let container: HTMLDivElement | null = null
+  let root: Root | null = null
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root!.unmount()
+      })
+    }
+    if (container) {
+      document.body.removeChild(container)
+    }
+    vi.clearAllMocks()
+  })
+
+  it('shows an inline semantic error and falls back to lexical results', async () => {
+    mockSearch.mockReturnValue([
+      {
+        item: {
+          day: 7,
+          title: 'Data Cleaning Basics',
+          difficulty: 'beginner',
+          plainContent: 'Use strip and lower.',
+          concepts: ['cleaning'],
+          tags: ['python'],
+          phase: 1,
+        },
+      },
+    ])
+    mockSemanticSearch.mockRejectedValue(new Error('Gemini down'))
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    const mountedRoot = root
+
+    await act(async () => {
+      mountedRoot.render(<SearchResults />)
+    })
+
+    const toggle = container.querySelector('.semantic-search-toggle') as HTMLButtonElement
+    expect(toggle).not.toBeNull()
+
+    await act(async () => {
+      toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(container.textContent).toContain(
+      'AI search is temporarily unavailable. Showing keyword results instead.',
+    )
+    expect(container.textContent).toContain('Data Cleaning Basics')
+    expect(mockSearch).toHaveBeenCalledWith('data', 50)
   })
 })


### PR DESCRIPTION
### Motivation
- Improve resilience of the semantic search UX so an AI outage doesn't leave users without results or a confusing blank state. 
- Surface a clear, non-blocking error message when semantic search fails while preserving discoverability.

### Description
- Added `semanticError` and `semanticFallbackResults` state to `SearchResults` and reset them appropriately when queries or modes change.
- When `semanticSearch(...)` rejects, set a user-facing inline status message and populate `semanticFallbackResults` by calling the lexical `search(...)` so keyword results are shown while semantic mode remains enabled.
- Render a non-blocking inline `<p role="status">` message under the search controls when `semanticError` is set.
- Added page tests in `src/pages/__tests__/SearchResults.test.tsx` that mock a semantic rejection, assert the inline error message appears, and verify lexical fallback results are shown and `search(...)` is called.

### Testing
- Ran `npm test -- src/pages/__tests__/SearchResults.test.tsx` and the test file passed (all tests succeeded).
- Ran `npm run typecheck` and TypeScript checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a78818408330b0d11dc3a4074ed0)