### PR TITLE
Add real Gemini availability detection with cached health probe

### DIFF
--- a/src/components/AiStudyPanel.tsx
+++ b/src/components/AiStudyPanel.tsx
@@ -11,342 +11,360 @@ import { useState, useRef, useEffect, useCallback, type FormEvent } from 'react'
 import { motion, AnimatePresence } from 'motion/react'
 import { useAiAssistantStore } from '../stores/aiAssistantStore'
 import {
-    askAboutLesson,
-    generateFlashcards,
-    isGeminiAvailable,
-    type ChatMessage,
+  askAboutLesson,
+  checkGeminiAvailability,
+  generateFlashcards,
+  isGeminiAvailable,
+  type ChatMessage,
 } from '../utils/geminiClient'
 import type { DayToken } from '../utils/dayToken'
 
 interface AiStudyPanelProps {
-    lessonContent: string
-    lessonDay: DayToken
-    lessonTitle: string
+  lessonContent: string
+  lessonDay: DayToken
+  lessonTitle: string
 }
 
 const QUICK_ACTIONS = [
-    { label: '📝 Summarise', prompt: 'Summarise this lesson in 5 key bullet points.' },
-    {
-        label: '🧒 ELI5',
-        prompt: "Explain this lesson like I'm 5 years old.",
-    },
-    {
-        label: '💼 MBA angle',
-        prompt: 'How does this lesson apply to real MBA business scenarios? Give 3 examples.',
-    },
-    {
-        label: '❓ Quiz me',
-        prompt: "Ask me 3 quiz questions based on this lesson (don't show answers yet).",
-    },
+  { label: '📝 Summarise', prompt: 'Summarise this lesson in 5 key bullet points.' },
+  {
+    label: '🧒 ELI5',
+    prompt: "Explain this lesson like I'm 5 years old.",
+  },
+  {
+    label: '💼 MBA angle',
+    prompt: 'How does this lesson apply to real MBA business scenarios? Give 3 examples.',
+  },
+  {
+    label: '❓ Quiz me',
+    prompt: "Ask me 3 quiz questions based on this lesson (don't show answers yet).",
+  },
 ]
 
-export default function AiStudyPanel({
-    lessonContent,
-    lessonDay,
-    lessonTitle,
-}: AiStudyPanelProps) {
-    const {
-        isOpen,
-        isLoading,
-        activeTab,
-        messagesByDay,
-        flashcardsByDay,
-        toggle,
-        close,
-        setLoading,
-        setActiveTab,
-        addMessage,
-        clearMessages,
-        setFlashcards,
-    } = useAiAssistantStore()
+export default function AiStudyPanel({ lessonContent, lessonDay, lessonTitle }: AiStudyPanelProps) {
+  const {
+    isOpen,
+    isLoading,
+    activeTab,
+    messagesByDay,
+    flashcardsByDay,
+    toggle,
+    close,
+    setLoading,
+    setActiveTab,
+    addMessage,
+    clearMessages,
+    setFlashcards,
+  } = useAiAssistantStore()
 
-    const [input, setInput] = useState('')
-    const [error, setError] = useState<string | null>(null)
-    const [flippedCards, setFlippedCards] = useState<Set<number>>(new Set())
-    const messagesEndRef = useRef<HTMLDivElement>(null)
-    const inputRef = useRef<HTMLInputElement>(null)
+  const [input, setInput] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isAiAvailable, setIsAiAvailable] = useState(() => isGeminiAvailable())
+  const [flippedCards, setFlippedCards] = useState<Set<number>>(new Set())
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
-    const dayKey = String(lessonDay)
-    const messages = messagesByDay[dayKey] || []
-    const flashcards = flashcardsByDay[dayKey] || []
+  const dayKey = String(lessonDay)
+  const messages = messagesByDay[dayKey] || []
+  const flashcards = flashcardsByDay[dayKey] || []
 
-    useEffect(() => {
-        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-    }, [messages.length, isLoading])
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages.length, isLoading])
 
-    useEffect(() => {
-        let focusTimeoutId: ReturnType<typeof setTimeout> | undefined
+  useEffect(() => {
+    let isMounted = true
 
-        if (isOpen && activeTab === 'chat') {
-            focusTimeoutId = setTimeout(() => inputRef.current?.focus(), 200)
+    checkGeminiAvailability()
+      .then((available) => {
+        if (isMounted) {
+          setIsAiAvailable(available)
         }
-
-        return () => {
-            if (focusTimeoutId) {
-                clearTimeout(focusTimeoutId)
-            }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setIsAiAvailable(false)
         }
-    }, [isOpen, activeTab])
+      })
 
-    const handleSubmit = useCallback(
-        async (questionOverride?: string) => {
-            const question = questionOverride || input.trim()
-            if (!question || isLoading) return
+    return () => {
+      isMounted = false
+    }
+  }, [])
 
-            setInput('')
-            setError(null)
+  useEffect(() => {
+    let focusTimeoutId: ReturnType<typeof setTimeout> | undefined
 
-            const userMsg: ChatMessage = { role: 'user', text: question }
-            addMessage(dayKey, userMsg)
-            setLoading(true)
-
-            try {
-                const history = messages.slice(-8)
-                const reply = await askAboutLesson(lessonContent, question, history)
-                addMessage(dayKey, { role: 'model', text: reply })
-            } catch (err) {
-                const message = err instanceof Error ? err.message : 'Something went wrong'
-                setError(message)
-            } finally {
-                setLoading(false)
-            }
-        },
-        [input, isLoading, dayKey, messages, lessonContent, addMessage, setLoading],
-    )
-
-    const handleFormSubmit = (e: FormEvent) => {
-        e.preventDefault()
-        handleSubmit()
+    if (isOpen && activeTab === 'chat') {
+      focusTimeoutId = setTimeout(() => inputRef.current?.focus(), 200)
     }
 
-    const handleGenerateFlashcards = useCallback(async () => {
-        if (isLoading) return
-        setLoading(true)
-        setError(null)
-        setFlippedCards(new Set())
-
-        try {
-            const cards = await generateFlashcards(lessonContent)
-            setFlashcards(dayKey, cards)
-        } catch (err) {
-            const message = err instanceof Error ? err.message : 'Failed to generate flashcards'
-            setError(message)
-        } finally {
-            setLoading(false)
-        }
-    }, [isLoading, lessonContent, dayKey, setFlashcards, setLoading])
-
-    const toggleFlashcard = (index: number) => {
-        setFlippedCards((prev) => {
-            const next = new Set(prev)
-            if (next.has(index)) {
-                next.delete(index)
-            } else {
-                next.add(index)
-            }
-            return next
-        })
+    return () => {
+      if (focusTimeoutId) {
+        clearTimeout(focusTimeoutId)
+      }
     }
+  }, [isOpen, activeTab])
 
-    if (!isGeminiAvailable()) return null
+  const handleSubmit = useCallback(
+    async (questionOverride?: string) => {
+      const question = questionOverride || input.trim()
+      if (!question || isLoading) return
 
-    return (
-        <>
-            {/* FAB Button */}
-            <AnimatePresence>
-                {!isOpen && (
-                    <motion.button
-                        className="ai-fab"
-                        onClick={toggle}
-                        initial={{ scale: 0, opacity: 0 }}
-                        animate={{ scale: 1, opacity: 1 }}
-                        exit={{ scale: 0, opacity: 0 }}
-                        transition={{ type: 'spring', stiffness: 400, damping: 25 }}
-                        aria-label="Open AI Study Assistant"
-                    >
-                        <span className="ai-fab-icon">✨</span>
-                        Ask AI
-                    </motion.button>
-                )}
-            </AnimatePresence>
+      setInput('')
+      setError(null)
 
-            {/* Panel */}
-            <AnimatePresence>
-                {isOpen && (
-                    <>
-                        <motion.div
-                            className="ai-panel-overlay"
-                            initial={{ opacity: 0 }}
-                            animate={{ opacity: 1 }}
-                            exit={{ opacity: 0 }}
-                            onClick={close}
-                        />
-                        <motion.div
-                            className="ai-panel"
-                            initial={{ opacity: 0, y: 40, scale: 0.95 }}
-                            animate={{ opacity: 1, y: 0, scale: 1 }}
-                            exit={{ opacity: 0, y: 40, scale: 0.95 }}
-                            transition={{ type: 'spring', stiffness: 350, damping: 30 }}
+      const userMsg: ChatMessage = { role: 'user', text: question }
+      addMessage(dayKey, userMsg)
+      setLoading(true)
+
+      try {
+        const history = messages.slice(-8)
+        const reply = await askAboutLesson(lessonContent, question, history)
+        addMessage(dayKey, { role: 'model', text: reply })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Something went wrong'
+        setError(message)
+      } finally {
+        setLoading(false)
+      }
+    },
+    [input, isLoading, dayKey, messages, lessonContent, addMessage, setLoading],
+  )
+
+  const handleFormSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    handleSubmit()
+  }
+
+  const handleGenerateFlashcards = useCallback(async () => {
+    if (isLoading) return
+    setLoading(true)
+    setError(null)
+    setFlippedCards(new Set())
+
+    try {
+      const cards = await generateFlashcards(lessonContent)
+      setFlashcards(dayKey, cards)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to generate flashcards'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }, [isLoading, lessonContent, dayKey, setFlashcards, setLoading])
+
+  const toggleFlashcard = (index: number) => {
+    setFlippedCards((prev) => {
+      const next = new Set(prev)
+      if (next.has(index)) {
+        next.delete(index)
+      } else {
+        next.add(index)
+      }
+      return next
+    })
+  }
+
+  if (!isAiAvailable) return null
+
+  return (
+    <>
+      {/* FAB Button */}
+      <AnimatePresence>
+        {!isOpen && (
+          <motion.button
+            className="ai-fab"
+            onClick={toggle}
+            initial={{ scale: 0, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0, opacity: 0 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 25 }}
+            aria-label="Open AI Study Assistant"
+          >
+            <span className="ai-fab-icon">✨</span>
+            Ask AI
+          </motion.button>
+        )}
+      </AnimatePresence>
+
+      {/* Panel */}
+      <AnimatePresence>
+        {isOpen && (
+          <>
+            <motion.div
+              className="ai-panel-overlay"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={close}
+            />
+            <motion.div
+              className="ai-panel"
+              initial={{ opacity: 0, y: 40, scale: 0.95 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 40, scale: 0.95 }}
+              transition={{ type: 'spring', stiffness: 350, damping: 30 }}
+            >
+              {/* Header */}
+              <div className="ai-panel-header">
+                <h3>
+                  <span>✨</span> AI Study Assistant
+                </h3>
+                <button className="ai-panel-close" onClick={close} aria-label="Close">
+                  ✕
+                </button>
+              </div>
+
+              {/* Tabs */}
+              <div className="ai-panel-tabs">
+                <button
+                  className={`ai-panel-tab ${activeTab === 'chat' ? 'active' : ''}`}
+                  onClick={() => setActiveTab('chat')}
+                >
+                  💬 Chat
+                </button>
+                <button
+                  className={`ai-panel-tab ${activeTab === 'flashcards' ? 'active' : ''}`}
+                  onClick={() => setActiveTab('flashcards')}
+                >
+                  🃏 Flashcards
+                </button>
+              </div>
+
+              {/* Chat Tab */}
+              {activeTab === 'chat' && (
+                <>
+                  {messages.length === 0 && (
+                    <div className="ai-quick-actions">
+                      {QUICK_ACTIONS.map((action) => (
+                        <button
+                          key={action.label}
+                          className="ai-quick-action"
+                          onClick={() => handleSubmit(action.prompt)}
+                          disabled={isLoading}
                         >
-                            {/* Header */}
-                            <div className="ai-panel-header">
-                                <h3>
-                                    <span>✨</span> AI Study Assistant
-                                </h3>
-                                <button className="ai-panel-close" onClick={close} aria-label="Close">
-                                    ✕
-                                </button>
-                            </div>
+                          {action.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
 
-                            {/* Tabs */}
-                            <div className="ai-panel-tabs">
-                                <button
-                                    className={`ai-panel-tab ${activeTab === 'chat' ? 'active' : ''}`}
-                                    onClick={() => setActiveTab('chat')}
-                                >
-                                    💬 Chat
-                                </button>
-                                <button
-                                    className={`ai-panel-tab ${activeTab === 'flashcards' ? 'active' : ''}`}
-                                    onClick={() => setActiveTab('flashcards')}
-                                >
-                                    🃏 Flashcards
-                                </button>
-                            </div>
+                  <div className="ai-messages">
+                    {messages.length === 0 && !isLoading && (
+                      <div className="ai-empty-state">
+                        <span className="ai-empty-icon">🤖</span>
+                        <p>
+                          Ask anything about <strong>{lessonTitle}</strong>
+                        </p>
+                      </div>
+                    )}
 
-                            {/* Chat Tab */}
-                            {activeTab === 'chat' && (
-                                <>
-                                    {messages.length === 0 && (
-                                        <div className="ai-quick-actions">
-                                            {QUICK_ACTIONS.map((action) => (
-                                                <button
-                                                    key={action.label}
-                                                    className="ai-quick-action"
-                                                    onClick={() => handleSubmit(action.prompt)}
-                                                    disabled={isLoading}
-                                                >
-                                                    {action.label}
-                                                </button>
-                                            ))}
-                                        </div>
-                                    )}
+                    {messages.map((msg, i) => (
+                      <div key={i} className={`ai-message ${msg.role}`}>
+                        {msg.text}
+                      </div>
+                    ))}
 
-                                    <div className="ai-messages">
-                                        {messages.length === 0 && !isLoading && (
-                                            <div className="ai-empty-state">
-                                                <span className="ai-empty-icon">🤖</span>
-                                                <p>
-                                                    Ask anything about <strong>{lessonTitle}</strong>
-                                                </p>
-                                            </div>
-                                        )}
+                    {isLoading && (
+                      <div className="ai-typing">
+                        <span className="ai-typing-dot" />
+                        <span className="ai-typing-dot" />
+                        <span className="ai-typing-dot" />
+                      </div>
+                    )}
 
-                                        {messages.map((msg, i) => (
-                                            <div key={i} className={`ai-message ${msg.role}`}>
-                                                {msg.text}
-                                            </div>
-                                        ))}
+                    {error && <div className="ai-error">⚠ {error}</div>}
 
-                                        {isLoading && (
-                                            <div className="ai-typing">
-                                                <span className="ai-typing-dot" />
-                                                <span className="ai-typing-dot" />
-                                                <span className="ai-typing-dot" />
-                                            </div>
-                                        )}
+                    <div ref={messagesEndRef} />
+                  </div>
 
-                                        {error && <div className="ai-error">⚠ {error}</div>}
+                  <form className="ai-input-area" onSubmit={handleFormSubmit}>
+                    <input
+                      ref={inputRef}
+                      type="text"
+                      className="ai-input"
+                      value={input}
+                      onChange={(e) => setInput(e.target.value)}
+                      placeholder="Ask about this lesson..."
+                      disabled={isLoading}
+                      aria-label="Ask a question"
+                    />
+                    <button
+                      type="submit"
+                      className="ai-send-btn"
+                      disabled={!input.trim() || isLoading}
+                    >
+                      Send
+                    </button>
+                  </form>
 
-                                        <div ref={messagesEndRef} />
-                                    </div>
+                  {messages.length > 0 && (
+                    <div style={{ textAlign: 'center', padding: '0.3rem' }}>
+                      <button
+                        onClick={() => clearMessages(dayKey)}
+                        style={{
+                          background: 'none',
+                          border: 'none',
+                          color: 'var(--text-muted)',
+                          fontSize: '0.72rem',
+                          cursor: 'pointer',
+                          fontFamily: 'var(--font-body)',
+                        }}
+                      >
+                        Clear chat history
+                      </button>
+                    </div>
+                  )}
+                </>
+              )}
 
-                                    <form className="ai-input-area" onSubmit={handleFormSubmit}>
-                                        <input
-                                            ref={inputRef}
-                                            type="text"
-                                            className="ai-input"
-                                            value={input}
-                                            onChange={(e) => setInput(e.target.value)}
-                                            placeholder="Ask about this lesson..."
-                                            disabled={isLoading}
-                                            aria-label="Ask a question"
-                                        />
-                                        <button
-                                            type="submit"
-                                            className="ai-send-btn"
-                                            disabled={!input.trim() || isLoading}
-                                        >
-                                            Send
-                                        </button>
-                                    </form>
-
-                                    {messages.length > 0 && (
-                                        <div style={{ textAlign: 'center', padding: '0.3rem' }}>
-                                            <button
-                                                onClick={() => clearMessages(dayKey)}
-                                                style={{
-                                                    background: 'none',
-                                                    border: 'none',
-                                                    color: 'var(--text-muted)',
-                                                    fontSize: '0.72rem',
-                                                    cursor: 'pointer',
-                                                    fontFamily: 'var(--font-body)',
-                                                }}
-                                            >
-                                                Clear chat history
-                                            </button>
-                                        </div>
-                                    )}
-                                </>
-                            )}
-
-                            {/* Flashcards Tab */}
-                            {activeTab === 'flashcards' && (
-                                <div className="ai-flashcards">
-                                    {flashcards.length === 0 ? (
-                                        <div className="ai-empty-state">
-                                            <span className="ai-empty-icon">🃏</span>
-                                            <p>Generate flashcards from this lesson to test your knowledge.</p>
-                                            <button
-                                                className="ai-quick-action ai-flashcard-generate"
-                                                onClick={handleGenerateFlashcards}
-                                                disabled={isLoading}
-                                            >
-                                                {isLoading ? 'Generating...' : '✨ Generate Flashcards'}
-                                            </button>
-                                        </div>
-                                    ) : (
-                                        <>
-                                            <p className="ai-flashcard-hint">Click a card to reveal the answer</p>
-                                            {flashcards.map((card, i) => (
-                                                <div
-                                                    key={i}
-                                                    className={`ai-flashcard ${!flippedCards.has(i) ? 'collapsed' : ''}`}
-                                                    onClick={() => toggleFlashcard(i)}
-                                                >
-                                                    <div className="ai-flashcard-front">{card.front}</div>
-                                                    <div className="ai-flashcard-back">{card.back}</div>
-                                                </div>
-                                            ))}
-                                            <button
-                                                className="ai-quick-action ai-flashcard-generate"
-                                                onClick={handleGenerateFlashcards}
-                                                disabled={isLoading}
-                                                style={{ alignSelf: 'center', marginTop: '0.5rem' }}
-                                            >
-                                                {isLoading ? 'Generating...' : '🔄 Regenerate'}
-                                            </button>
-                                        </>
-                                    )}
-
-                                    {error && <div className="ai-error">⚠ {error}</div>}
-                                </div>
-                            )}
-                        </motion.div>
+              {/* Flashcards Tab */}
+              {activeTab === 'flashcards' && (
+                <div className="ai-flashcards">
+                  {flashcards.length === 0 ? (
+                    <div className="ai-empty-state">
+                      <span className="ai-empty-icon">🃏</span>
+                      <p>Generate flashcards from this lesson to test your knowledge.</p>
+                      <button
+                        className="ai-quick-action ai-flashcard-generate"
+                        onClick={handleGenerateFlashcards}
+                        disabled={isLoading}
+                      >
+                        {isLoading ? 'Generating...' : '✨ Generate Flashcards'}
+                      </button>
+                    </div>
+                  ) : (
+                    <>
+                      <p className="ai-flashcard-hint">Click a card to reveal the answer</p>
+                      {flashcards.map((card, i) => (
+                        <div
+                          key={i}
+                          className={`ai-flashcard ${!flippedCards.has(i) ? 'collapsed' : ''}`}
+                          onClick={() => toggleFlashcard(i)}
+                        >
+                          <div className="ai-flashcard-front">{card.front}</div>
+                          <div className="ai-flashcard-back">{card.back}</div>
+                        </div>
+                      ))}
+                      <button
+                        className="ai-quick-action ai-flashcard-generate"
+                        onClick={handleGenerateFlashcards}
+                        disabled={isLoading}
+                        style={{ alignSelf: 'center', marginTop: '0.5rem' }}
+                      >
+                        {isLoading ? 'Generating...' : '🔄 Regenerate'}
+                      </button>
                     </>
-                )}
-            </AnimatePresence>
-        </>
-    )
+                  )}
+
+                  {error && <div className="ai-error">⚠ {error}</div>}
+                </div>
+              )}
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </>
+  )
 }

--- a/src/utils/__tests__/geminiClient.availability.test.ts
+++ b/src/utils/__tests__/geminiClient.availability.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+async function loadGeminiClient() {
+  vi.resetModules()
+  return import('../geminiClient')
+}
+
+describe('gemini availability', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    vi.useRealTimers()
+  })
+
+  it('returns false when VITE_GEMINI_API_BASE is empty', async () => {
+    vi.stubEnv('VITE_GEMINI_API_BASE', '')
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    const geminiClient = await loadGeminiClient()
+
+    expect(geminiClient.isGeminiAvailable()).toBe(false)
+    await expect(geminiClient.checkGeminiAvailability(true)).resolves.toBe(false)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns false when VITE_GEMINI_API_BASE is malformed', async () => {
+    vi.stubEnv('VITE_GEMINI_API_BASE', 'not-a-url')
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    const geminiClient = await loadGeminiClient()
+
+    expect(geminiClient.isGeminiAvailable()).toBe(false)
+    await expect(geminiClient.checkGeminiAvailability(true)).resolves.toBe(false)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns true for a healthy backend and caches the probe result', async () => {
+    vi.stubEnv('VITE_GEMINI_API_BASE', 'https://api.example.com/')
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true } as Response)
+
+    const geminiClient = await loadGeminiClient()
+
+    await expect(geminiClient.checkGeminiAvailability()).resolves.toBe(true)
+    expect(geminiClient.isGeminiAvailable()).toBe(true)
+
+    await expect(geminiClient.checkGeminiAvailability()).resolves.toBe(true)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(fetchSpy).toHaveBeenCalledWith('https://api.example.com/api/gemini/health', {
+      method: 'GET',
+      signal: expect.any(AbortSignal),
+    })
+  })
+
+  it('returns false when the health probe times out', async () => {
+    vi.useFakeTimers()
+    vi.stubEnv('VITE_GEMINI_API_BASE', 'https://api.example.com')
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      (_url: string | URL | Request, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'))
+          })
+        }),
+    )
+
+    const geminiClient = await loadGeminiClient()
+    const probePromise = geminiClient.checkGeminiAvailability(true)
+
+    await vi.advanceTimersByTimeAsync(1_500)
+
+    await expect(probePromise).resolves.toBe(false)
+    expect(geminiClient.isGeminiAvailable()).toBe(false)
+  })
+})

--- a/src/utils/geminiClient.ts
+++ b/src/utils/geminiClient.ts
@@ -7,9 +7,7 @@
  * @module utils/geminiClient
  */
 
-const GEMINI_API_BASE = (import.meta.env.VITE_GEMINI_API_BASE as string | undefined) || ''
-const GENERATE_URL = `${GEMINI_API_BASE}/api/gemini/generate`
-const EMBED_URL = `${GEMINI_API_BASE}/api/gemini/embed`
+const GEMINI_HEALTH_PATH = '/api/gemini/health'
 
 const GEMINI_TIMEOUT_MS = clampNumber(
   Number(import.meta.env.VITE_GEMINI_TIMEOUT_MS),
@@ -25,6 +23,19 @@ const GEMINI_RETRY_BASE_DELAY_MS = clampNumber(
   2_000,
 )
 const GEMINI_RETRY_MAX_DELAY_MS = 4_000
+const GEMINI_AVAILABILITY_CACHE_TTL_MS = 30_000
+const GEMINI_AVAILABILITY_PROBE_TIMEOUT_MS = 1_500
+
+interface GeminiAvailabilityCache {
+  value: boolean
+  expiresAt: number
+  inFlightProbe?: Promise<boolean>
+}
+
+const geminiAvailabilityCache: GeminiAvailabilityCache = {
+  value: false,
+  expiresAt: 0,
+}
 
 const GEMINI_ERROR_MESSAGES = {
   timeout: 'Request timed out. Please try again.',
@@ -48,6 +59,28 @@ class GeminiClientError extends Error {
 function clampNumber(value: number, fallback: number, min: number, max: number): number {
   if (!Number.isFinite(value)) return fallback
   return Math.min(Math.max(value, min), max)
+}
+
+function getGeminiApiBase(): string {
+  const apiBase = ((import.meta.env.VITE_GEMINI_API_BASE as string | undefined) || '').trim()
+  if (!apiBase) return ''
+
+  try {
+    const parsed = new URL(apiBase)
+    return parsed.origin + parsed.pathname.replace(/\/$/, '')
+  } catch {
+    return ''
+  }
+}
+
+function joinBaseAndPath(base: string, path: string): string {
+  const normalizedBase = base.replace(/\/$/, '')
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${normalizedBase}${normalizedPath}`
+}
+
+function getGeminiUrl(path: string): string {
+  return joinBaseAndPath(getGeminiApiBase(), path)
 }
 
 function mapHttpStatusToError(status: number): GeminiClientError {
@@ -158,7 +191,54 @@ export interface Flashcard {
 }
 
 export function isGeminiAvailable(): boolean {
+  const now = Date.now()
+  const base = getGeminiApiBase()
+  if (!base) return false
+  if (geminiAvailabilityCache.expiresAt > now) {
+    return geminiAvailabilityCache.value
+  }
   return true
+}
+
+export async function checkGeminiAvailability(forceProbe = false): Promise<boolean> {
+  const now = Date.now()
+  const base = getGeminiApiBase()
+
+  if (!base) {
+    geminiAvailabilityCache.value = false
+    geminiAvailabilityCache.expiresAt = now + GEMINI_AVAILABILITY_CACHE_TTL_MS
+    return false
+  }
+
+  if (!forceProbe && geminiAvailabilityCache.expiresAt > now) {
+    return geminiAvailabilityCache.value
+  }
+
+  if (!forceProbe && geminiAvailabilityCache.inFlightProbe) {
+    return geminiAvailabilityCache.inFlightProbe
+  }
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), GEMINI_AVAILABILITY_PROBE_TIMEOUT_MS)
+
+  const probePromise = fetch(getGeminiUrl(GEMINI_HEALTH_PATH), {
+    method: 'GET',
+    signal: controller.signal,
+  })
+    .then((response) => response.ok)
+    .catch(() => false)
+    .finally(() => {
+      clearTimeout(timeoutId)
+      geminiAvailabilityCache.inFlightProbe = undefined
+    })
+
+  geminiAvailabilityCache.inFlightProbe = probePromise
+
+  const isHealthy = await probePromise
+  geminiAvailabilityCache.value = isHealthy
+  geminiAvailabilityCache.expiresAt = Date.now() + GEMINI_AVAILABILITY_CACHE_TTL_MS
+
+  return isHealthy
 }
 
 async function callGemini(
@@ -166,7 +246,7 @@ async function callGemini(
   userMessage: string,
   history: ChatMessage[] = [],
 ): Promise<string> {
-  const data = await postGemini<{ text?: string }>(GENERATE_URL, {
+  const data = await postGemini<{ text?: string }>(getGeminiUrl('/api/gemini/generate'), {
     systemInstruction,
     userMessage,
     history,
@@ -269,7 +349,9 @@ export async function getExerciseHint(
 // ─── Feature 4: Text Embeddings ──────────────────────────────────────────────
 
 export async function embedText(text: string): Promise<number[]> {
-  const data = await postGemini<{ embedding?: number[] }>(EMBED_URL, { text })
+  const data = await postGemini<{ embedding?: number[] }>(getGeminiUrl('/api/gemini/embed'), {
+    text,
+  })
   const values = data.embedding
   if (!values || values.length === 0) throw new GeminiClientError('invalidResponse')
   return values


### PR DESCRIPTION
### Motivation
- Replace the hardcoded always-true Gemini availability check so UI can hide/disable AI features when no backend is configured or the service is unhealthy.
- Use the configured endpoint base (`VITE_GEMINI_API_BASE`) and an optional lightweight health probe to detect real backend health.

### Description
- Validate and normalise `VITE_GEMINI_API_BASE` via `getGeminiApiBase()` and build endpoint URLs with `getGeminiUrl()` instead of using interpolated constants.  
- Add `checkGeminiAvailability()` which performs a `GET /api/gemini/health` probe with a 1.5s timeout, in-flight deduplication, and a 30s TTL cache; probe failures/timeouts resolve to `false`.  
- Make `isGeminiAvailable()` reflect the configured base URL and cached probe state so callers can quickly decide availability synchronously.  
- Update `callGemini` and `embedText` to use `getGeminiUrl()` for `generate` and `embed` endpoints.  
- Update `AiStudyPanel` to initialize UI from `isGeminiAvailable()` synchronously and then call `checkGeminiAvailability()` on mount, hiding the panel when AI is unavailable.  
- Add unit tests `src/utils/__tests__/geminiClient.availability.test.ts` covering empty env, malformed URL, healthy backend (and caching behavior), and probe timeout/unhealthy behavior.

### Testing
- Ran the new unit tests with `npm run test -- src/utils/__tests__/geminiClient.availability.test.ts`, all tests passed (4 tests).  
- Ran the TypeScript build/typecheck with `npm run typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2b012da088330953bc31b6a0d6c0f)