### PR TITLE
Eager incremental search indexing with readiness state and first-search perf test

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,6 @@ import MobileNav from './components/MobileNav'
 import KeyboardShortcutsOverlay from './components/KeyboardShortcutsOverlay'
 import { PageSkeleton } from './components/Skeleton'
 import { ThemeProvider } from './context/ThemeProvider'
-import { preloadSearchIndex } from './utils/searchIndex'
 import { hydrateProgressStore } from './utils/progressTracker'
 import { hydrateQuizStore } from './stores/quizStore'
 import { useUserPreferencesStore } from './stores/userPreferencesStore'
@@ -51,7 +50,6 @@ export default function App() {
   useLearningAnalytics(location.pathname)
 
   useEffect(() => {
-    preloadSearchIndex()
     hydrateProgressStore()
     hydrateQuizStore()
     hydrateGamificationStore()

--- a/src/components/SearchPalette.tsx
+++ b/src/components/SearchPalette.tsx
@@ -7,7 +7,13 @@
 
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { getSearchSnippet, search, type SearchResult } from '../utils/searchIndex'
+import {
+  getSearchSnippet,
+  getSearchIndexStatus,
+  search,
+  subscribeSearchIndexStatus,
+  type SearchResult,
+} from '../utils/searchIndex'
 import { difficultyConfig } from '../utils/contentLoader'
 import { useDebounce } from '../hooks/useDebounce'
 
@@ -45,6 +51,7 @@ export default function SearchPalette({ isOpen, onClose }: SearchPaletteProps) {
 
   const debouncedQuery = useDebounce(query, 300, shouldResetImmediately)
   const [activeIndex, setActiveIndex] = useState(0)
+  const [indexStatus, setIndexStatus] = useState(getSearchIndexStatus)
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
   const navigate = useNavigate()
@@ -74,6 +81,10 @@ export default function SearchPalette({ isOpen, onClose }: SearchPaletteProps) {
   /**
    * Scrolls active result item into view when selection changes.
    */
+  useEffect(() => {
+    return subscribeSearchIndexStatus(setIndexStatus)
+  }, [])
+
   useEffect(() => {
     const list = listRef.current
     if (!list) return
@@ -220,7 +231,15 @@ export default function SearchPalette({ isOpen, onClose }: SearchPaletteProps) {
           </div>
         )}
 
-        {debouncedQuery.trim().length >= 2 && results.length === 0 && (
+        {debouncedQuery.trim().length >= 2 && results.length === 0 && !indexStatus.isReady && (
+          <div className="search-empty">
+            <p>
+              Indexing lessons… ({indexStatus.processedCount}/{indexStatus.totalCount})
+            </p>
+          </div>
+        )}
+
+        {debouncedQuery.trim().length >= 2 && results.length === 0 && indexStatus.isReady && (
           <div className="search-empty">
             <svg
               className="search-empty-icon"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,7 +17,10 @@ import { Toaster } from 'react-hot-toast'
 import App from './App'
 import { TOAST_DEFAULT_OPTIONS } from './utils/toast'
 import ErrorBoundary from './components/ErrorBoundary'
+import { preloadSearchIndex } from './utils/searchIndex'
 import './styles/index.css'
+
+preloadSearchIndex()
 
 /**
  * Renders the React application into the DOM.

--- a/src/utils/__tests__/searchIndex-functions.test.ts
+++ b/src/utils/__tests__/searchIndex-functions.test.ts
@@ -148,8 +148,8 @@ _Italic_
     expect(requestIdleCallback).toHaveBeenCalled()
   })
 
-  it('runs search function', () => {
+  it('runs search function before chunks are processed', () => {
     const results = search('python')
-    expect(results.length).toBeGreaterThan(0)
+    expect(results).toEqual([])
   })
 })

--- a/src/utils/__tests__/searchIndex.perf.test.ts
+++ b/src/utils/__tests__/searchIndex.perf.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const lessons = Array.from({ length: 1500 }, (_, i) => ({
+  day: String(i + 1),
+  daySortKey: String(i + 1).padStart(5, '0') + ':',
+  title: i === 1499 ? 'Corporate Finance Search Target' : `Lesson ${i + 1}`,
+  phase: 1,
+  tags: ['finance', 'mba'],
+  concepts: ['valuation'],
+  content: `Long lesson ${i + 1} content `.repeat(20),
+  path: `/fake/${i + 1}`,
+}))
+
+vi.mock('../contentLoader', () => ({
+  getAllLessons: () => lessons,
+}))
+
+describe('searchIndex first-search performance', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    if (!window.requestIdleCallback) {
+      window.requestIdleCallback = vi.fn((cb) => {
+        const id = setTimeout(cb, 1)
+        return Number(id)
+      }) as any
+    }
+  })
+
+  it('keeps first-search latency low while indexing in background', async () => {
+    const { preloadSearchIndex, search } = await import('../searchIndex')
+
+    preloadSearchIndex()
+
+    const start = performance.now()
+    const immediateResults = search('corporate finance')
+    const elapsedMs = performance.now() - start
+
+    expect(immediateResults).toEqual([])
+    expect(elapsedMs).toBeLessThan(50)
+
+    let laterResults = search('corporate finance')
+    for (let i = 0; i < 20 && laterResults.length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      laterResults = search('corporate finance')
+    }
+
+    expect(laterResults.length).toBeGreaterThan(0)
+  })
+})

--- a/src/utils/__tests__/searchIndex.test.ts
+++ b/src/utils/__tests__/searchIndex.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const lessons = [
   {
@@ -29,10 +29,10 @@ vi.mock('../contentLoader', () => ({
 
 let search: (query: string, limit?: number) => unknown[]
 let preloadSearchIndex: () => void
+let getSearchIndexStatus: () => { isReady: boolean; processedCount: number; totalCount: number }
 
 beforeEach(async () => {
   vi.resetModules()
-  // Mock requestIdleCallback if it doesn't exist (Vitest env usually has window but maybe not RIC)
   if (!window.requestIdleCallback) {
     window.requestIdleCallback = vi.fn((cb) => {
       const id = setTimeout(cb, 1)
@@ -43,6 +43,7 @@ beforeEach(async () => {
   const mod = await import('../searchIndex')
   search = mod.search
   preloadSearchIndex = mod.preloadSearchIndex
+  getSearchIndexStatus = mod.getSearchIndexStatus
 })
 
 afterEach(() => {
@@ -55,23 +56,32 @@ describe('searchIndex', () => {
     expect(search('   ')).toEqual([])
   })
 
-  it('finds and ranks likely results by relevance (synchronous fallback)', () => {
-    // Calling search() immediately forces the index to build synchronously
+  it('returns empty before any docs are processed and then returns partial results', async () => {
+    expect(search('python')).toEqual([])
+
+    await new Promise((resolve) => setTimeout(resolve, 5))
+
     const results = search('python')
     expect(results.length).toBeGreaterThan(0)
     expect((results[0] as { item: { day: string } }).item.day).toBe('11')
   })
 
-  it('respects result limit', () => {
+  it('respects result limit', async () => {
+    preloadSearchIndex()
+    await new Promise((resolve) => setTimeout(resolve, 5))
+
     const results = search('11B', 1)
     expect(results.length).toBe(1)
   })
 
-  it('supports background preloading via preloadSearchIndex', async () => {
-    // Start background indexing
+  it('supports background preloading via preloadSearchIndex and reports readiness progress', async () => {
     preloadSearchIndex()
+    await new Promise((resolve) => setTimeout(resolve, 5))
 
-    // Even if background indexing is "in progress", search() should force finish it and return results
+    const status = getSearchIndexStatus()
+    expect(status.totalCount).toBe(2)
+    expect(status.processedCount).toBeGreaterThan(0)
+
     const results = search('sql')
     expect(results.length).toBeGreaterThan(0)
     expect((results[0] as { item: { title: string } }).item.title).toContain('SQL')

--- a/src/utils/searchIndex.ts
+++ b/src/utils/searchIndex.ts
@@ -33,6 +33,13 @@ export interface SearchResult {
   score?: number
 }
 
+export interface SearchIndexStatus {
+  isReady: boolean
+  isIndexing: boolean
+  processedCount: number
+  totalCount: number
+}
+
 const TITLE_WEIGHT = 8
 const CONCEPT_WEIGHT = 4
 const TAG_WEIGHT = 3
@@ -139,19 +146,55 @@ export function createSearchEngine(lessons = getAllLessons()): Fuse<SearchDocume
 }
 
 let cachedEngine: Fuse<SearchDocument> | null = null
+let partialEngine: Fuse<SearchDocument> | null = null
 const processedDocs: SearchDocument[] = []
 let indexingComplete = false
 let isIndexing = false
 let currentIndex = 0
+let allLessonsCache: readonly Lesson[] | null = null
+const statusListeners = new Set<(status: SearchIndexStatus) => void>()
+
+function getAllLessonsCached(): readonly Lesson[] {
+  if (!allLessonsCache) {
+    allLessonsCache = getAllLessons()
+  }
+  return allLessonsCache
+}
+
+function emitStatus() {
+  const status = getSearchIndexStatus()
+  statusListeners.forEach((listener) => listener(status))
+}
+
+export function getSearchIndexStatus(): SearchIndexStatus {
+  const lessons = getAllLessonsCached()
+  return {
+    isReady: indexingComplete,
+    isIndexing,
+    processedCount: processedDocs.length,
+    totalCount: lessons.length,
+  }
+}
+
+export function subscribeSearchIndexStatus(
+  listener: (status: SearchIndexStatus) => void,
+): () => void {
+  statusListeners.add(listener)
+  listener(getSearchIndexStatus())
+  return () => {
+    statusListeners.delete(listener)
+  }
+}
 
 function processChunk() {
   if (indexingComplete || cachedEngine) {
     indexingComplete = true
     isIndexing = false
+    emitStatus()
     return
   }
 
-  const allLessons = getAllLessons()
+  const allLessons = getAllLessonsCached()
   const startTime = performance.now()
   const CHUNK_TIME_LIMIT = 12 // ms
 
@@ -162,6 +205,9 @@ function processChunk() {
     }
     currentIndex++
   }
+
+  partialEngine = new Fuse(processedDocs, FUSE_OPTIONS)
+  emitStatus()
 
   if (currentIndex < allLessons.length) {
     if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
@@ -175,15 +221,18 @@ function processChunk() {
     }
   } else {
     // Finished
-    cachedEngine = new Fuse(processedDocs, FUSE_OPTIONS)
+    cachedEngine = partialEngine
+    partialEngine = null
     indexingComplete = true
     isIndexing = false
+    emitStatus()
   }
 }
 
 export function startBackgroundIndexing(): void {
   if (isIndexing || indexingComplete || cachedEngine) return
   isIndexing = true
+  emitStatus()
 
   if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
     ;(
@@ -196,29 +245,19 @@ export function startBackgroundIndexing(): void {
   }
 }
 
-function getEngine(): Fuse<SearchDocument> {
+function getEngine(): Fuse<SearchDocument> | null {
   if (cachedEngine) return cachedEngine
-
-  // If background indexing is in progress or not started, force finish it
-  const allLessons = getAllLessons()
-  while (currentIndex < allLessons.length) {
-    const lesson = allLessons[currentIndex]
-    if (lesson) {
-      processedDocs.push(toDocument(lesson))
-    }
-    currentIndex++
+  if (!isIndexing) {
+    startBackgroundIndexing()
   }
-
-  cachedEngine = new Fuse(processedDocs, FUSE_OPTIONS)
-  indexingComplete = true
-  isIndexing = false
-
-  return cachedEngine
+  return partialEngine
 }
 
 export function search(query: string, limit = 20): SearchResult[] {
   if (!query.trim()) return []
-  const rawResults = getEngine().search(query, { limit: Math.max(limit * 2, 20) })
+  const engine = getEngine()
+  if (!engine) return []
+  const rawResults = engine.search(query, { limit: Math.max(limit * 2, 20) })
 
   return rawResults
     .map((result) => ({


### PR DESCRIPTION
### Motivation

- Make the client search index build eagerly (in background) at app boot so the UI can surface progress and avoid blocking user keystrokes.  
- Avoid the previous synchronous while-loop forced build on the keystroke path to keep first-search latency low.  
- Provide a small API to let UI components show partial results or an “indexing…” message while documents are still being processed.

### Description

- Added a readiness/progress API in `src/utils/searchIndex.ts`: `getSearchIndexStatus`, `subscribeSearchIndexStatus`, `SearchIndexStatus`, and status emission as chunks are processed.  
- Implemented incremental idle-chunk indexing with a `partialEngine` built per chunk and removed the synchronous full-build fallback in `getEngine()` so `search()` no longer blocks; `search()` will query the partial engine or return empty until the first chunk is ready.  
- Triggered eager background indexing at application startup by calling `preloadSearchIndex()` from `src/main.tsx`.  
- Updated `src/components/SearchPalette.tsx` to subscribe to index status and show an “Indexing lessons… (processed/total)” message when a query returns no results but indexing is still in progress, while keeping the normal “No results found” message after the index is ready.  
- Added/updated tests: adjusted unit tests in `src/utils/__tests__/searchIndex.test.ts` and `src/utils/__tests__/searchIndex-functions.test.ts` for partial-index behavior and added a first-search latency benchmark test in `src/utils/__tests__/searchIndex.perf.test.ts`.

### Testing

- Ran targeted unit and perf tests with `vitest` for the modified files using `npm run test -- src/utils/__tests__/searchIndex.test.ts src/utils/__tests__/searchIndex-functions.test.ts src/utils/__tests__/searchIndex.perf.test.ts`, and all targeted tests passed (3 test files, 14 tests).  
- Observed a first-search latency assertion in the perf test confirming immediate searches remain low-latency while indexing proceeds in the background.  
- Ran `npm run typecheck` earlier which surfaced unrelated TypeScript errors in other test files; those were unrelated to the search-index changes and did not block the targeted test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2bfaf24ac833088a0d5ea674a8777)