### PR TITLE
Polish reading-focused UI with calmer visual styling

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -6,9 +6,13 @@ html {
 
 body {
   font-family: var(--font-body);
-  background: var(--bg-primary);
+  background:
+    radial-gradient(circle at 20% -10%, rgba(99, 102, 241, 0.14), transparent 38%),
+    var(--bg-primary);
   color: var(--text-primary);
-  line-height: calc(1.7 * var(--density-scale, 1));
+  line-height: calc(1.75 * var(--density-scale, 1));
+  letter-spacing: 0.005em;
+  text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   overflow-x: hidden;
@@ -33,6 +37,16 @@ a:hover {
 img {
   max-width: 100%;
   height: auto;
+}
+
+::selection {
+  background: color-mix(in srgb, var(--accent-primary) 34%, transparent);
+  color: var(--text-heading);
+}
+
+:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent-primary) 68%, white 32%);
+  outline-offset: 2px;
 }
 
 /* --- Accessibility --- */
@@ -134,7 +148,7 @@ img {
 .page-container {
   max-width: var(--content-max-width);
   margin: 0 auto;
-  padding: 2.5rem var(--page-padding) 4rem;
+  padding: 2.75rem var(--page-padding) 4rem;
 }
 
 .page-container.lesson-with-toc {

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -1,8 +1,10 @@
 /* ===== MARKDOWN RENDERER ===== */
 
 .markdown-body {
-  line-height: 1.8;
+  line-height: 1.85;
   color: var(--text-primary);
+  max-width: var(--reading-max-width);
+  font-size: clamp(1rem, 0.97rem + 0.2vw, 1.08rem);
 }
 
 .markdown-body > *:first-child {
@@ -10,16 +12,16 @@
 }
 
 .markdown-body h1 {
-  font-size: 2rem;
+  font-size: clamp(1.9rem, 1.55rem + 1.2vw, 2.35rem);
   font-weight: 800;
   color: var(--text-heading);
-  margin: 1rem 0 1rem;
+  margin: 1.2rem 0 1rem;
   line-height: 1.2;
   letter-spacing: -0.02em;
 }
 
 .markdown-body h2 {
-  font-size: 1.5rem;
+  font-size: clamp(1.35rem, 1.2rem + 0.7vw, 1.72rem);
   font-weight: 700;
   color: var(--text-heading);
   margin: 2.5rem 0 1rem;
@@ -28,7 +30,7 @@
 }
 
 .markdown-body h3 {
-  font-size: 1.25rem;
+  font-size: clamp(1.18rem, 1.08rem + 0.45vw, 1.35rem);
   font-weight: 600;
   color: var(--text-heading);
   margin: 2rem 0 0.75rem;
@@ -42,17 +44,18 @@
 }
 
 .markdown-body p {
-  margin-bottom: 1rem;
+  margin-bottom: 1.1rem;
+  color: color-mix(in srgb, var(--text-primary) 94%, white 6%);
 }
 
 .markdown-body ul,
 .markdown-body ol {
   padding-left: 1.5rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.2rem;
 }
 
 .markdown-body li {
-  margin-bottom: 0.375rem;
+  margin-bottom: 0.45rem;
 }
 
 .markdown-body li > ul,
@@ -72,9 +75,9 @@
 
 .markdown-body blockquote {
   border-left: 3px solid var(--accent-primary);
-  padding: 0.75rem 1.25rem;
-  margin: 1.25rem 0;
-  background: rgba(99, 102, 241, 0.05);
+  padding: 0.9rem 1.25rem;
+  margin: 1.4rem 0;
+  background: color-mix(in srgb, var(--accent-primary) 9%, transparent);
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
   color: var(--text-secondary);
 }
@@ -269,4 +272,15 @@
   left: 1px;
   font-size: 0.75rem;
   color: white;
+}
+
+.markdown-body :is(h1, h2, h3, h4) {
+  scroll-margin-top: calc(var(--navbar-height) + 1.25rem);
+}
+
+@media (max-width: 900px) {
+  .markdown-body {
+    max-width: 100%;
+    font-size: clamp(0.98rem, 0.94rem + 0.28vw, 1.03rem);
+  }
 }

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -6,9 +6,9 @@
   left: var(--sidebar-width);
   right: 0;
   height: var(--navbar-height);
-  background: rgba(11, 15, 26, 0.8);
-  backdrop-filter: blur(20px) saturate(1.2);
-  -webkit-backdrop-filter: blur(20px) saturate(1.2);
+  background: color-mix(in srgb, var(--bg-primary) 80%, transparent);
+  backdrop-filter: blur(14px) saturate(1.08);
+  -webkit-backdrop-filter: blur(14px) saturate(1.08);
   border-bottom: 1px solid var(--border-subtle);
   display: flex;
   align-items: center;
@@ -57,7 +57,10 @@
   font-size: 0.875rem;
   font-weight: 500;
   color: var(--text-secondary);
-  transition: all var(--transition-fast);
+  transition:
+    color var(--transition-fast),
+    background var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .navbar-links a:hover {

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -6,7 +6,7 @@
   left: 0;
   bottom: 0;
   width: var(--sidebar-width);
-  background: var(--bg-secondary);
+  background: color-mix(in srgb, var(--bg-secondary) 94%, transparent);
   border-right: 1px solid var(--border-subtle);
   z-index: 210;
   display: flex;
@@ -57,6 +57,7 @@
   flex: 1;
   overflow-y: auto;
   padding: 0.75rem 0 1rem;
+  scrollbar-gutter: stable;
 }
 
 .sidebar-close {
@@ -90,7 +91,9 @@
   font-size: 0.8125rem;
   font-weight: 500;
   text-align: left;
-  transition: all var(--transition-fast);
+  transition:
+    color var(--transition-fast),
+    background var(--transition-fast);
 }
 
 .phase-toggle:hover {
@@ -138,7 +141,10 @@
   font-size: 0.8125rem;
   color: var(--text-muted);
   text-decoration: none;
-  transition: all var(--transition-fast);
+  transition:
+    color var(--transition-fast),
+    background var(--transition-fast),
+    border-color var(--transition-fast);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/styles/ux-features.css
+++ b/src/styles/ux-features.css
@@ -2,25 +2,25 @@
 
 /* ---------- Light Theme ---------- */
 :root[data-theme='light'] {
-  --bg-primary: #f8fafc;
-  --bg-secondary: #f1f5f9;
+  --bg-primary: #f7f8fc;
+  --bg-secondary: #eff3f8;
   --bg-card: #ffffff;
-  --bg-card-hover: #f1f5f9;
+  --bg-card-hover: #f3f6fb;
   --bg-surface: #ffffff;
-  --bg-code: #f1f5f9;
+  --bg-code: #f4f6fa;
 
-  --text-primary: #1e293b;
-  --text-secondary: #475569;
-  --text-muted: #94a3b8;
-  --text-heading: #0f172a;
+  --text-primary: #243248;
+  --text-secondary: #455a78;
+  --text-muted: #7284a0;
+  --text-heading: #111b2d;
 
   --accent-primary: #6366f1;
   --accent-secondary: #7c3aed;
   --accent-tertiary: #8b5cf6;
   --accent-glow: rgba(99, 102, 241, 0.12);
 
-  --border-subtle: rgba(148, 163, 184, 0.15);
-  --border-card: rgba(148, 163, 184, 0.2);
+  --border-subtle: rgba(124, 144, 175, 0.2);
+  --border-card: rgba(124, 144, 175, 0.25);
   --border-active: rgba(99, 102, 241, 0.5);
 
   --gradient-hero: linear-gradient(135deg, #6366f1 0%, #8b5cf6 40%, #a78bfa 100%);

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -12,18 +12,18 @@
 /* --- Custom Properties --- */
 :root {
   /* Background */
-  --bg-primary: #0b0f1a;
-  --bg-secondary: #111827;
-  --bg-card: #1a1f35;
-  --bg-card-hover: #222842;
-  --bg-surface: #151b2e;
-  --bg-code: #1e2540;
+  --bg-primary: #0f1526;
+  --bg-secondary: #141d32;
+  --bg-card: #1a243b;
+  --bg-card-hover: #212f4c;
+  --bg-surface: #172039;
+  --bg-code: #1d2842;
 
   /* Text */
-  --text-primary: #f1f5f9;
-  --text-secondary: #94a3b8;
-  --text-muted: #64748b;
-  --text-heading: #ffffff;
+  --text-primary: #e5ebf5;
+  --text-secondary: #b7c1d4;
+  --text-muted: #8793a9;
+  --text-heading: #f8fbff;
 
   /* Accent */
   --accent-primary: #6366f1;
@@ -32,8 +32,8 @@
   --accent-glow: rgba(99, 102, 241, 0.25);
 
   /* Borders */
-  --border-subtle: rgba(148, 163, 184, 0.08);
-  --border-card: rgba(148, 163, 184, 0.12);
+  --border-subtle: rgba(176, 191, 219, 0.12);
+  --border-card: rgba(176, 191, 219, 0.18);
   --border-active: rgba(99, 102, 241, 0.4);
 
   /* Gradients */
@@ -58,6 +58,7 @@
   --sidebar-width: 300px;
   --navbar-height: 64px;
   --content-max-width: 900px;
+  --reading-max-width: 74ch;
   --page-padding: 2rem;
 
   /* Radius */


### PR DESCRIPTION
### Motivation
- Reduce harsh contrast and visual noise to make long-form content easier to read and scan. 
- Improve overall UI smoothness and legibility by tuning tokens, spacing, and subtle interaction feedback.

### Description
- Tuned core design tokens for the dark theme and adjusted light-theme overrides in `src/styles/variables.css` and `src/styles/ux-features.css` to a softer, calmer palette and updated border translucency. 
- Added a `--reading-max-width` token and adjusted global typography and background treatment in `src/styles/base.css` to improve legibility and add a subtle visual wash. 
- Enhanced markdown reading ergonomics in `src/styles/markdown.css` with constrained line length, responsive heading and body sizing, increased paragraph/list rhythm, softened blockquotes, and heading `scroll-margin-top`. 
- Softened navbar/sidebar glass effects and narrowed interactive transitions in `src/styles/navbar.css` and `src/styles/sidebar.css` to make navigation feel less noisy.

### Testing
- Ran type checking with `npm run typecheck` which completed successfully. 
- Ran the test suite with `npm test` (Vitest) and all tests passed: `335 tests, 58 files` (status: all ✅). 
- Ran formatting checks and fixed files with `npx prettier --write` and rechecked with `npm run format:check` to ensure consistent formatting. 
- Exercised the UI via a Playwright script: Chromium headless crashed in this environment (SIGSEGV), then retried with Firefox which succeeded and produced a homepage screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c68d9a0c8330a57736b51146e11e)