### PR TITLE
Support VITE_GEMINI_API_KEY as fallback for Gemini backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The frontend no longer calls Google Gemini APIs directly. It now calls backend e
 ### Environment Variables
 
 - `GEMINI_API_KEY` (**server only**): real Gemini key used by backend handlers.
+  - Backward-compatible fallback: `VITE_GEMINI_API_KEY` is also accepted on the server (useful if your GitHub secret is already named this way).
 - `VITE_GEMINI_API_BASE` (optional, frontend): base URL for backend API if it is hosted separately. Leave empty for same-origin (`/api/...`).
 
 ### Local Development

--- a/api/gemini/_shared.js
+++ b/api/gemini/_shared.js
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto'
 
-const GEMINI_API_KEY = process.env.GEMINI_API_KEY
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY || process.env.VITE_GEMINI_API_KEY
 
 const GENERATE_URL =
   'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent'


### PR DESCRIPTION
### Motivation

- The backend previously required `GEMINI_API_KEY` but many CI/Secrets setups (including this repo) may store the key as `VITE_GEMINI_API_KEY`, so a compatibility fallback is needed. 

### Description

- Accept `VITE_GEMINI_API_KEY` on the server by changing the lookup to `process.env.GEMINI_API_KEY || process.env.VITE_GEMINI_API_KEY` in `api/gemini/_shared.js`. 
- Document the fallback in the README under the Gemini environment variables so maintainers know the supported secret names. 

### Testing

- Ran type checking with `npm run lint:ci` which completed successfully. 
- Ran unit tests `npm test -- src/utils/__tests__/geminiErrorHandling.test.ts src/utils/__tests__/geminiRateLimitStore.test.ts` and all tests passed (2 files, 12 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c54043688330b30f63d9241b81fa)