### PR TITLE
Add user preference toggle for custom cursor behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ const NotFound = lazy(() => import('./pages/NotFound'))
 
 export default function App() {
   const sidebarDefaultOpen = useUserPreferencesStore((state) => state.sidebarDefaultOpen)
+  const customCursorEnabled = useUserPreferencesStore((state) => state.customCursorEnabled)
   const [sidebarOpen, setSidebarOpen] = useState(sidebarDefaultOpen)
   const location = useLocation()
   const prefersReducedMotion = useReducedMotion()
@@ -109,7 +110,7 @@ export default function App() {
         </main>
         <MobileNav />
         <KeyboardShortcutsOverlay />
-        <CustomCursor />
+        {customCursorEnabled && <CustomCursor />}
       </div>
     </ThemeProvider>
   )

--- a/src/components/CustomCursor.tsx
+++ b/src/components/CustomCursor.tsx
@@ -28,11 +28,15 @@ export default function CustomCursor() {
   const prefersReducedMotion = useReducedMotion()
 
   useEffect(() => {
-    if (prefersReducedMotion || !isFinePointer()) return
-    setEnabled(true)
-
     const mql = window.matchMedia('(pointer: fine)')
-    const onChange = (e: MediaQueryListEvent) => setEnabled(e.matches)
+
+    const updateEnabled = (matches: boolean) => {
+      setEnabled(Boolean(matches && !prefersReducedMotion))
+    }
+
+    updateEnabled(mql.matches)
+
+    const onChange = (e: MediaQueryListEvent) => updateEnabled(e.matches)
     mql.addEventListener('change', onChange)
 
     return () => mql.removeEventListener('change', onChange)
@@ -62,7 +66,11 @@ export default function CustomCursor() {
   }, [])
 
   useEffect(() => {
-    if (!enabled) return
+    if (!enabled) {
+      document.documentElement.classList.remove('custom-cursor-active')
+      return
+    }
+
     document.documentElement.classList.add('custom-cursor-active')
     window.addEventListener('mousemove', handleMouseMove, { passive: true })
     window.addEventListener('mouseover', handleMouseOver, { passive: true })
@@ -76,7 +84,7 @@ export default function CustomCursor() {
     }
   }, [enabled, handleMouseMove, handleMouseOver, handleMouseOut])
 
-  if (!enabled) return null
+  if (!enabled || !isFinePointer()) return null
 
   return (
     <>

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -93,12 +93,14 @@ export default function ProgressDashboard() {
     codeLanguage,
     density,
     readingMode,
+    customCursorEnabled,
     setTheme,
     setSidebarDefaultOpen,
     setFontSize,
     setCodeLanguage,
     setDensity,
     setReadingMode,
+    setCustomCursorEnabled,
   } = useUserPreferencesStore()
 
   return (
@@ -366,6 +368,23 @@ export default function ProgressDashboard() {
             </span>
             <small id="reading-mode-help">
               Focus on lesson text with reduced interface chrome.
+            </small>
+          </label>
+
+          <label className="preferences-field preferences-toggle" htmlFor="custom-cursor-enabled">
+            Custom cursor
+            <span className="preferences-toggle-row">
+              <input
+                id="custom-cursor-enabled"
+                type="checkbox"
+                checked={customCursorEnabled}
+                onChange={(event) => setCustomCursorEnabled(event.target.checked)}
+                aria-describedby="custom-cursor-help"
+              />
+              Enable enhanced pointer effects on desktop
+            </span>
+            <small id="custom-cursor-help">
+              Disabled by default for a calmer reading experience.
             </small>
           </label>
         </div>

--- a/src/stores/userPreferencesStore.ts
+++ b/src/stores/userPreferencesStore.ts
@@ -26,12 +26,14 @@ export type UserPreferencesStore = {
   codeLanguage: CodeLanguagePreference
   density: DensityPreference
   readingMode: boolean
+  customCursorEnabled: boolean
   setTheme: (theme: ThemePreference) => void
   setSidebarDefaultOpen: (open: boolean) => void
   setFontSize: (size: FontSizePreference) => void
   setCodeLanguage: (language: CodeLanguagePreference) => void
   setDensity: (density: DensityPreference) => void
   setReadingMode: (readingMode: boolean) => void
+  setCustomCursorEnabled: (customCursorEnabled: boolean) => void
 }
 
 const STORAGE_KEY = 'coding-for-mba-user-preferences'
@@ -91,16 +93,18 @@ export const useUserPreferencesStore = create<UserPreferencesStore>()(
       codeLanguage: 'python',
       density: 'comfortable',
       readingMode: false,
+      customCursorEnabled: false,
       setTheme: (theme) => set({ theme }),
       setSidebarDefaultOpen: (sidebarDefaultOpen) => set({ sidebarDefaultOpen }),
       setFontSize: (fontSize) => set({ fontSize }),
       setCodeLanguage: (codeLanguage) => set({ codeLanguage }),
       setDensity: (density) => set({ density }),
       setReadingMode: (readingMode) => set({ readingMode }),
+      setCustomCursorEnabled: (customCursorEnabled) => set({ customCursorEnabled }),
     }),
     {
       name: STORAGE_KEY,
-      version: 2,
+      version: 3,
       storage: createJSONStorage(() => safeStorage),
       partialize: (state) => ({
         theme: state.theme,
@@ -109,6 +113,7 @@ export const useUserPreferencesStore = create<UserPreferencesStore>()(
         codeLanguage: state.codeLanguage,
         density: state.density,
         readingMode: state.readingMode,
+        customCursorEnabled: state.customCursorEnabled,
       }),
       migrate: (persistedState) => {
         const raw = (persistedState || {}) as Record<string, unknown>
@@ -120,6 +125,8 @@ export const useUserPreferencesStore = create<UserPreferencesStore>()(
           codeLanguage: normalizeCodeLanguage(raw.codeLanguage),
           density: normalizeDensity(raw.density),
           readingMode: typeof raw.readingMode === 'boolean' ? raw.readingMode : false,
+          customCursorEnabled:
+            typeof raw.customCursorEnabled === 'boolean' ? raw.customCursorEnabled : false,
         }
       },
     },

--- a/src/styles/ux-features.css
+++ b/src/styles/ux-features.css
@@ -618,6 +618,7 @@
   z-index: 99999;
   will-change: transform;
   mix-blend-mode: difference;
+  opacity: 0;
 }
 
 .custom-cursor-ring {
@@ -631,10 +632,17 @@
   pointer-events: none;
   z-index: 99998;
   will-change: transform;
+  opacity: 0;
   transition:
     border-color var(--transition-fast),
     width var(--transition-fast),
-    height var(--transition-fast);
+    height var(--transition-fast),
+    opacity var(--transition-fast);
+}
+
+.custom-cursor-active .custom-cursor-dot,
+.custom-cursor-active .custom-cursor-ring {
+  opacity: 1;
 }
 
 .custom-cursor-ring--hover {


### PR DESCRIPTION
### Motivation
- Provide users a way to opt in to the custom pointer effect while keeping the default reading experience calm by disabling the cursor enhancement by default.
- Ensure the custom cursor respects accessibility signals (reduced motion / non-fine pointers) and that no document-level `custom-cursor-active` class remains applied when the feature is disabled.

### Description
- Add `customCursorEnabled: boolean` and `setCustomCursorEnabled` to the persisted preferences store in `src/stores/userPreferencesStore.ts`, set default to `false`, and add migration/partialize support (storage version bumped to `3`).
- Expose a new `Custom cursor` toggle in `src/pages/ProgressDashboard.tsx` and wire it to the store via `setCustomCursorEnabled`.
- Render `<CustomCursor />` conditionally in `src/App.tsx` so the component is mounted only when `customCursorEnabled` is `true`.
- Update `src/components/CustomCursor.tsx` so reduced-motion and pointer checks remain enforced and the `custom-cursor-active` document class is explicitly removed when the feature is disabled.
- Scope the CSS in `src/styles/ux-features.css` so cursor elements are hidden by default and become visible only when `.custom-cursor-active` is present, preserving existing cursor selectors.

### Testing
- Ran `npm run typecheck` (`tsc`) which completed successfully.
- Ran `npm run format:check` (`prettier --check`) which reported pre-existing formatting warnings in unrelated files and therefore failed; no style changes introduced by this PR require fixing other files.
- Launched the dev server and executed an automated Playwright script to navigate to `/progress` and capture a screenshot of the Preferences UI showing the new toggle, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2cb08d820833082bb01970a5ad6ba)