### PR TITLE
Harden flashcard schema validation and add unit tests

### DIFF
--- a/src/utils/__tests__/geminiClient.flashcards.test.ts
+++ b/src/utils/__tests__/geminiClient.flashcards.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+async function loadGeminiClient() {
+  vi.resetModules()
+  return import('../geminiClient')
+}
+
+function mockGenerateResponse(text: string): Response {
+  return {
+    ok: true,
+    json: async () => ({ text }),
+  } as Response
+}
+
+describe('generateFlashcards schema validation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it('returns a retry-friendly error for malformed JSON', async () => {
+    vi.stubEnv('VITE_GEMINI_API_BASE', 'https://api.example.com')
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockGenerateResponse('not json'))
+
+    const geminiClient = await loadGeminiClient()
+
+    await expect(geminiClient.generateFlashcards('Lesson body')).rejects.toThrow(
+      'We could not generate valid flashcards this time. Please try again.',
+    )
+  })
+
+  it('returns a retry-friendly error when flashcard count is not exactly 8', async () => {
+    vi.stubEnv('VITE_GEMINI_API_BASE', 'https://api.example.com')
+    const sevenCards = Array.from({ length: 7 }, (_, index) => ({
+      front: `Question ${index + 1}`,
+      back: `Answer ${index + 1}`,
+    }))
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockGenerateResponse(JSON.stringify(sevenCards)),
+    )
+
+    const geminiClient = await loadGeminiClient()
+
+    await expect(geminiClient.generateFlashcards('Lesson body')).rejects.toThrow(
+      'We could not generate valid flashcards this time. Please try again.',
+    )
+  })
+
+  it('returns a retry-friendly error when card fields are invalid', async () => {
+    vi.stubEnv('VITE_GEMINI_API_BASE', 'https://api.example.com')
+    const cardsWithInvalidField = Array.from({ length: 8 }, (_, index) => ({
+      front: `Question ${index + 1}`,
+      back: `Answer ${index + 1}`,
+    }))
+    cardsWithInvalidField[3] = { front: '   ', back: 'Valid answer' }
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockGenerateResponse(JSON.stringify(cardsWithInvalidField)),
+    )
+
+    const geminiClient = await loadGeminiClient()
+
+    await expect(geminiClient.generateFlashcards('Lesson body')).rejects.toThrow(
+      'We could not generate valid flashcards this time. Please try again.',
+    )
+  })
+})

--- a/src/utils/geminiClient.ts
+++ b/src/utils/geminiClient.ts
@@ -190,6 +190,12 @@ export interface Flashcard {
   back: string
 }
 
+const FLASHCARD_COUNT = 8
+const FLASHCARD_FRONT_MAX_LENGTH = 160
+const FLASHCARD_BACK_MAX_LENGTH = 400
+const FLASHCARD_RETRY_ERROR_MESSAGE =
+  'We could not generate valid flashcards this time. Please try again.'
+
 export function isGeminiAvailable(): boolean {
   const now = Date.now()
   const base = getGeminiApiBase()
@@ -306,13 +312,36 @@ export async function generateFlashcards(lessonContent: string): Promise<Flashca
 
   try {
     const parsed = JSON.parse(cleaned) as unknown
-    if (!Array.isArray(parsed)) throw new Error('Not an array')
-    return parsed.map((card: { front?: string; back?: string }) => ({
-      front: card.front || 'No question',
-      back: card.back || 'No answer',
-    }))
+    if (!Array.isArray(parsed) || parsed.length !== FLASHCARD_COUNT) {
+      throw new Error('Invalid flashcard count')
+    }
+
+    return parsed.map((card) => {
+      if (typeof card !== 'object' || card === null || Array.isArray(card)) {
+        throw new Error('Invalid flashcard item type')
+      }
+
+      const { front, back } = card as { front?: unknown; back?: unknown }
+      if (typeof front !== 'string' || typeof back !== 'string') {
+        throw new Error('Invalid flashcard field type')
+      }
+
+      const trimmedFront = front.trim()
+      const trimmedBack = back.trim()
+
+      if (
+        trimmedFront.length === 0 ||
+        trimmedBack.length === 0 ||
+        trimmedFront.length > FLASHCARD_FRONT_MAX_LENGTH ||
+        trimmedBack.length > FLASHCARD_BACK_MAX_LENGTH
+      ) {
+        throw new Error('Invalid flashcard field value')
+      }
+
+      return { front: trimmedFront, back: trimmedBack }
+    })
   } catch {
-    throw new Error('Failed to parse flashcards. Please try again.')
+    throw new Error(FLASHCARD_RETRY_ERROR_MESSAGE)
   }
 }
 


### PR DESCRIPTION
### Motivation
- Improve robustness of flashcard generation by strictly validating the AI response shape and content to avoid silent fallback values.
- Surface a clear, retry-friendly error to users when the model returns malformed or unexpected data.
- Add unit tests to catch malformed JSON, incorrect card counts, and invalid card fields early in development.

### Description
- Require parsed flashcard payload to be an array of exactly 8 objects and reject any other length.
- Enforce `front` and `back` to be trimmed, non-empty strings and apply max lengths of `160` for `front` and `400` for `back`. 
- Reject malformed cards instead of filling placeholders and replace generic parse failures with a user-facing retry message `We could not generate valid flashcards this time. Please try again.`
- Files changed: `src/utils/geminiClient.ts` (validation logic) and added tests in `src/utils/__tests__/geminiClient.flashcards.test.ts` covering malformed JSON, wrong count, and invalid fields.

### Testing
- Ran `npm test -- src/utils/__tests__/geminiClient.flashcards.test.ts` and the new flashcard tests passed. 
- Ran `npm test -- src/utils/__tests__/geminiClient.availability.test.ts` to ensure existing availability tests still pass. 
- Both test runs succeeded (all tests in the invoked files passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2bd4a6b708330b2fd92eb7044ce33)