### PR TITLE
Improve markdown token preservation for search indexing

### DIFF
--- a/src/utils/__tests__/searchIndex-functions.test.ts
+++ b/src/utils/__tests__/searchIndex-functions.test.ts
@@ -40,6 +40,32 @@ const lessons: Lesson[] = [
     content: 'Body also mentions python variables in plain text.',
     path: '/fake/3',
   },
+  {
+    day: '4',
+    daySortKey: '00004:',
+    title: 'Python Naming and Tooling',
+    phase: 1,
+    tags: ['style guide'],
+    concepts: ['naming conventions'],
+    content: `
+### Variable Naming Conventions
+
+In professional Python (following PEP 8 style guide):
+
+\`\`\`python
+# Variables and functions: snake_case
+customer_lifetime_value = 2500
+monthly-recurring-revenue = 45000
+\`\`\`
+
+- Read [NumPy Documentation](https://numpy.org/doc/)
+- Review [Pandas Documentation](https://pandas.pydata.org/docs/)
+1. Prefer clear names for feature-engineering pipelines.
+
+Photon is Databricks' C++ query engine for SQL workloads.
+`,
+    path: '/fake/4',
+  },
 ]
 
 // Mock getAllLessons if it was imported directly, but here passing lessons explicitly to createSearchDocuments
@@ -57,10 +83,11 @@ describe('search index', () => {
     vi.restoreAllMocks()
   })
 
-  it('creates plain content without fenced code blocks', () => {
+  it('creates plain content without fence markers', () => {
     const docs = createSearchDocuments(lessons)
     expect(docs[0]?.plainContent).toContain('Variables store values')
-    expect(docs[0]?.plainContent).not.toContain('print("ignore me")')
+    expect(docs[0]?.plainContent).toContain('print("ignore me")')
+    expect(docs[0]?.plainContent).not.toContain('```python')
   })
 
   it('strips complex markdown correctly', () => {
@@ -100,6 +127,19 @@ _Italic_
     expect(plain).toContain('Italic')
   })
 
+  it('preserves technical tokens from lesson markdown structures', () => {
+    const docs = createSearchDocuments([lessons[3]!])
+    const plain = docs[0]?.plainContent ?? ''
+
+    expect(plain).toContain('snake_case')
+    expect(plain).toContain('monthly-recurring-revenue')
+    expect(plain).toContain('C++')
+    expect(plain).toContain('NumPy Documentation')
+    expect(plain).toContain('Pandas Documentation')
+    expect(plain).not.toContain('```')
+    expect(plain).not.toContain('[NumPy Documentation]')
+  })
+
   it('applies stronger ranking for title > concepts > tags > body', () => {
     const docs = createSearchDocuments(lessons)
     const [titleDoc, tagDoc, conceptDoc] = docs
@@ -119,12 +159,28 @@ _Italic_
     expect(results[0]?.item.day).toBe('1')
   })
 
+  it('maintains recall for technical identifier queries', () => {
+    const engine = createSearchEngine(lessons)
+
+    expect(engine.search('snake_case')[0]?.item.day).toBe('4')
+    expect(engine.search('c++ query engine')[0]?.item.day).toBe('4')
+    expect(engine.search('numpy documentation')[0]?.item.day).toBe('4')
+  })
+
   it('generates correct snippets', () => {
     const content =
       'This is a long text containing the keyword python in the middle of the sentence.'
     const snippet = getSearchSnippet(content, 'python', 20)
     expect(snippet).toContain('python')
     expect(snippet.length).toBeLessThan(50)
+  })
+
+  it('generates compact snippets for technical queries', () => {
+    const doc = createSearchDocuments([lessons[3]!])[0]!
+    const snippet = getSearchSnippet(doc.plainContent, 'c++ query engine', 28)
+
+    expect(snippet.toLowerCase()).toContain('engine')
+    expect(snippet.length).toBeLessThanOrEqual(65)
   })
 
   it('handles empty query in snippet', () => {
@@ -139,11 +195,13 @@ _Italic_
     expect(snippet).toBe('Some content…')
   })
 
-  it('starts background indexing using requestIdleCallback', () => {
+  it('starts background indexing using requestIdleCallback', async () => {
+    vi.resetModules()
     const requestIdleCallback = vi.fn()
     window.requestIdleCallback = requestIdleCallback
 
-    startBackgroundIndexing()
+    const { startBackgroundIndexing: startFreshIndexing } = await import('../searchIndex')
+    startFreshIndexing()
 
     expect(requestIdleCallback).toHaveBeenCalled()
   })

--- a/src/utils/searchIndex.ts
+++ b/src/utils/searchIndex.ts
@@ -68,15 +68,25 @@ const FUSE_OPTIONS: IFuseOptions<SearchDocument> = {
  */
 function stripMarkdown(md: string): string {
   if (!md) return ''
+
   return (
     md
-      // Combined pass: Remove code blocks, inline code, and images
-      .replace(/```[\s\S]*?```|`[^`]*`|!\[[^\]]*\]\([^)]+\)/g, ' ')
-      // Pass 2: Extract text from links [text](url) -> text
-      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-      // Pass 3: Remove list markers (ordered/unordered), headers, blockquotes, horizontal rules
-      .replace(/(^\s*\d+\.\s+|^\s*[-*+]\s+|[#_~>|]+)/gm, ' ')
-      // Pass 4: Collapse whitespace
+      // Keep code content and remove fence markers (` ```python ` / ` ``` `).
+      .replace(/```[^\n]*\n?/g, ' ')
+      // Keep identifier-like tokens from inline code while dropping wrapping ticks.
+      .replace(/`([^`]+)`/g, '$1')
+      // Keep human-readable alt text and link text.
+      .replace(/!\[([^\]]*)\]\([^)]+\)/g, ' $1 ')
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, ' $1 ')
+      // Remove structural markdown syntax without touching intra-token punctuation.
+      .replace(/^\s{0,3}(?:[-*+]|\d+\.)\s+/gm, ' ')
+      .replace(/^\s{0,3}>\s?/gm, ' ')
+      .replace(/^\s{0,3}#{1,6}\s+/gm, ' ')
+      .replace(/^\s{0,3}(?:[-*_]\s*){3,}$/gm, ' ')
+      // Remove emphasis markers only when used as wrappers around words.
+      .replace(/(\*\*|__|~~)(?=\S)([\s\S]*?\S)\1/g, '$2')
+      .replace(/(^|\s)([*_])(?=\S)([^\n]*?\S)\2(?=\s|$)/g, '$1$3')
+      // Collapse whitespace deterministically.
       .replace(/\s+/g, ' ')
       .trim()
   )


### PR DESCRIPTION
### Motivation
- Improve search indexing so technical identifier-like tokens (`snake_case`, `kebab-case`, `C++`, etc.) are preserved while stripping markdown scaffolding. 
- Use deterministic, low-allocation regex passes to keep search normalization performant and predictable. 
- Add lesson-derived test cases covering code snippets, links, lists, and snippet/recall behavior for technical queries to prevent regressions.

### Description
- Rewrote `stripMarkdown` in `src/utils/searchIndex.ts` to perform ordered, focused regex passes that remove fence markers while keeping fenced code content, unwrap inline code ticks, extract link text and alt text, remove list/header/blockquote/hr wrappers, strip emphasis wrappers, and deterministically collapse whitespace. 
- Kept intra-token punctuation intact so identifier-like tokens (e.g. `snake_case`, `monthly-recurring-revenue`, `C++`) remain searchable. 
- Added a lesson-style test fixture and assertions to `src/utils/__tests__/searchIndex-functions.test.ts` that include fenced code, links, and lists, plus new tests for token preservation, technical-query recall (via `createSearchEngine`), and compact snippet generation. 
- Stabilized the background-indexing test by resetting modules and importing a fresh `startBackgroundIndexing` to reliably assert `requestIdleCallback` invocation in test environments.

### Testing
- Ran the focused test suite with `npm test -- src/utils/__tests__/searchIndex-functions.test.ts` and all tests passed (`12 passed`).
- The staged typecheck task executed during the commit hook (`npm run typecheck:staged`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c1a03a3083308eb13f1e8dce1126)