### PR TITLE
Harden parseJsonBody settlement and add regression tests

### DIFF
--- a/api/gemini/_shared.js
+++ b/api/gemini/_shared.js
@@ -146,20 +146,65 @@ export function validateEmbedPayload(payload) {
 export function parseJsonBody(req) {
   return new Promise((resolve, reject) => {
     let body = ''
-    req.on('data', (chunk) => {
+    let done = false
+
+    const cleanup = () => {
+      req.off('data', onData)
+      req.off('end', onEnd)
+      req.off('error', onError)
+    }
+
+    const resolveOnce = (value) => {
+      if (done) {
+        return
+      }
+      done = true
+      cleanup()
+      resolve(value)
+    }
+
+    const rejectOnce = (error) => {
+      if (done) {
+        return
+      }
+      done = true
+      cleanup()
+      reject(error)
+    }
+
+    const onData = (chunk) => {
+      if (done) {
+        return
+      }
+
       body += chunk
       if (body.length > 100_000) {
-        reject(new Error('Payload too large'))
+        cleanup()
+        if (typeof req.destroy === 'function' && !req.destroyed) {
+          req.destroy()
+        }
+        rejectOnce(new Error('Payload too large'))
       }
-    })
-    req.on('end', () => {
+    }
+
+    const onEnd = () => {
+      if (done) {
+        return
+      }
       try {
-        resolve(body ? JSON.parse(body) : {})
+        resolveOnce(body ? JSON.parse(body) : {})
       } catch {
-        reject(new Error('Invalid JSON payload'))
+        rejectOnce(new Error('Invalid JSON payload'))
       }
-    })
-    req.on('error', reject)
+    }
+
+    const onError = (error) => {
+      rejectOnce(error)
+    }
+
+    req.on('data', onData)
+    req.on('end', onEnd)
+    req.on('error', onError)
   })
 }
 

--- a/src/utils/__tests__/parseJsonBody.test.ts
+++ b/src/utils/__tests__/parseJsonBody.test.ts
@@ -1,0 +1,50 @@
+import { EventEmitter } from 'node:events'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { parseJsonBody } from '../../../api/gemini/_shared.js'
+
+class MockRequest extends EventEmitter {
+  destroyed = false
+  destroy = vi.fn(() => {
+    this.destroyed = true
+    return this
+  })
+}
+
+describe('parseJsonBody', () => {
+  it('rejects oversized payloads, destroys stream, and settles only once', async () => {
+    const req = new MockRequest()
+    const promise = parseJsonBody(req as never)
+
+    const settleSpy = vi.fn()
+    promise.then(
+      () => settleSpy('resolved'),
+      (error) => settleSpy(`rejected:${(error as Error).message}`),
+    )
+
+    req.emit('data', 'x'.repeat(100_001))
+    req.emit('end')
+
+    await expect(promise).rejects.toThrow('Payload too large')
+
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(req.destroy).toHaveBeenCalledTimes(1)
+    expect(settleSpy).toHaveBeenCalledTimes(1)
+    expect(settleSpy).toHaveBeenCalledWith('rejected:Payload too large')
+    expect(req.listenerCount('data')).toBe(0)
+    expect(req.listenerCount('end')).toBe(0)
+    expect(req.listenerCount('error')).toBe(0)
+  })
+
+  it('rejects malformed JSON payloads', async () => {
+    const req = new MockRequest()
+    const promise = parseJsonBody(req as never)
+
+    req.emit('data', '{"broken":')
+    req.emit('end')
+
+    await expect(promise).rejects.toThrow('Invalid JSON payload')
+  })
+})


### PR DESCRIPTION
### Motivation
- Prevent multiple settlements and late-event side effects in `parseJsonBody` when request streams emit oversized data, errors, or malformed JSON.
- Ensure the server rejects oversized payloads safely by tearing down the request stream and listeners to avoid resource leaks and unpredictable state.

### Description
- Introduced a `done` guard and one-shot wrappers `resolveOnce`/`rejectOnce` to ensure the Promise returned by `parseJsonBody` settles only once in `api/gemini/_shared.js`.
- Added a `cleanup` routine that removes `data`, `end`, and `error` listeners after settlement to prevent late-event handling.
- On oversized bodies, the handler now cleans up listeners and calls `req.destroy()` when available before rejecting with `Payload too large`.
- Added regression tests in `src/utils/__tests__/parseJsonBody.test.ts` that verify oversized payload handling (stream destroyed, listeners removed, single settlement) and malformed JSON rejection.

### Testing
- Ran `npx vitest run src/utils/__tests__/parseJsonBody.test.ts src/utils/__tests__/geminiErrorHandling.test.ts` and all tests passed.
- New tests exercise oversized payload rejection and malformed JSON handling and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2b1f82920833096554eebdb80d749)