### PR TITLE
Align exercise loader with extractor output types

### DIFF
--- a/src/utils/__tests__/exerciseExtractor.test.ts
+++ b/src/utils/__tests__/exerciseExtractor.test.ts
@@ -1,0 +1,66 @@
+import { extractExercises } from '../exerciseExtractor'
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
+
+type Assert<T extends true> = T
+
+type ExtractedExerciseShape = ReturnType<typeof extractExercises>[number]
+
+const typeAssertions: [
+  Assert<
+    Equal<
+      keyof ExtractedExerciseShape,
+      'title' | 'goal' | 'starterCode' | 'expectedOutput' | 'tags'
+    >
+  >,
+  Assert<Equal<ExtractedExerciseShape['expectedOutput'], string | undefined>>,
+  Assert<Equal<ExtractedExerciseShape['tags'], string[]>>,
+] = [true, true, true]
+
+expect(typeAssertions).toHaveLength(3)
+
+describe('exerciseExtractor', () => {
+  it('extracts exercises with the expected output shape', () => {
+    const markdown = `
+### Exercise 1: Compute Sum
+**Goal**: Add two numbers.
+
+\`\`\`python
+print(2 + 3)
+\`\`\`
+
+**Expected Output:**
+\`\`\`text
+5
+\`\`\`
+`
+
+    const exercises = extractExercises(markdown)
+
+    expect(exercises).toHaveLength(1)
+    expect(exercises[0]).toMatchObject({
+      title: 'Compute Sum',
+      goal: 'Add two numbers.',
+      starterCode: 'print(2 + 3)',
+      expectedOutput: '5',
+      tags: [],
+    })
+  })
+
+  it('keeps expectedOutput optional when omitted in markdown', () => {
+    const markdown = `
+### Exercise 1: No Output Block
+**Goal**: Print hello.
+
+\`\`\`python
+print('hello')
+\`\`\`
+`
+
+    const exercises = extractExercises(markdown)
+
+    expect(exercises).toHaveLength(1)
+    expect(exercises[0]?.expectedOutput).toBeUndefined()
+  })
+})

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -213,6 +213,7 @@ export interface Exercise {
   title: string
   goal: string
   starterCode: string
+  expectedOutput?: string
   tags: readonly string[]
 }
 
@@ -236,8 +237,8 @@ function extractExercisesFromLesson(lesson: Lesson): Exercise[] {
     title: ex.title,
     goal: ex.goal,
     starterCode: ex.starterCode,
-    tags: lesson.tags || [],
     expectedOutput: ex.expectedOutput,
+    tags: ex.tags.length > 0 ? ex.tags : (lesson.tags ?? []),
   }))
 }
 


### PR DESCRIPTION
### Motivation
- The markdown exercise extractor returns `expectedOutput` and `tags`, but the lesson exercise builder in `contentLoader` did not declare `expectedOutput`, causing a typed-field mismatch and potential runtime/typing drift.  
- Add compile-time shape assertions to ensure the extractor output shape remains stable and to catch regressions early.

### Description
- Added `expectedOutput?: string` to the `Exercise` interface in `src/utils/contentLoader.ts`.  
- Updated `extractExercisesFromLesson` to consume extractor-provided fields explicitly, using `ex.expectedOutput` and preferring `ex.tags` with a fallback to `lesson.tags`.  
- Added `src/utils/__tests__/exerciseExtractor.test.ts` which contains TypeScript compile-time assertions for the extractor return shape and runtime tests verifying expected-output present/omitted behavior.  
- Changes are scoped to `src/utils/contentLoader.ts` and the new test file `src/utils/__tests__/exerciseExtractor.test.ts`.

### Testing
- Ran unit tests with `npm run test -- src/utils/__tests__/contentLoader.test.ts src/utils/__tests__/exerciseExtractor.test.ts` and both test files passed (`15 tests` total).  
- Ran the extractor-only tests with `npm run test -- src/utils/__tests__/exerciseExtractor.test.ts` and they passed.  
- Ran type checking with `npm run typecheck`; this failed due to unrelated pre-existing typing errors in other test files (gemini-related tests), not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2bedd245883308a27f728a88cbcfe)