### PR TITLE
Add stable IDs for AI assistant chat messages and flashcards

### DIFF
--- a/src/components/AiStudyPanel.tsx
+++ b/src/components/AiStudyPanel.tsx
@@ -60,7 +60,7 @@ export default function AiStudyPanel({ lessonContent, lessonDay, lessonTitle }: 
   const [input, setInput] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isAiAvailable, setIsAiAvailable] = useState(() => isGeminiAvailable())
-  const [flippedCards, setFlippedCards] = useState<Set<number>>(new Set())
+  const [flippedCards, setFlippedCards] = useState<Set<string>>(new Set())
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -154,13 +154,13 @@ export default function AiStudyPanel({ lessonContent, lessonDay, lessonTitle }: 
     }
   }, [isLoading, lessonContent, dayKey, setFlashcards, setLoading])
 
-  const toggleFlashcard = (index: number) => {
+  const toggleFlashcard = (cardId: string) => {
     setFlippedCards((prev) => {
       const next = new Set(prev)
-      if (next.has(index)) {
-        next.delete(index)
+      if (next.has(cardId)) {
+        next.delete(cardId)
       } else {
-        next.add(index)
+        next.add(cardId)
       }
       return next
     })
@@ -260,11 +260,15 @@ export default function AiStudyPanel({ lessonContent, lessonDay, lessonTitle }: 
                       </div>
                     )}
 
-                    {messages.map((msg, i) => (
-                      <div key={i} className={`ai-message ${msg.role}`}>
-                        {msg.text}
-                      </div>
-                    ))}
+                    {messages.map((msg) => {
+                      const messageId = msg.id || `${msg.role}-${msg.text}`
+
+                      return (
+                        <div key={messageId} className={`ai-message ${msg.role}`}>
+                          {msg.text}
+                        </div>
+                      )
+                    })}
 
                     {isLoading && (
                       <div className="ai-typing">
@@ -337,16 +341,20 @@ export default function AiStudyPanel({ lessonContent, lessonDay, lessonTitle }: 
                   ) : (
                     <>
                       <p className="ai-flashcard-hint">Click a card to reveal the answer</p>
-                      {flashcards.map((card, i) => (
-                        <div
-                          key={i}
-                          className={`ai-flashcard ${!flippedCards.has(i) ? 'collapsed' : ''}`}
-                          onClick={() => toggleFlashcard(i)}
-                        >
-                          <div className="ai-flashcard-front">{card.front}</div>
-                          <div className="ai-flashcard-back">{card.back}</div>
-                        </div>
-                      ))}
+                      {flashcards.map((card) => {
+                        const cardId = card.id || `${card.front}-${card.back}`
+
+                        return (
+                          <div
+                            key={cardId}
+                            className={`ai-flashcard ${!flippedCards.has(cardId) ? 'collapsed' : ''}`}
+                            onClick={() => toggleFlashcard(cardId)}
+                          >
+                            <div className="ai-flashcard-front">{card.front}</div>
+                            <div className="ai-flashcard-back">{card.back}</div>
+                          </div>
+                        )
+                      })}
                       <button
                         className="ai-quick-action ai-flashcard-generate"
                         onClick={handleGenerateFlashcards}

--- a/src/stores/__tests__/aiAssistantStore.test.ts
+++ b/src/stores/__tests__/aiAssistantStore.test.ts
@@ -5,6 +5,7 @@ const STORAGE_KEY = 'ai-assistant-store'
 
 function makeMessage(index: number): ChatMessage {
   return {
+    id: `msg-${index}`,
     role: index % 2 === 0 ? 'user' : 'model',
     text: `message-${index}`,
   }
@@ -12,6 +13,7 @@ function makeMessage(index: number): ChatMessage {
 
 function makeFlashcard(index: number): Flashcard {
   return {
+    id: `card-${index}`,
     front: `front-${index}`,
     back: `back-${index}`,
   }
@@ -133,10 +135,12 @@ describe('aiAssistantStore', () => {
     expect(state.messagesByDay['2025-12-31']).toBeDefined()
     expect(state.messagesByDay['2025-12-31']!).toHaveLength(100)
     expect(state.messagesByDay['2025-12-31']?.[0]?.text).toBe('message-30')
+    expect(state.messagesByDay['2025-12-31']?.[0]?.id).toBe('msg-30')
 
     expect(state.flashcardsByDay['2025-12-31']).toBeDefined()
     expect(state.flashcardsByDay['2025-12-31']!).toHaveLength(50)
     expect(state.flashcardsByDay['2025-12-31']?.[0]?.front).toBe('front-30')
+    expect(state.flashcardsByDay['2025-12-31']?.[0]?.id).toBe('card-30')
     expect(state.hintLevelsByExercise.ex1).toBe(2)
 
     const rawPersisted = window.localStorage.getItem(STORAGE_KEY)
@@ -154,5 +158,37 @@ describe('aiAssistantStore', () => {
     expect(persisted.state.messagesByDay['2025-12-31']).toHaveLength(100)
     expect(persisted.state.flashcardsByDay['2025-12-31']).toHaveLength(50)
     expect(persisted.version).toBe(1)
+  })
+
+  it('assigns stable IDs to new messages and generated flashcards', () => {
+    const store = useAiAssistantStore.getState()
+
+    store.addMessage('2026-03-01', { role: 'user', text: 'no-id-message' })
+    store.setFlashcards('2026-03-01', [{ front: 'Q', back: 'A' }])
+
+    const state = useAiAssistantStore.getState()
+
+    expect(state.messagesByDay['2026-03-01']?.[0]?.id).toMatch(/^msg-/)
+    expect(state.flashcardsByDay['2026-03-01']?.[0]?.id).toMatch(/^card-/)
+  })
+
+  it('keeps IDs stable when clearing chat, regenerating flashcards, and reordering cards', () => {
+    const store = useAiAssistantStore.getState()
+
+    store.addMessage('2026-03-02', makeMessage(1))
+    store.addMessage('2026-03-02', makeMessage(2))
+    store.clearMessages('2026-03-02')
+    store.addMessage('2026-03-02', makeMessage(3))
+
+    const regeneratedCards = [makeFlashcard(100), makeFlashcard(101), makeFlashcard(102)]
+    store.setFlashcards('2026-03-02', regeneratedCards)
+    store.setFlashcards('2026-03-02', [...regeneratedCards].reverse())
+
+    const state = useAiAssistantStore.getState()
+    const chatIds = (state.messagesByDay['2026-03-02'] || []).map((msg) => msg.id)
+    const flashcardIds = (state.flashcardsByDay['2026-03-02'] || []).map((card) => card.id)
+
+    expect(chatIds).toEqual(['msg-3'])
+    expect(flashcardIds).toEqual(['card-102', 'card-101', 'card-100'])
   })
 })

--- a/src/stores/aiAssistantStore.ts
+++ b/src/stores/aiAssistantStore.ts
@@ -17,6 +17,27 @@ const MAX_DAYS_RETAINED = 30
 
 type DayBuckets<T> = Record<string, T[]>
 
+let idNonce = 0
+
+function createStableId(prefix: 'msg' | 'card'): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `${prefix}-${crypto.randomUUID()}`
+  }
+
+  idNonce += 1
+  return `${prefix}-${Date.now()}-${idNonce}`
+}
+
+function withMessageId(message: ChatMessage): ChatMessage {
+  if (message.id) return message
+  return { ...message, id: createStableId('msg') }
+}
+
+function withFlashcardId(card: Flashcard): Flashcard {
+  if (card.id) return card
+  return { ...card, id: createStableId('card') }
+}
+
 function pruneDayBuckets<T>(
   buckets: DayBuckets<T>,
   maxItemsPerDay: number,
@@ -35,11 +56,7 @@ function pruneDayBuckets<T>(
 
 function prunePersistedState(state: Pick<AiAssistantState, 'messagesByDay' | 'flashcardsByDay'>) {
   return {
-    messagesByDay: pruneDayBuckets(
-      state.messagesByDay,
-      MAX_MESSAGES_PER_DAY,
-      MAX_DAYS_RETAINED,
-    ),
+    messagesByDay: pruneDayBuckets(state.messagesByDay, MAX_MESSAGES_PER_DAY, MAX_DAYS_RETAINED),
     flashcardsByDay: pruneDayBuckets(
       state.flashcardsByDay,
       MAX_FLASHCARDS_PER_DAY,
@@ -49,111 +66,126 @@ function prunePersistedState(state: Pick<AiAssistantState, 'messagesByDay' | 'fl
 }
 
 interface AiAssistantState {
-    isOpen: boolean
-    isLoading: boolean
-    activeTab: 'chat' | 'flashcards'
-    messagesByDay: Record<string, ChatMessage[]>
-    flashcardsByDay: Record<string, Flashcard[]>
-    hintLevelsByExercise: Record<string, number>
+  isOpen: boolean
+  isLoading: boolean
+  activeTab: 'chat' | 'flashcards'
+  messagesByDay: Record<string, ChatMessage[]>
+  flashcardsByDay: Record<string, Flashcard[]>
+  hintLevelsByExercise: Record<string, number>
 
-    toggle: () => void
-    open: () => void
-    close: () => void
-    setLoading: (loading: boolean) => void
-    setActiveTab: (tab: 'chat' | 'flashcards') => void
-    addMessage: (day: string, message: ChatMessage) => void
-    clearMessages: (day: string) => void
-    setFlashcards: (day: string, cards: Flashcard[]) => void
-    getHintLevel: (exerciseId: string) => number
-    incrementHintLevel: (exerciseId: string) => number
-    resetHintLevel: (exerciseId: string) => void
+  toggle: () => void
+  open: () => void
+  close: () => void
+  setLoading: (loading: boolean) => void
+  setActiveTab: (tab: 'chat' | 'flashcards') => void
+  addMessage: (day: string, message: ChatMessage) => void
+  clearMessages: (day: string) => void
+  setFlashcards: (day: string, cards: Flashcard[]) => void
+  getHintLevel: (exerciseId: string) => number
+  incrementHintLevel: (exerciseId: string) => number
+  resetHintLevel: (exerciseId: string) => void
 }
 
 export const useAiAssistantStore = create<AiAssistantState>()(
-    persist(
-        (set, get) => ({
-            isOpen: false,
-            isLoading: false,
-            activeTab: 'chat',
-            messagesByDay: {},
-            flashcardsByDay: {},
-            hintLevelsByExercise: {},
+  persist(
+    (set, get) => ({
+      isOpen: false,
+      isLoading: false,
+      activeTab: 'chat',
+      messagesByDay: {},
+      flashcardsByDay: {},
+      hintLevelsByExercise: {},
 
-            toggle: () => set((s) => ({ isOpen: !s.isOpen })),
-            open: () => set({ isOpen: true }),
-            close: () => set({ isOpen: false }),
-            setLoading: (loading) => set({ isLoading: loading }),
-            setActiveTab: (tab) => set({ activeTab: tab }),
+      toggle: () => set((s) => ({ isOpen: !s.isOpen })),
+      open: () => set({ isOpen: true }),
+      close: () => set({ isOpen: false }),
+      setLoading: (loading) => set({ isLoading: loading }),
+      setActiveTab: (tab) => set({ activeTab: tab }),
 
-            addMessage: (day, message) =>
-                set((s) => {
-                    const nextMessagesByDay = {
-                        ...s.messagesByDay,
-                        [day]: [...(s.messagesByDay[day] || []), message],
-                    }
+      addMessage: (day, message) =>
+        set((s) => {
+          const nextMessagesByDay = {
+            ...s.messagesByDay,
+            [day]: [...(s.messagesByDay[day] || []), withMessageId(message)],
+          }
 
-                    return {
-                        messagesByDay: pruneDayBuckets(
-                            nextMessagesByDay,
-                            MAX_MESSAGES_PER_DAY,
-                            MAX_DAYS_RETAINED,
-                        ),
-                    }
-                }),
-
-            clearMessages: (day) =>
-                set((s) => ({
-                    messagesByDay: { ...s.messagesByDay, [day]: [] },
-                })),
-
-            setFlashcards: (day, cards) =>
-                set((s) => {
-                    const nextFlashcardsByDay = { ...s.flashcardsByDay, [day]: cards }
-                    return {
-                        flashcardsByDay: pruneDayBuckets(
-                            nextFlashcardsByDay,
-                            MAX_FLASHCARDS_PER_DAY,
-                            MAX_DAYS_RETAINED,
-                        ),
-                    }
-                }),
-
-            getHintLevel: (exerciseId) => get().hintLevelsByExercise[exerciseId] || 0,
-
-            incrementHintLevel: (exerciseId) => {
-                const current = get().hintLevelsByExercise[exerciseId] || 0
-                const next = Math.min(current + 1, 3)
-                set((s) => ({
-                    hintLevelsByExercise: { ...s.hintLevelsByExercise, [exerciseId]: next },
-                }))
-                return next
-            },
-
-            resetHintLevel: (exerciseId) =>
-                set((s) => ({
-                    hintLevelsByExercise: { ...s.hintLevelsByExercise, [exerciseId]: 0 },
-                })),
+          return {
+            messagesByDay: pruneDayBuckets(
+              nextMessagesByDay,
+              MAX_MESSAGES_PER_DAY,
+              MAX_DAYS_RETAINED,
+            ),
+          }
         }),
-        {
-            name: 'ai-assistant-store',
-            version: 1,
-            migrate: (persistedState) => {
-                const raw = (persistedState || {}) as Partial<AiAssistantState>
-                const pruned = prunePersistedState({
-                    messagesByDay: raw.messagesByDay || {},
-                    flashcardsByDay: raw.flashcardsByDay || {},
-                })
 
-                return {
-                    ...raw,
-                    ...pruned,
-                    hintLevelsByExercise: raw.hintLevelsByExercise || {},
-                }
-            },
-            partialize: (state) => ({
-                ...prunePersistedState(state),
-                hintLevelsByExercise: state.hintLevelsByExercise,
-            }),
-        },
-    ),
+      clearMessages: (day) =>
+        set((s) => ({
+          messagesByDay: { ...s.messagesByDay, [day]: [] },
+        })),
+
+      setFlashcards: (day, cards) =>
+        set((s) => {
+          const nextFlashcardsByDay = {
+            ...s.flashcardsByDay,
+            [day]: cards.map(withFlashcardId),
+          }
+          return {
+            flashcardsByDay: pruneDayBuckets(
+              nextFlashcardsByDay,
+              MAX_FLASHCARDS_PER_DAY,
+              MAX_DAYS_RETAINED,
+            ),
+          }
+        }),
+
+      getHintLevel: (exerciseId) => get().hintLevelsByExercise[exerciseId] || 0,
+
+      incrementHintLevel: (exerciseId) => {
+        const current = get().hintLevelsByExercise[exerciseId] || 0
+        const next = Math.min(current + 1, 3)
+        set((s) => ({
+          hintLevelsByExercise: { ...s.hintLevelsByExercise, [exerciseId]: next },
+        }))
+        return next
+      },
+
+      resetHintLevel: (exerciseId) =>
+        set((s) => ({
+          hintLevelsByExercise: { ...s.hintLevelsByExercise, [exerciseId]: 0 },
+        })),
+    }),
+    {
+      name: 'ai-assistant-store',
+      version: 1,
+      migrate: (persistedState) => {
+        const raw = (persistedState || {}) as Partial<AiAssistantState>
+        const pruned = prunePersistedState({
+          messagesByDay: raw.messagesByDay || {},
+          flashcardsByDay: raw.flashcardsByDay || {},
+        })
+
+        return {
+          ...raw,
+          ...pruned,
+          messagesByDay: Object.fromEntries(
+            Object.entries(pruned.messagesByDay).map(([day, messages]) => [
+              day,
+              messages.map(withMessageId),
+            ]),
+          ),
+          flashcardsByDay: Object.fromEntries(
+            Object.entries(pruned.flashcardsByDay).map(([day, cards]) => [
+              day,
+              cards.map(withFlashcardId),
+            ]),
+          ),
+          hintLevelsByExercise: raw.hintLevelsByExercise || {},
+        }
+      },
+      partialize: (state) => ({
+        ...prunePersistedState(state),
+        hintLevelsByExercise: state.hintLevelsByExercise,
+      }),
+    },
+  ),
 )

--- a/src/utils/geminiClient.ts
+++ b/src/utils/geminiClient.ts
@@ -181,11 +181,13 @@ async function postGemini<T>(url: string, payload: Record<string, unknown>): Pro
 }
 
 export interface ChatMessage {
+  id?: string
   role: 'user' | 'model'
   text: string
 }
 
 export interface Flashcard {
+  id?: string
   front: string
   back: string
 }


### PR DESCRIPTION
### Motivation
- Ensure list stability in the AI Study Assistant UI by giving chat messages and flashcards stable IDs so keys are deterministic across clears, regenerations, and reorderings.
- Backfill IDs for previously persisted entries so migrated state remains usable and flip state remains stable.

### Description
- Added optional `id` fields to the `ChatMessage` and `Flashcard` models in `src/utils/geminiClient.ts`.
- Implemented stable ID generation and backfill helpers (`createStableId`, `withMessageId`, `withFlashcardId`) and applied them in `src/stores/aiAssistantStore.ts` for `addMessage`, `setFlashcards`, and migration logic.
- Updated `src/components/AiStudyPanel.tsx` to use ID-based keys in `.map(...)` for messages and flashcards and switched flashcard flip tracking from numeric indices to card IDs.
- Extended `src/stores/__tests__/aiAssistantStore.test.ts` to assert ID assignment and stability across clearing, regenerating, and reordering flows.

### Testing
- Ran the targeted unit tests with `npm run test -- src/stores/__tests__/aiAssistantStore.test.ts`, and all tests in that file passed (5 tests).
- Ran `npm run typecheck` which failed due to unrelated pre-existing TypeScript errors in other test files outside the changed code (typecheck errors are not caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2bde509cc833099a8aab9254835b3)