### PR TITLE
Optimize glossary lookup in MarkdownRenderer and add regression tests

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -163,6 +163,9 @@ function createHeadingComponent(Tag: 'h1' | 'h2' | 'h3') {
 
 // Use global flag 'g' to iterate over matches without string slicing
 const glossaryRegex = new RegExp(getGlossaryRegex().source, 'gi')
+const glossaryDefinitionsByLowerTerm = Object.fromEntries(
+  Object.entries(glossaryTerms).map(([term, definition]) => [term.toLowerCase(), definition]),
+)
 
 /** Wrap only the first occurrence of each glossary term in a text node. */
 function addGlossaryTooltips(text: string): (string | JSX.Element)[] {
@@ -190,8 +193,7 @@ function addGlossaryTooltips(text: string): (string | JSX.Element)[] {
       parts.push(match[0])
     } else {
       matched.add(termLower)
-      const defKey = Object.keys(glossaryTerms).find((k) => k.toLowerCase() === termLower)
-      const definition = defKey ? glossaryTerms[defKey] : undefined
+      const definition = glossaryDefinitionsByLowerTerm[termLower]
 
       if (definition) {
         parts.push(

--- a/src/components/__tests__/MarkdownRenderer.test.tsx
+++ b/src/components/__tests__/MarkdownRenderer.test.tsx
@@ -245,4 +245,30 @@ It prints:
     expect(glossaryTerm?.textContent).toBe('function')
     expect(glossaryTerm?.getAttribute('data-definition')).toBeTruthy()
   })
+
+  it('renders glossary tooltips identically for repeated mixed-case terms', () => {
+    const content = 'Function function VARIABLE variable'
+    act(() => {
+      root.render(<MarkdownRenderer content={content} />)
+    })
+
+    const glossaryTerms = container.querySelectorAll('.glossary-term')
+    expect(glossaryTerms).toHaveLength(2)
+    expect(glossaryTerms[0]?.textContent).toBe('Function')
+    expect(glossaryTerms[1]?.textContent).toBe('VARIABLE')
+    expect(glossaryTerms[0]?.getAttribute('data-definition')).toBeTruthy()
+    expect(glossaryTerms[1]?.getAttribute('data-definition')).toBeTruthy()
+    expect(container.querySelector('p')?.textContent).toBe('Function function VARIABLE variable')
+  })
+
+  it('renders the same tooltip markup for glossary terms in running text', () => {
+    const content = 'A function takes an argument and another function.'
+    act(() => {
+      root.render(<MarkdownRenderer content={content} />)
+    })
+
+    expect(container.querySelector('p')?.innerHTML).toBe(
+      'A <span class="glossary-term" data-definition="A reusable block of code that performs a specific task.">function</span> takes an <span class="glossary-term" data-definition="A value passed to a function when it is called.">argument</span> and another function.',
+    )
+  })
 })


### PR DESCRIPTION
### Motivation
- Reduce per-match cost of finding a glossary definition by building a case-insensitive map once at module scope. 
- Preserve existing behavior that only the first occurrence of each glossary term in a paragraph becomes a tooltip. 

### Description
- Add a module-scope `glossaryDefinitionsByLowerTerm` map built from `glossaryTerms` keyed by lowercase terms. 
- Replace the per-match `Object.keys(...).find(...)` lookup with direct O(1) access using `glossaryDefinitionsByLowerTerm[termLower]`. 
- Keep the existing `matched` set logic so first-occurrence-per-paragraph behavior and displayed casing remain unchanged. 
- Add two regression tests in `src/components/__tests__/MarkdownRenderer.test.tsx` that verify repeated mixed-case terms and exact tooltip HTML markup render identically. 

### Testing
- Ran `npm run test -- src/components/__tests__/MarkdownRenderer.test.tsx` and all tests in that file passed (14 tests, 14 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2bfa9c63c833082d59e0165b37915)