### PR TITLE
Add compact responsive TOC for sub-1200px viewports

### DIFF
--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -10,7 +10,7 @@
  * - Hide if insufficient headings exist.
  */
 
-import { useMemo, useState, useEffect } from 'react'
+import { useMemo, useState, useEffect, useId, type MouseEvent } from 'react'
 import { parseHeadings } from '../utils/toc'
 
 interface TableOfContentsProps {
@@ -20,6 +20,9 @@ interface TableOfContentsProps {
 export default function TableOfContents({ content }: TableOfContentsProps) {
   const headings = useMemo(() => parseHeadings(content), [content])
   const [activeId, setActiveId] = useState<string>('')
+  const [isCompact, setIsCompact] = useState(false)
+  const [isCompactOpen, setIsCompactOpen] = useState(false)
+  const tocListId = useId()
 
   /**
    * Sets up IntersectionObserver to track which heading is currently visible.
@@ -47,27 +50,79 @@ export default function TableOfContents({ content }: TableOfContentsProps) {
     return () => observer.disconnect()
   }, [headings])
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const mediaQuery = window.matchMedia('(max-width: 1200px)')
+    const syncCompact = () => {
+      const nextCompactState = mediaQuery.matches
+      setIsCompact(nextCompactState)
+
+      if (!nextCompactState) {
+        setIsCompactOpen(false)
+      }
+    }
+
+    syncCompact()
+    mediaQuery.addEventListener('change', syncCompact)
+
+    return () => mediaQuery.removeEventListener('change', syncCompact)
+  }, [])
+
+  useEffect(() => {
+    if (!isCompactOpen) return
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsCompactOpen(false)
+      }
+    }
+
+    window.addEventListener('keydown', handleEscape)
+    return () => window.removeEventListener('keydown', handleEscape)
+  }, [isCompactOpen])
+
+  const handleHeadingClick = (event: MouseEvent<HTMLAnchorElement>, headingId: string) => {
+    event.preventDefault()
+    const el = document.getElementById(headingId)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      el.focus({ preventScroll: true })
+      setActiveId(headingId)
+      setIsCompactOpen(false)
+    }
+  }
+
   if (headings.length < 2) return null
 
   return (
-    <aside className="toc" aria-label="Table of contents">
+    <aside className={`toc ${isCompact ? 'toc-compact' : ''}`} aria-label="Table of contents">
       <div className="toc-title">On this page</div>
-      <nav>
-        <ul className="toc-list">
+      {isCompact && (
+        <button
+          type="button"
+          className="toc-toggle"
+          aria-expanded={isCompactOpen}
+          aria-controls={tocListId}
+          onClick={() => setIsCompactOpen((prev) => !prev)}
+        >
+          <span>Jump to section</span>
+          <span aria-hidden="true" className={`toc-toggle-chevron ${isCompactOpen ? 'open' : ''}`}>
+            ▾
+          </span>
+        </button>
+      )}
+      <nav id={tocListId} className={isCompact ? `toc-panel ${isCompactOpen ? 'open' : ''}` : ''}>
+        <ul
+          className="toc-list"
+          onKeyDown={(event) => event.key === 'Escape' && setIsCompactOpen(false)}
+        >
           {headings.map((h) => (
             <li key={h.id} className={h.level === 3 ? 'toc-sub' : ''}>
               <a
                 href={`#${h.id}`}
                 className={`toc-link ${activeId === h.id ? 'active' : ''}`}
-                onClick={(e) => {
-                  e.preventDefault()
-                  const el = document.getElementById(h.id)
-                  if (el) {
-                    el.scrollIntoView({ behavior: 'smooth', block: 'start' })
-                    el.focus({ preventScroll: true })
-                    setActiveId(h.id)
-                  }
-                }}
+                onClick={(event) => handleHeadingClick(event, h.id)}
               >
                 {h.text}
               </a>

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -82,7 +82,6 @@ export default function Lesson() {
   const readingModePreference = useUserPreferencesStore((state) => state.readingMode)
   const setReadingModePreference = useUserPreferencesStore((state) => state.setReadingMode)
   const [readingMode, setReadingMode] = useState(readingModePreference)
-  const [isMediumWidth, setIsMediumWidth] = useState(false)
   const [nearBottom, setNearBottom] = useState(false)
   const [completed, setCompleted] = useState(() =>
     dayNum ? isLessonComplete(dayTokenToProgressId(dayNum)) : false,
@@ -92,16 +91,6 @@ export default function Lesson() {
   useEffect(() => {
     setReadingMode(readingModePreference)
   }, [readingModePreference, dayNum])
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    const mediaQuery = window.matchMedia('(max-width: 1200px)')
-    const syncWidth = () => setIsMediumWidth(mediaQuery.matches)
-    syncWidth()
-    mediaQuery.addEventListener('change', syncWidth)
-    return () => mediaQuery.removeEventListener('change', syncWidth)
-  }, [])
-
   useEffect(() => {
     const updateNearBottom = () => {
       const maxScrollable = document.documentElement.scrollHeight - window.innerHeight
@@ -238,7 +227,6 @@ export default function Lesson() {
   const lessonTitle = `Day ${lesson.day}: ${lesson.title}`
   const lessonDescription = `Day ${lesson.day} of Phase ${lesson.phase}: ${lesson.title}. Part of the 108-day Coding for MBA curriculum.`
   const lessonPath = `/lesson/${lesson.day}`
-  const showTableOfContents = !(readingMode && isMediumWidth)
   const showSecondaryUi = !readingMode || nearBottom
 
   return (
@@ -360,7 +348,7 @@ export default function Lesson() {
       </div>
 
       {/* Table of Contents sidebar */}
-      {showTableOfContents && <TableOfContents content={lesson.content} />}
+      <TableOfContents content={lesson.content} />
 
       {/* AI Study Assistant */}
       {!readingMode && (

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -99,7 +99,8 @@
 
 .toc-link {
   display: block;
-  padding: 0.25rem 0.5rem;
+  min-height: 44px;
+  padding: 0.5rem 0.625rem;
   color: var(--text-muted);
   text-decoration: none;
   border-left: 2px solid transparent;
@@ -110,6 +111,7 @@
   line-height: 1.4;
   word-wrap: break-word;
   overflow-wrap: break-word;
+  white-space: normal;
 }
 
 .toc-link:hover {
@@ -212,8 +214,67 @@
     grid-template-columns: 1fr;
   }
 
-  .reading-mode .toc {
-    display: none;
+  .toc {
+    position: sticky;
+    bottom: 1rem;
+    top: auto;
+    width: 100%;
+    max-height: none;
+    margin-top: 1rem;
+    padding: 0.75rem;
+    z-index: 30;
+  }
+
+  .toc-title {
+    margin-bottom: 0.5rem;
+  }
+
+  .toc-toggle {
+    width: 100%;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.625rem 0.875rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-card);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .toc-toggle-chevron {
+    transition: transform var(--transition-fast);
+  }
+
+  .toc-toggle-chevron.open {
+    transform: rotate(180deg);
+  }
+
+  .toc-panel {
+    max-height: 0;
+    overflow: hidden;
+    opacity: 0;
+    transition:
+      max-height var(--transition-base),
+      opacity var(--transition-base),
+      margin-top var(--transition-base);
+  }
+
+  .toc-panel.open {
+    max-height: min(50vh, 420px);
+    opacity: 1;
+    overflow-y: auto;
+    margin-top: 0.625rem;
+  }
+
+  .toc-panel .toc-list li {
+    margin-bottom: 0.125rem;
+  }
+
+  .toc-panel .toc-link {
+    padding-block: 0.625rem;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Keep the existing desktop sticky TOC while providing a compact, touch-friendly TOC for smaller screens below `1200px` so users on tablets/phones can navigate without hiding the TOC entirely. 
- Preserve the current behavior of active-heading highlighting and smooth anchor jumps while improving accessibility and touch targets.

### Description
- Added a compact variant to `src/components/TableOfContents.tsx` that detects the `@media (max-width: 1200px)` breakpoint via `window.matchMedia`, presenting a toggle button and collapsible panel when active, and keeping the desktop sticky sidebar otherwise.
- Implemented accessibility and interaction improvements in the TOC: `aria-expanded` and `aria-controls` on the toggle, Escape-to-close handling, keyboard-friendly toggle, and close-on-select behavior for heading links; preserved existing IntersectionObserver-based active heading tracking and smooth scrolling.
- Updated `src/styles/navigation.css` to replace the previous `display: none` behavior under `@media (max-width: 1200px)` with a compact presentation (expandable panel), ensured touch targets are at least `44px` high, kept heading text wrapping (`white-space: normal`), and adjusted spacing for readability.
- Changed `src/pages/Lesson.tsx` to always mount `TableOfContents` (removed the previous conditional) so the component itself switches between desktop/compact modes based on viewport.

### Testing
- Ran type checking with `npm run typecheck`, which completed successfully.
- Ran unit tests for the TOC with `npm run test -- src/components/__tests__/TableOfContents.test.ts`, and the test suite passed (`1 test` passed).
- Ran formatting checks with `npx prettier --check src/components/TableOfContents.tsx src/styles/navigation.css src/pages/Lesson.tsx` and applied `prettier --write` where needed; final check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2ca00d6c88330ab08d750432d5444)