### PR TITLE
Improve notebook parse failure diagnostics while preserving resilient UX

### DIFF
--- a/src/utils/__tests__/contentLoader.test.ts
+++ b/src/utils/__tests__/contentLoader.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import {
   getAdjacentLessons,
   getAllExercises,
@@ -11,6 +13,7 @@ import {
   getPrerequisiteLessons,
   getReadingTime,
   getRelatedLessons,
+  parseNotebookEntry,
 } from '../contentLoader'
 
 describe('contentLoader', () => {
@@ -103,6 +106,52 @@ test words repeated `.repeat(120)
     expect(notebooks.length).toBeGreaterThan(0)
 
     expect(getNotebook(9999)).toBeUndefined()
+  })
+
+  it('logs notebook parse failures and keeps UX resilient', () => {
+    const notebookPath = '/content/lessons/Phase_99_Test/Phase_99_Solutions.ipynb'
+    const invalidNotebookRaw = readFileSync(
+      resolve(__dirname, 'fixtures', 'invalid-notebook.ipynb'),
+      'utf-8',
+    )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const parsed = parseNotebookEntry(notebookPath, invalidNotebookRaw, {
+      attachParseError: false,
+    })
+
+    expect(parsed.phase).toBe(99)
+    expect(parsed.cells).toEqual([])
+    expect(parsed.parseError).toBeUndefined()
+    expect(warnSpy).toHaveBeenCalledWith(
+      `[contentLoader] Failed to parse notebook JSON for phase 99 at ${notebookPath}.`,
+      expect.any(SyntaxError),
+    )
+
+    warnSpy.mockRestore()
+  })
+
+  it('attaches parseError metadata in dev diagnostics mode', () => {
+    const notebookPath = '/content/lessons/Phase_7_ML/Phase_7_Solutions.ipynb'
+    const invalidNotebookRaw = readFileSync(
+      resolve(__dirname, 'fixtures', 'invalid-notebook.ipynb'),
+      'utf-8',
+    )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const parsed = parseNotebookEntry(notebookPath, invalidNotebookRaw, {
+      attachParseError: true,
+    })
+
+    expect(parsed.cells).toEqual([])
+    expect(parsed.parseError).toEqual(
+      expect.objectContaining({
+        path: notebookPath,
+        phase: 7,
+      }),
+    )
+
+    warnSpy.mockRestore()
   })
 
   it('returns empty prerequisites when none are configured', () => {

--- a/src/utils/__tests__/fixtures/invalid-notebook.ipynb
+++ b/src/utils/__tests__/fixtures/invalid-notebook.ipynb
@@ -1,0 +1,7 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": ["# Broken notebook fixture"]
+    }
+  ],

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -377,6 +377,11 @@ export interface NotebookCell {
 export interface Notebook {
   phase: number
   cells: readonly NotebookCell[]
+  parseError?: {
+    path: string
+    phase: number
+    message: string
+  }
 }
 
 type ImmutableLesson = Readonly<Lesson>
@@ -465,18 +470,47 @@ const notebookFiles = import.meta.glob('/content/lessons/**/Phase_*_Solutions.ip
 /** Parse notebook files and map each one to a phase number. */
 function parseNotebooks(): Notebook[] {
   return Object.entries(notebookFiles)
-    .map(([path, raw]) => {
-      const phaseMatch = path.match(/Phase_(\d+)/)
-      const phaseValue = phaseMatch?.[1]
-      const phase = phaseValue ? parseInt(phaseValue, 10) : 0
-      try {
-        const nb = JSON.parse(raw) as { cells: NotebookCell[] }
-        return { phase, cells: nb.cells || [] }
-      } catch {
-        return { phase, cells: [] }
-      }
-    })
+    .map(([path, raw]) =>
+      parseNotebookEntry(path, raw, { attachParseError: Boolean(import.meta.env.DEV) }),
+    )
     .sort((a, b) => a.phase - b.phase)
+}
+
+type ParseNotebookEntryOptions = {
+  attachParseError?: boolean
+}
+
+export function parseNotebookEntry(
+  path: string,
+  raw: string,
+  options: ParseNotebookEntryOptions = {},
+): Notebook {
+  const phaseMatch = path.match(/Phase_(\d+)/)
+  const phaseValue = phaseMatch?.[1]
+  const phase = phaseValue ? parseInt(phaseValue, 10) : 0
+
+  try {
+    const nb = JSON.parse(raw) as { cells?: NotebookCell[] }
+    return { phase, cells: nb.cells || [] }
+  } catch (error) {
+    console.warn(
+      `[contentLoader] Failed to parse notebook JSON for phase ${phase} at ${path}.`,
+      error,
+    )
+
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      phase,
+      cells: [],
+      parseError: options.attachParseError
+        ? {
+            path,
+            phase,
+            message,
+          }
+        : undefined,
+    }
+  }
 }
 
 let immutableNotebooks: readonly ImmutableNotebook[] | null = null


### PR DESCRIPTION
### Motivation
- Parsing Jupyter `.ipynb` files can fail when notebook JSON is invalid, and those failures should be visible to developers without breaking the production UX.
- Provide actionable diagnostics for the UI and developer tooling in development mode while keeping a safe empty-cell fallback in production.

### Description
- Added an optional `parseError` field to the `Notebook` interface to carry `path`, `phase`, and `message` for diagnostics when enabled.
- Refactored notebook parsing into a reusable `parseNotebookEntry(path, raw, options)` helper and made `parseNotebooks()` delegate to it, using `attachParseError: Boolean(import.meta.env.DEV)`.
- On JSON parse failures the loader now emits a non-fatal `console.warn` that includes the inferred phase and notebook path and returns an empty `cells` array to preserve UX.
- Added an invalid notebook fixture and tests that exercise both resilient fallback behavior and attaching `parseError` metadata when diagnostics are enabled.

### Testing
- Ran `npm run test -- src/utils/__tests__/contentLoader.test.ts` and the targeted test file passed all tests (`15 tests` passed).
- Ran `npm run typecheck` which failed due to unrelated, pre-existing TypeScript errors in other test files and not due to changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2bf9b8920833091e0c30a169d78d6)