### PR TITLE
Add rate-limit cleanup cadence and defensive store trimming

### DIFF
--- a/api/gemini/_shared.js
+++ b/api/gemini/_shared.js
@@ -7,6 +7,11 @@ const EMBED_URL =
 
 const rateLimitStore = globalThis.__geminiRateLimitStore ?? new Map()
 globalThis.__geminiRateLimitStore = rateLimitStore
+const rateLimitMeta = globalThis.__geminiRateLimitMeta ?? { requestCount: 0 }
+globalThis.__geminiRateLimitMeta = rateLimitMeta
+
+const RATE_LIMIT_CLEANUP_CADENCE = 50
+const MAX_RATE_LIMIT_ENTRIES = 10_000
 
 const ERROR_KIND = {
   VALIDATION: 'validation',
@@ -76,17 +81,46 @@ function getClientKey(req) {
   return `${ip}:${userId}`
 }
 
-function checkRateLimit(req, endpoint, maxRequests, windowMs) {
-  const now = Date.now()
+function cleanupExpiredRateLimitEntries(now) {
+  for (const [key, entry] of rateLimitStore.entries()) {
+    if (entry.resetAt < now) {
+      rateLimitStore.delete(key)
+    }
+  }
+}
+
+function trimRateLimitStore(maxEntries) {
+  while (rateLimitStore.size > maxEntries) {
+    const oldestKey = rateLimitStore.keys().next().value
+    if (typeof oldestKey === 'undefined') {
+      break
+    }
+    rateLimitStore.delete(oldestKey)
+  }
+}
+
+export function checkRateLimit(req, endpoint, maxRequests, windowMs, options = {}) {
+  const now = options.now ?? Date.now()
+  const cleanupEveryNRequests = options.cleanupEveryNRequests ?? RATE_LIMIT_CLEANUP_CADENCE
+  const maxEntries = options.maxEntries ?? MAX_RATE_LIMIT_ENTRIES
+
+  rateLimitMeta.requestCount += 1
+  if (rateLimitMeta.requestCount % cleanupEveryNRequests === 0) {
+    cleanupExpiredRateLimitEntries(now)
+  }
+
   const clientKey = `${endpoint}:${getClientKey(req)}`
   const entry = rateLimitStore.get(clientKey)
 
   if (!entry || now > entry.resetAt) {
     rateLimitStore.set(clientKey, { count: 1, resetAt: now + windowMs })
+    trimRateLimitStore(maxEntries)
     return { allowed: true, retryAfterSeconds: 0 }
   }
 
   if (entry.count >= maxRequests) {
+    rateLimitStore.delete(clientKey)
+    rateLimitStore.set(clientKey, entry)
     return {
       allowed: false,
       retryAfterSeconds: Math.max(1, Math.ceil((entry.resetAt - now) / 1000)),
@@ -94,8 +128,19 @@ function checkRateLimit(req, endpoint, maxRequests, windowMs) {
   }
 
   entry.count += 1
+  rateLimitStore.delete(clientKey)
   rateLimitStore.set(clientKey, entry)
+  trimRateLimitStore(maxEntries)
   return { allowed: true, retryAfterSeconds: 0 }
+}
+
+export function __resetRateLimitStore() {
+  rateLimitStore.clear()
+  rateLimitMeta.requestCount = 0
+}
+
+export function __getRateLimitEntries() {
+  return Array.from(rateLimitStore.entries())
 }
 
 function validateMessages(history) {

--- a/src/utils/__tests__/geminiRateLimitStore.test.ts
+++ b/src/utils/__tests__/geminiRateLimitStore.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  __getRateLimitEntries,
+  __resetRateLimitStore,
+  checkRateLimit,
+} from '../../../api/gemini/_shared.js'
+
+function createReq(id: string) {
+  return {
+    headers: { 'x-user-id': id },
+    socket: { remoteAddress: '127.0.0.1' },
+  }
+}
+
+describe('checkRateLimit store maintenance', () => {
+  beforeEach(() => {
+    __resetRateLimitStore()
+  })
+
+  it('purges expired entries while preserving active ones during cleanup cadence', () => {
+    checkRateLimit(createReq('expired-user'), 'generate', 5, 100, {
+      now: 1_000,
+      cleanupEveryNRequests: 999,
+    })
+
+    checkRateLimit(createReq('active-user'), 'generate', 5, 1_000, {
+      now: 1_000,
+      cleanupEveryNRequests: 999,
+    })
+
+    checkRateLimit(createReq('trigger-user'), 'generate', 5, 1_000, {
+      now: 1_200,
+      cleanupEveryNRequests: 1,
+    })
+
+    const keys = __getRateLimitEntries().map(([key]) => key)
+
+    expect(keys).not.toContain('generate:127.0.0.1:expired-user')
+    expect(keys).toContain('generate:127.0.0.1:active-user')
+    expect(keys).toContain('generate:127.0.0.1:trigger-user')
+  })
+
+  it('trims oldest keys and keeps recently used entries when map exceeds max size', () => {
+    checkRateLimit(createReq('a'), 'embed', 10, 5_000, {
+      now: 0,
+      maxEntries: 3,
+      cleanupEveryNRequests: 999,
+    })
+    checkRateLimit(createReq('b'), 'embed', 10, 5_000, {
+      now: 0,
+      maxEntries: 3,
+      cleanupEveryNRequests: 999,
+    })
+    checkRateLimit(createReq('c'), 'embed', 10, 5_000, {
+      now: 0,
+      maxEntries: 3,
+      cleanupEveryNRequests: 999,
+    })
+
+    checkRateLimit(createReq('a'), 'embed', 10, 5_000, {
+      now: 100,
+      maxEntries: 3,
+      cleanupEveryNRequests: 999,
+    })
+    checkRateLimit(createReq('d'), 'embed', 10, 5_000, {
+      now: 100,
+      maxEntries: 3,
+      cleanupEveryNRequests: 999,
+    })
+
+    const keys = __getRateLimitEntries().map(([key]) => key)
+
+    expect(keys).toContain('embed:127.0.0.1:a')
+    expect(keys).toContain('embed:127.0.0.1:c')
+    expect(keys).toContain('embed:127.0.0.1:d')
+    expect(keys).not.toContain('embed:127.0.0.1:b')
+  })
+})


### PR DESCRIPTION
### Motivation
- Prevent unbounded growth of the in-memory Gemini rate-limit map and ensure expired entries are removed so the server memory and rate-limiting behavior remain correct.
- Run cleanup opportunistically from the existing `checkRateLimit` path to avoid extra timers or background work.
- Defensively preserve recently used entries when trimming the map to avoid evicting active clients.

### Description
- Added a global `rateLimitMeta` request counter and constants `RATE_LIMIT_CLEANUP_CADENCE` and `MAX_RATE_LIMIT_ENTRIES` in `api/gemini/_shared.js` to support opportunistic maintenance. 
- Implemented `cleanupExpiredRateLimitEntries(now)` to purge entries with `resetAt < now` and `trimRateLimitStore(maxEntries)` to evict oldest keys when size exceeds the bound. 
- Updated `checkRateLimit` (now exported) to accept an `options` argument, increment the request counter, run expired-entry cleanup on a low-frequency cadence, refresh key recency on access by deleting/re-setting entries, and trim the store after writes. 
- Exported test helpers `__resetRateLimitStore()` and `__getRateLimitEntries()` to enable deterministic unit tests. 
- Added unit tests at `src/utils/__tests__/geminiRateLimitStore.test.ts` that verify expired entries are purged and that trimming preserves recently used entries.

### Testing
- Ran `npm test -- src/utils/__tests__/geminiRateLimitStore.test.ts`, which executed the two new tests and passed (2 tests, both passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2b2da8da88330af8e8ce5de0bc4fd)