### PR TITLE
Add persistent readingMode preference and reading-focused lesson UI

### DIFF
--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -51,6 +51,7 @@ import { useSwipe } from '../hooks/useSwipe'
 import { toastInfo, toastSuccess } from '../utils/toast'
 import { isTypingInEditableElement } from '../utils/shortcuts'
 import { useGamificationStore } from '../stores/gamificationStore'
+import { useUserPreferencesStore } from '../stores/userPreferencesStore'
 import {
   triggerSparkle,
   triggerPhaseUnlockConfetti,
@@ -78,10 +79,55 @@ export default function Lesson() {
   const navigate = useNavigate()
   const lesson = getLesson(dayNum!)
   const { prev, next } = getAdjacentLessons(dayNum!)
+  const readingModePreference = useUserPreferencesStore((state) => state.readingMode)
+  const setReadingModePreference = useUserPreferencesStore((state) => state.setReadingMode)
+  const [readingMode, setReadingMode] = useState(readingModePreference)
+  const [isMediumWidth, setIsMediumWidth] = useState(false)
+  const [nearBottom, setNearBottom] = useState(false)
   const [completed, setCompleted] = useState(() =>
     dayNum ? isLessonComplete(dayTokenToProgressId(dayNum)) : false,
   )
   const lastToastAtRef = useRef(0)
+
+  useEffect(() => {
+    setReadingMode(readingModePreference)
+  }, [readingModePreference, dayNum])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const mediaQuery = window.matchMedia('(max-width: 1200px)')
+    const syncWidth = () => setIsMediumWidth(mediaQuery.matches)
+    syncWidth()
+    mediaQuery.addEventListener('change', syncWidth)
+    return () => mediaQuery.removeEventListener('change', syncWidth)
+  }, [])
+
+  useEffect(() => {
+    const updateNearBottom = () => {
+      const maxScrollable = document.documentElement.scrollHeight - window.innerHeight
+      if (maxScrollable <= 0) {
+        setNearBottom(true)
+        return
+      }
+      const scrollRatio = window.scrollY / maxScrollable
+      setNearBottom(scrollRatio > 0.78)
+    }
+    updateNearBottom()
+    window.addEventListener('scroll', updateNearBottom, { passive: true })
+    window.addEventListener('resize', updateNearBottom)
+    return () => {
+      window.removeEventListener('scroll', updateNearBottom)
+      window.removeEventListener('resize', updateNearBottom)
+    }
+  }, [lesson?.day])
+
+  const handleReadingMode = useCallback(
+    (value: boolean) => {
+      setReadingMode(value)
+      setReadingModePreference(value)
+    },
+    [setReadingModePreference],
+  )
 
   // Track last visited lesson
   useEffect(() => {
@@ -117,13 +163,13 @@ export default function Lesson() {
       const afterCompleted = getCompletedLessons()
       const wasPhaseCompleted = lesson
         ? getLessonsByPhase(lesson.phase).every((entry) =>
-          beforeCompleted.has(dayTokenToProgressId(entry.day)),
-        )
+            beforeCompleted.has(dayTokenToProgressId(entry.day)),
+          )
         : false
       const isPhaseCompleted = lesson
         ? getLessonsByPhase(lesson.phase).every((entry) =>
-          afterCompleted.includes(dayTokenToProgressId(entry.day)),
-        )
+            afterCompleted.includes(dayTokenToProgressId(entry.day)),
+          )
         : false
 
       if (lesson && !wasPhaseCompleted && isPhaseCompleted) {
@@ -192,9 +238,14 @@ export default function Lesson() {
   const lessonTitle = `Day ${lesson.day}: ${lesson.title}`
   const lessonDescription = `Day ${lesson.day} of Phase ${lesson.phase}: ${lesson.title}. Part of the 108-day Coding for MBA curriculum.`
   const lessonPath = `/lesson/${lesson.day}`
+  const showTableOfContents = !(readingMode && isMediumWidth)
+  const showSecondaryUi = !readingMode || nearBottom
 
   return (
-    <div className="page-container lesson-with-toc" ref={swipeRef}>
+    <div
+      className={`page-container lesson-with-toc ${readingMode ? 'reading-mode' : ''}`}
+      ref={swipeRef}
+    >
       <SEOHead
         title={lessonTitle}
         description={lessonDescription}
@@ -217,6 +268,17 @@ export default function Lesson() {
       />
       {/* Main content column */}
       <div className="lesson-main-content">
+        {readingMode && (
+          <button
+            type="button"
+            className="reading-mode-exit"
+            onClick={() => handleReadingMode(false)}
+            aria-label="Exit reading mode"
+          >
+            Exit reading mode
+          </button>
+        )}
+
         {/* Breadcrumb */}
         <div className="lesson-header">
           <Breadcrumb
@@ -227,12 +289,15 @@ export default function Lesson() {
             ]}
           />
 
-          <motion.div className="lesson-day-badge" layoutId={`lesson-day-badge-${lesson.day}`}>
+          <motion.div
+            className={`lesson-day-badge ${showSecondaryUi ? '' : 'reading-muted'}`}
+            layoutId={`lesson-day-badge-${lesson.day}`}
+          >
             Day {lesson.day}
           </motion.div>
 
           {/* Meta bar */}
-          <div className="lesson-meta-bar">
+          <div className={`lesson-meta-bar ${showSecondaryUi ? '' : 'reading-muted'}`}>
             <span className="difficulty-badge" style={{ color: diff.color, background: diff.bg }}>
               {diff.label}
             </span>
@@ -246,16 +311,20 @@ export default function Lesson() {
               ))}
           </div>
 
-          <button
-            type="button"
-            className={`lesson-complete-btn ${completed ? 'completed' : ''}`}
-            onClick={handleToggleComplete}
-            aria-pressed={completed}
-          >
-            {completed ? '✓ Completed' : '○ Mark as Complete'}
-          </button>
+          {showSecondaryUi && (
+            <>
+              <button
+                type="button"
+                className={`lesson-complete-btn ${completed ? 'completed' : ''}`}
+                onClick={handleToggleComplete}
+                aria-pressed={completed}
+              >
+                {completed ? '✓ Completed' : '○ Mark as Complete'}
+              </button>
 
-          <PrerequisitePills lesson={lesson} />
+              <PrerequisitePills lesson={lesson} />
+            </>
+          )}
         </div>
 
         {/* Markdown content wrapped in semantic article tag */}
@@ -283,20 +352,24 @@ export default function Lesson() {
           )}
         </nav>
 
-        <RelatedLessons lesson={lesson} />
+        <div className={showSecondaryUi ? '' : 'reading-muted'}>
+          <RelatedLessons lesson={lesson} />
+        </div>
 
-        <BackToTop />
+        {!readingMode && <BackToTop />}
       </div>
 
       {/* Table of Contents sidebar */}
-      <TableOfContents content={lesson.content} />
+      {showTableOfContents && <TableOfContents content={lesson.content} />}
 
       {/* AI Study Assistant */}
-      <AiStudyPanel
-        lessonContent={lesson.content}
-        lessonDay={lesson.day}
-        lessonTitle={lesson.title}
-      />
+      {!readingMode && (
+        <AiStudyPanel
+          lessonContent={lesson.content}
+          lessonDay={lesson.day}
+          lessonTitle={lesson.title}
+        />
+      )}
     </div>
   )
 }

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -92,11 +92,13 @@ export default function ProgressDashboard() {
     fontSize,
     codeLanguage,
     density,
+    readingMode,
     setTheme,
     setSidebarDefaultOpen,
     setFontSize,
     setCodeLanguage,
     setDensity,
+    setReadingMode,
   } = useUserPreferencesStore()
 
   return (
@@ -348,6 +350,23 @@ export default function ProgressDashboard() {
               Open sidebar on new pages
             </span>
             <small id="sidebar-default-help">You can still toggle the sidebar anytime.</small>
+          </label>
+
+          <label className="preferences-field preferences-toggle" htmlFor="reading-mode-default">
+            Reading mode
+            <span className="preferences-toggle-row">
+              <input
+                id="reading-mode-default"
+                type="checkbox"
+                checked={readingMode}
+                onChange={(event) => setReadingMode(event.target.checked)}
+                aria-describedby="reading-mode-help"
+              />
+              Start lessons in reading mode
+            </span>
+            <small id="reading-mode-help">
+              Focus on lesson text with reduced interface chrome.
+            </small>
           </label>
         </div>
       </section>

--- a/src/stores/userPreferencesStore.ts
+++ b/src/stores/userPreferencesStore.ts
@@ -25,11 +25,13 @@ export type UserPreferencesStore = {
   fontSize: FontSizePreference
   codeLanguage: CodeLanguagePreference
   density: DensityPreference
+  readingMode: boolean
   setTheme: (theme: ThemePreference) => void
   setSidebarDefaultOpen: (open: boolean) => void
   setFontSize: (size: FontSizePreference) => void
   setCodeLanguage: (language: CodeLanguagePreference) => void
   setDensity: (density: DensityPreference) => void
+  setReadingMode: (readingMode: boolean) => void
 }
 
 const STORAGE_KEY = 'coding-for-mba-user-preferences'
@@ -88,15 +90,17 @@ export const useUserPreferencesStore = create<UserPreferencesStore>()(
       fontSize: 'md',
       codeLanguage: 'python',
       density: 'comfortable',
+      readingMode: false,
       setTheme: (theme) => set({ theme }),
       setSidebarDefaultOpen: (sidebarDefaultOpen) => set({ sidebarDefaultOpen }),
       setFontSize: (fontSize) => set({ fontSize }),
       setCodeLanguage: (codeLanguage) => set({ codeLanguage }),
       setDensity: (density) => set({ density }),
+      setReadingMode: (readingMode) => set({ readingMode }),
     }),
     {
       name: STORAGE_KEY,
-      version: 1,
+      version: 2,
       storage: createJSONStorage(() => safeStorage),
       partialize: (state) => ({
         theme: state.theme,
@@ -104,6 +108,7 @@ export const useUserPreferencesStore = create<UserPreferencesStore>()(
         fontSize: state.fontSize,
         codeLanguage: state.codeLanguage,
         density: state.density,
+        readingMode: state.readingMode,
       }),
       migrate: (persistedState) => {
         const raw = (persistedState || {}) as Record<string, unknown>
@@ -114,6 +119,7 @@ export const useUserPreferencesStore = create<UserPreferencesStore>()(
           fontSize: normalizeFontSize(raw.fontSize),
           codeLanguage: normalizeCodeLanguage(raw.codeLanguage),
           density: normalizeDensity(raw.density),
+          readingMode: typeof raw.readingMode === 'boolean' ? raw.readingMode : false,
         }
       },
     },
@@ -122,3 +128,4 @@ export const useUserPreferencesStore = create<UserPreferencesStore>()(
 
 export const selectThemePreference = (state: UserPreferencesStore) => state.theme
 export const selectSidebarDefaultOpen = (state: UserPreferencesStore) => state.sidebarDefaultOpen
+export const selectReadingMode = (state: UserPreferencesStore) => state.readingMode

--- a/src/styles/lesson.css
+++ b/src/styles/lesson.css
@@ -111,3 +111,56 @@
   font-weight: 600;
   color: var(--text-primary);
 }
+
+.lesson-main-content > article {
+  max-width: 72ch;
+}
+
+.reading-mode {
+  --shadow-card: none;
+}
+
+.reading-mode .lesson-header {
+  border-bottom-color: rgba(148, 163, 184, 0.22);
+}
+
+.reading-mode .lesson-nav-btn,
+.reading-mode .toc {
+  box-shadow: none;
+  background: color-mix(in srgb, var(--bg-card) 88%, transparent);
+}
+
+.reading-mode-exit {
+  position: sticky;
+  top: calc(var(--navbar-height) + 0.5rem);
+  z-index: 20;
+  margin: 0 0 0.75rem auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-card);
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.reading-mode-exit:hover {
+  color: var(--text-primary);
+  border-color: var(--border-active);
+}
+
+.reading-muted {
+  opacity: 0.4;
+  filter: saturate(0.55);
+  transition: opacity var(--transition-fast);
+}
+
+@media (max-width: 1200px) {
+  .reading-mode .lesson-meta-bar {
+    margin-bottom: 0.75rem;
+  }
+}

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -44,7 +44,7 @@
 /* --- Lesson-with-TOC grid layout --- */
 .lesson-with-toc {
   display: grid;
-  grid-template-columns: minmax(0, var(--content-max-width)) 260px;
+  grid-template-columns: minmax(0, min(var(--content-max-width), 76ch)) 260px;
   gap: 2rem;
   align-items: start;
 }
@@ -207,14 +207,13 @@
   font-size: 0.75rem;
 }
 
-/* Hide ToC on small screens */
 @media (max-width: 1200px) {
-  .toc {
-    display: none;
-  }
-
   .lesson-with-toc {
     grid-template-columns: 1fr;
+  }
+
+  .reading-mode .toc {
+    display: none;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Provide a distraction-free, reading-focused lesson experience that users can opt into and persist across sessions. 
- Allow users to default to a simplified lesson view from Preferences so lessons can surface only the essential reading UI.

### Description
- Added a persisted `readingMode: boolean` to the Zustand user preferences store with `setReadingMode`, default `false`, migration handling, `partialize` inclusion and a selector export (`selectReadingMode`). (`src/stores/userPreferencesStore.ts`)
- Exposed a new toggle in the Progress Dashboard Preferences (`Start lessons in reading mode`) wired to the store setter so users can set their default lesson experience. (`src/pages/ProgressDashboard.tsx`)
- Updated the Lesson page to honor the preference by applying a `reading-mode` class to the root lesson container, adding a sticky `Exit reading mode` control, and conditionally simplifying UI: hide ToC on medium/small widths when in reading mode, mute metadata chips and related sections until scrolled near the bottom, and keep only content, breadcrumb, and next/previous navigation visible during reading sessions. (`src/pages/Lesson.tsx`)
- Added CSS adjustments to support reading mode and improved prose layout: tuned content `max-width` for readable prose, reduced shadows/background chrome in reading mode, styles for the pinned `Exit reading mode` control, and a `.reading-muted` style to de-emphasize secondary UI. (`src/styles/lesson.css`, `src/styles/navigation.css`)

### Testing
- Ran type checking with `npm run typecheck` which completed successfully.
- Ran formatting checks with `npx prettier --check` on the modified files which passed for the changed files; general `npm run format:check` reported unrelated pre-existing style warnings in other files not touched by this change.
- Started the dev server to validate UI wiring (`vite` via `npm run dev`) and attempted an automated Playwright screenshot to validate the reading-mode view, but the Chromium process crashed in this container environment (SIGSEGV) so no screenshot artifact could be captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c8a68bcc833089f124baba443574)