### PR TITLE
Add scoped calm reading surface styling for lesson pages

### DIFF
--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -231,7 +231,7 @@ export default function Lesson() {
 
   return (
     <div
-      className={`page-container lesson-with-toc ${readingMode ? 'reading-mode' : ''}`}
+      className={`page-container lesson-with-toc lesson-reading-surface ${readingMode ? 'reading-mode' : ''}`}
       ref={swipeRef}
     >
       <SEOHead

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -154,3 +154,28 @@ img {
 .page-container.lesson-with-toc {
   max-width: calc(var(--content-max-width) + 260px + 2rem);
 }
+
+.lesson-reading-surface {
+  --bg-primary: var(--reading-bg-primary);
+  --bg-surface: var(--reading-bg-surface);
+  --bg-card: color-mix(in srgb, var(--reading-bg-surface) 94%, #1f2d49 6%);
+  --bg-card-hover: color-mix(in srgb, var(--reading-bg-surface) 90%, #243452 10%);
+  --bg-code: var(--reading-bg-code);
+  --border-subtle: var(--reading-border-subtle);
+  --border-card: var(--reading-border-card);
+  --border-active: var(--reading-border-active);
+  --accent-glow: var(--reading-accent-glow);
+  --gradient-card: linear-gradient(
+    145deg,
+    rgba(99, 102, 241, 0.03) 0%,
+    rgba(139, 92, 246, 0.02) 100%
+  );
+  --gradient-glow: none;
+  --shadow-card: 0 3px 18px rgba(0, 0, 0, 0.22);
+  --shadow-glow: none;
+}
+
+.lesson-reading-surface.page-container {
+  background:
+    radial-gradient(circle at 18% -18%, rgba(99, 102, 241, 0.06), transparent 45%), transparent;
+}

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -284,3 +284,53 @@
     font-size: clamp(0.98rem, 0.94rem + 0.28vw, 1.03rem);
   }
 }
+
+.lesson-reading-surface .markdown-body {
+  line-height: 1.92;
+  font-size: clamp(1.02rem, 0.99rem + 0.2vw, 1.1rem);
+}
+
+.lesson-reading-surface .markdown-body p {
+  margin-bottom: 1.2rem;
+  color: color-mix(in srgb, var(--text-primary) 96%, white 4%);
+}
+
+.lesson-reading-surface .markdown-body h2 {
+  margin-top: 2.65rem;
+  border-bottom-color: color-mix(in srgb, var(--border-subtle) 84%, transparent);
+}
+
+.lesson-reading-surface .markdown-body blockquote {
+  border-left-color: color-mix(in srgb, var(--accent-primary) 72%, var(--border-subtle) 28%);
+  background: color-mix(in srgb, var(--accent-primary) 6%, transparent);
+  color: color-mix(in srgb, var(--text-secondary) 94%, white 6%);
+}
+
+.lesson-reading-surface .markdown-body code:not(pre code) {
+  border-color: color-mix(in srgb, var(--border-card) 88%, transparent);
+  color: color-mix(in srgb, var(--accent-tertiary) 88%, var(--text-primary) 12%);
+}
+
+.lesson-reading-surface .markdown-body .code-block-wrapper,
+.lesson-reading-surface .markdown-body .table-wrapper,
+.lesson-reading-surface .markdown-body details {
+  border-color: color-mix(in srgb, var(--border-card) 84%, transparent);
+  box-shadow: none;
+}
+
+.lesson-reading-surface .markdown-body thead th {
+  background: color-mix(in srgb, var(--accent-primary) 5%, transparent);
+  border-bottom-color: color-mix(in srgb, var(--border-card) 88%, transparent);
+}
+
+.lesson-reading-surface .markdown-body tbody tr:hover {
+  background: transparent;
+}
+
+.lesson-reading-surface .markdown-body details summary {
+  background: color-mix(in srgb, var(--accent-primary) 4%, transparent);
+}
+
+.lesson-reading-surface .markdown-body details summary:hover {
+  background: color-mix(in srgb, var(--accent-primary) 6%, transparent);
+}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -49,6 +49,15 @@
     transparent 40%
   );
 
+  /* Calm reading surface */
+  --reading-bg-primary: #111a2c;
+  --reading-bg-surface: #162238;
+  --reading-bg-code: #1a253d;
+  --reading-border-subtle: rgba(176, 191, 219, 0.1);
+  --reading-border-card: rgba(176, 191, 219, 0.14);
+  --reading-border-active: rgba(139, 92, 246, 0.26);
+  --reading-accent-glow: rgba(99, 102, 241, 0.1);
+
   /* Shadows */
   --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.3);
   --shadow-elevated: 0 8px 40px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
### Motivation
- Provide a “calm reading” visual layer for lesson screens that tones down gradients, glows, border contrast and non-essential hover/shadow effects to prioritize typography and spacing.
- Ensure these softened styles are applied only on lesson pages so the homepage and feature pages retain stronger visual styling by scoping via a class on the lesson container.

### Description
- Introduce calm-reading design tokens in `src/styles/variables.css` (`--reading-...`) to centralize softer background, border, code and glow values. 
- Add a `.lesson-reading-surface` scope in `src/styles/base.css` that overrides a subset of CSS variables and reduces gradients/shadows for lesson containers. 
- Add scoped readability-focused rules in `src/styles/markdown.css` under `.lesson-reading-surface` to increase line-height/font-size, soften blockquote/table/code borders, remove non-essential hover highlights, and disable extra box-shadows in prose regions. 
- Apply the scope to the lesson container by adding the `lesson-reading-surface` class in `src/pages/Lesson.tsx` so the effect is limited to lesson pages.

### Testing
- Ran TypeScript typecheck with `npm run typecheck` (calls `tsc -b`) and it completed successfully. 
- Ran code formatting via `npx prettier --write` on affected files and the run completed successfully. 
- Launched a local dev server with `npm run dev` and captured a full-page lesson screenshot using a Playwright script to validate visual changes (`browser:/tmp/codex_browser_invocations/da6feef03aeac268/artifacts/artifacts/lesson-calm-reading.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2cc070d588330aa041b3d2687e7b0)