### PR TITLE
Fix CI typecheck failures and silence build warnings

### DIFF
--- a/api/gemini/_shared.d.ts
+++ b/api/gemini/_shared.d.ts
@@ -10,6 +10,29 @@ export class InternalApiError extends Error {
 
 export function handleGenerate(req: IncomingMessage, res: ServerResponse): Promise<void>
 export function handleEmbed(req: IncomingMessage, res: ServerResponse): Promise<void>
+export function parseJsonBody(req: NodeJS.EventEmitter): Promise<unknown>
+export function checkRateLimit(
+  req: {
+    headers?: Record<string, string | string[] | undefined>
+    socket?: { remoteAddress?: string | null }
+    auth?: { userId?: string }
+    sessionID?: string
+    session?: { id?: string }
+  },
+  endpoint: string,
+  maxRequests: number,
+  windowMs: number,
+  options?: {
+    now?: number
+    cleanupEveryNRequests?: number
+    maxEntries?: number
+  },
+): {
+  allowed: boolean
+  retryAfterSeconds: number
+}
+export function __resetRateLimitStore(): void
+export function __getRateLimitEntries(): Array<[string, { count: number; resetAt: number }]>
 export function withErrorHandling(
   handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>,
   req: IncomingMessage,

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -341,3 +341,52 @@
   - Concepts: demographic parity and equalized odds, dataset bias, model bias audit, red-teaming LLMs, AI transparency and disclosure
 - [Day 120: Capstone: Build an AI-Powered Data Assistant](https://saint2706.github.io/Coding-For-MBA/#/lesson/120)
   - Concepts: end-to-end LLM application, RAG + agents + evaluation, production-ready deployment, responsible AI principles
+
+### [Phase 11: Cloud Data Engineering](https://saint2706.github.io/Coding-For-MBA/#/phase/11)
+
+**Lessons:**
+- [Day 121: Cloud Fundamentals — AWS, GCP, Azure](https://saint2706.github.io/Coding-For-MBA/#/lesson/121)
+  - Concepts: cloud computing models (IaaS, PaaS, SaaS), shared responsibility model, IAM (Identity and Access Management), regions and availability zones, cloud cost management
+- [Day 122: Object Storage — S3, GCS, Delta Lake, Iceberg](https://saint2706.github.io/Coding-For-MBA/#/lesson/122)
+  - Concepts: object storage vs block storage, data lake architecture, open table formats (Delta Lake, Iceberg), partitioning strategies, lifecycle policies
+- [Day 123: Cloud Data Warehouses — BigQuery, Snowflake, Redshift](https://saint2706.github.io/Coding-For-MBA/#/lesson/123)
+  - Concepts: columnar storage, massively parallel processing (MPP), compute-storage separation, slots vs virtual warehouses, materialized views
+- [Day 124: dbt at Scale — Incremental Models, Snapshots, Advanced Patterns](https://saint2706.github.io/Coding-For-MBA/#/lesson/124)
+  - Concepts: incremental models, dbt snapshots (SCD Type 2), Jinja macros and packages, dbt tests and contracts, model governance
+- [Day 125: Orchestration — Apache Airflow, Prefect, Dagster](https://saint2706.github.io/Coding-For-MBA/#/lesson/125)
+  - Concepts: directed acyclic graphs (DAGs), task dependencies and scheduling, idempotency in data pipelines, retry strategies and alerting, orchestrator selection
+- [Day 126: Streaming Pipelines — Kafka, Pub/Sub, Kinesis](https://saint2706.github.io/Coding-For-MBA/#/lesson/126)
+  - Concepts: event-driven architecture, topics, partitions, and consumer groups, exactly-once vs at-least-once delivery, stream processing patterns, windowing (tumbling, sliding, session)
+- [Day 127: Lakehouse Architecture — Databricks, Unity Catalog, Delta Live Tables](https://saint2706.github.io/Coding-For-MBA/#/lesson/127)
+  - Concepts: lakehouse paradigm, Unity Catalog for data governance, Delta Live Tables for declarative ETL, medallion architecture at scale, photon engine optimization
+- [Day 128: Data Contracts and Quality — Great Expectations, Soda, SLAs](https://saint2706.github.io/Coding-For-MBA/#/lesson/128)
+  - Concepts: data contracts between producers and consumers, expectation suites and validation, data SLAs and SLOs, schema validation and profiling, anomaly detection on data
+- [Day 129: Cloud Security and Compliance — VPC, Encryption, PII](https://saint2706.github.io/Coding-For-MBA/#/lesson/129)
+  - Concepts: network security (VPC, subnets, security groups), encryption at rest and in transit, PII detection and masking, compliance frameworks (GDPR, HIPAA, SOC 2), secrets management
+- [Day 130: Cost Engineering — FinOps for Data Platforms](https://saint2706.github.io/Coding-For-MBA/#/lesson/130)
+  - Concepts: FinOps principles and culture, cost attribution and tagging, reserved vs on-demand vs spot, query cost optimization, storage tiering
+- [Day 131: Platform Engineering — Terraform, IaC, Self-Serve Infrastructure](https://saint2706.github.io/Coding-For-MBA/#/lesson/131)
+  - Concepts: Infrastructure as Code (IaC), Terraform resources and state, CI/CD for data pipelines, self-serve data infrastructure, GitOps for data platforms
+- [Day 132: Capstone — Cloud Data Pipeline End-to-End](https://saint2706.github.io/Coding-For-MBA/#/lesson/132)
+  - Concepts: end-to-end pipeline architecture, medallion architecture implementation, orchestrated ETL with quality gates, cost monitoring and optimization, production deployment checklist
+
+### [Phase 12: Analytics Engineering & Data Products](https://saint2706.github.io/Coding-For-MBA/#/phase/12)
+
+**Lessons:**
+- [Day 133: The Analytics Engineer Role — Beyond the Data Analyst](https://saint2706.github.io/Coding-For-MBA/#/lesson/133)
+  - Concepts: analytics engineer vs data analyst vs data scientist vs data engineer, the analytics engineering workflow, dbt as the analytics engineer's tool, data team structures, career progression paths
+- [Day 134: Semantic and Metrics Layers — Define Once, Use Everywhere](https://saint2706.github.io/Coding-For-MBA/#/lesson/134)
+  - Concepts: semantic layer architecture, metric definitions and governance, dbt Semantic Layer and MetricFlow, Cube.js for headless BI, LookML for Looker
+- [Day 135: Self-Serve Analytics — Empowering Stakeholders Without Chaos](https://saint2706.github.io/Coding-For-MBA/#/lesson/135)
+  - Concepts: self-serve analytics spectrum, guardrails vs gatekeeping, data catalogs and discovery, no-code/low-code analytics tools, measuring self-serve adoption
+- [Day 136: Data Mesh Principles — Domain Ownership and Federated Governance](https://saint2706.github.io/Coding-For-MBA/#/lesson/136)
+  - Concepts: four principles of data mesh, domain-oriented ownership, data as a product, self-serve data platform, federated computational governance
+- [Day 137: Product Analytics Deep Dive — Retention, Funnels, Cohorts](https://saint2706.github.io/Coding-For-MBA/#/lesson/137)
+  - Concepts: product analytics frameworks, retention curves and cohort analysis, funnel analysis and conversion optimization, engagement metrics (DAU/MAU, stickiness), product-led growth metrics
+- [Day 138: A/B Testing at Scale — Statistical Rigor and Experimentation Platforms](https://saint2706.github.io/Coding-For-MBA/#/lesson/138)
+  - Concepts: hypothesis testing and p-values, sample size calculation and power, multiple testing correction, experimentation platforms, sequential testing and peeking
+- [Day 139: Data Products and Monetization — Building Revenue from Data](https://saint2706.github.io/Coding-For-MBA/#/lesson/139)
+  - Concepts: types of data products, data monetization strategies, embedded analytics, data-as-a-service, pricing models for data products
+- [Day 140: Capstone — Design and Pitch a Data Product](https://saint2706.github.io/Coding-For-MBA/#/lesson/140)
+  - Concepts: end-to-end data product design, business case development, technical architecture for data products, go-to-market strategy, stakeholder presentation
+

--- a/scripts/vite-plugin-critical-css.ts
+++ b/scripts/vite-plugin-critical-css.ts
@@ -7,23 +7,34 @@
  * Uses beasties (the maintained fork of critters).
  */
 
-import type { Plugin } from 'vite'
+import path from 'node:path'
+
+import type { Plugin, ResolvedConfig } from 'vite'
 
 export default function criticalCss(): Plugin {
+  let resolvedConfig: ResolvedConfig | null = null
+
   return {
     name: 'vite-plugin-critical-css',
     apply: 'build',
     enforce: 'post',
 
+    configResolved(config) {
+      resolvedConfig = config
+    },
+
     async transformIndexHtml(html: string) {
       try {
         const { default: Beasties } = await import('beasties')
+        const outDir = resolvedConfig?.build.outDir ?? 'dist'
+        const rootDir = resolvedConfig?.root ?? process.cwd()
         const beasties = new Beasties({
-          path: '', // not used since we pass HTML directly
-          publicPath: '',
+          path: path.resolve(rootDir, outDir),
+          publicPath: resolvedConfig?.base ?? '/',
           inlineFonts: false,
           preload: 'swap',
           pruneSource: false,
+          logLevel: 'error',
         })
         return await beasties.process(html)
       } catch {

--- a/src/utils/__tests__/geminiErrorHandling.test.ts
+++ b/src/utils/__tests__/geminiErrorHandling.test.ts
@@ -31,17 +31,17 @@ describe('withErrorHandling', () => {
 
   it('maps validation errors to 400 with stable message', async () => {
     const req = {} as never
-    const res = createMockResponse() as never
+    const res = createMockResponse()
     const logger = vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
     const handleGenerate = vi.fn(async () => {
       throw new InternalApiError('validation', 'userMessage is required')
     })
 
-    await withErrorHandling(handleGenerate, req, res)
+    await withErrorHandling(handleGenerate, req, res as never)
 
     expect(res.statusCode).toBe(400)
-    expect(JSON.parse((res as MockResponse).body)).toEqual({
+    expect(JSON.parse(res.body)).toEqual({
       error: { type: 'validation', message: 'Invalid request' },
     })
     expect(logger).toHaveBeenCalled()
@@ -49,7 +49,7 @@ describe('withErrorHandling', () => {
 
   it('maps rate-limit errors to 429 and keeps retry-after header', async () => {
     const req = {} as never
-    const res = createMockResponse() as never
+    const res = createMockResponse()
 
     const handleGenerate = vi.fn(async () => {
       throw new InternalApiError('rate_limit', 'Rate limit exceeded', {
@@ -57,59 +57,59 @@ describe('withErrorHandling', () => {
       })
     })
 
-    await withErrorHandling(handleGenerate, req, res)
+    await withErrorHandling(handleGenerate, req, res as never)
 
     expect(res.statusCode).toBe(429)
-    expect((res as MockResponse).headers.get('Retry-After')).toBe('7')
-    expect(JSON.parse((res as MockResponse).body)).toEqual({
+    expect(res.headers.get('Retry-After')).toBe('7')
+    expect(JSON.parse(res.body)).toEqual({
       error: { type: 'rate_limit', message: 'Too many requests' },
     })
   })
 
   it('maps upstream errors to 502 with service unavailable message', async () => {
     const req = {} as never
-    const res = createMockResponse() as never
+    const res = createMockResponse()
 
     const handleEmbed = vi.fn(async () => {
       throw new InternalApiError('upstream', 'Provider timeout: socket hang up')
     })
 
-    await withErrorHandling(handleEmbed, req, res)
+    await withErrorHandling(handleEmbed, req, res as never)
 
     expect(res.statusCode).toBe(502)
-    expect(JSON.parse((res as MockResponse).body)).toEqual({
+    expect(JSON.parse(res.body)).toEqual({
       error: { type: 'upstream', message: 'Service unavailable' },
     })
   })
 
   it('maps config errors to 503 with service unavailable message', async () => {
     const req = {} as never
-    const res = createMockResponse() as never
+    const res = createMockResponse()
 
     const handleEmbed = vi.fn(async () => {
       throw new InternalApiError('config', 'Server missing GEMINI_API_KEY')
     })
 
-    await withErrorHandling(handleEmbed, req, res)
+    await withErrorHandling(handleEmbed, req, res as never)
 
     expect(res.statusCode).toBe(503)
-    expect(JSON.parse((res as MockResponse).body)).toEqual({
+    expect(JSON.parse(res.body)).toEqual({
       error: { type: 'config', message: 'Service unavailable' },
     })
   })
 
   it('maps unexpected errors to 500 and internal server error message', async () => {
     const req = {} as never
-    const res = createMockResponse() as never
+    const res = createMockResponse()
 
     const handleGenerate = vi.fn(async () => {
       throw new Error('socket reset by peer')
     })
 
-    await withErrorHandling(handleGenerate, req, res)
+    await withErrorHandling(handleGenerate, req, res as never)
 
     expect(res.statusCode).toBe(500)
-    expect(JSON.parse((res as MockResponse).body)).toEqual({
+    expect(JSON.parse(res.body)).toEqual({
       error: { type: 'unexpected', message: 'Internal server error' },
     })
   })

--- a/src/utils/__tests__/parseJsonBody.test.ts
+++ b/src/utils/__tests__/parseJsonBody.test.ts
@@ -20,7 +20,7 @@ describe('parseJsonBody', () => {
     const settleSpy = vi.fn()
     promise.then(
       () => settleSpy('resolved'),
-      (error) => settleSpy(`rejected:${(error as Error).message}`),
+      (error: unknown) => settleSpy(`rejected:${(error as Error).message}`),
     )
 
     req.emit('data', 'x'.repeat(100_001))

--- a/src/utils/__tests__/searchIndex-functions.test.ts
+++ b/src/utils/__tests__/searchIndex-functions.test.ts
@@ -5,7 +5,6 @@ import {
   computeRankingBoost,
   getSearchSnippet,
   search,
-  startBackgroundIndexing,
 } from '../searchIndex'
 import type { Lesson } from '../contentLoader'
 


### PR DESCRIPTION
### Motivation
- Resolve TypeScript typecheck failures in CI caused by missing test-facing exports and tighten test typings to remove `never`/implicit `any` errors.
- Silence noisy build-time warnings from the Beasties critical-CSS plugin by using resolved build paths and reducing its logging.

### Description
- Added missing declarations in `api/gemini/_shared.d.ts` for `parseJsonBody`, `checkRateLimit`, `__resetRateLimitStore`, and `__getRateLimitEntries` so tests can import and type-check these helpers.
- Adjusted tests in `src/utils/__tests__/*` to use a properly typed mock response and typed rejection callbacks, and removed an unused import from `searchIndex-functions.test.ts` to satisfy strict checks.
- Reworked `scripts/vite-plugin-critical-css.ts` to use `configResolved` (resolved `outDir`/`root`/`base`) and set Beasties `logLevel: 'error'` to prevent noisy stylesheet warnings during production builds.
- Regenerated `public/llms.txt` as part of the validated build output (committed updated content for new phases/lessons).

### Testing
- Ran `npm run typecheck` and it completed successfully with no errors.
- Ran `npm_config_loglevel=error npm test` (Vitest) and all tests passed (`58` test files, `335` tests total).
- Ran `npm_config_loglevel=error npm run build` and the production build completed successfully with no new warnings from Beasties.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c2a2be888330815b1597be094d76)