### PR TITLE
Increase minimum UI text sizes for markdown, TOC, and badges

### DIFF
--- a/src/styles/content-features.css
+++ b/src/styles/content-features.css
@@ -22,7 +22,7 @@
 }
 
 .prerequisite-label {
-  font-size: 0.6875rem;
+  font-size: 0.8125rem;
   font-weight: 600;
   color: #f59e0b;
   text-transform: uppercase;
@@ -38,7 +38,7 @@
   background: rgba(245, 158, 11, 0.1);
   border: 1px solid rgba(245, 158, 11, 0.2);
   border-radius: 100px;
-  font-size: 0.6875rem;
+  font-size: 0.8125rem;
   font-weight: 500;
   color: #fbbf24;
   text-decoration: none;
@@ -55,7 +55,7 @@
 
 .prerequisite-pill::before {
   content: '📋';
-  font-size: 0.625rem;
+  font-size: 0.8125rem;
 }
 
 /* --- Related Lessons --- */
@@ -101,7 +101,7 @@
 }
 
 .related-lesson-day {
-  font-size: 0.625rem;
+  font-size: 0.8125rem;
   font-weight: 600;
   color: var(--accent-tertiary);
   text-transform: uppercase;
@@ -123,8 +123,8 @@
 }
 
 .related-lesson-badge {
-  font-size: 0.5625rem;
-  padding: 0.125rem 0.375rem;
+  font-size: 0.8125rem;
+  padding: 0.1875rem 0.5rem;
   border-radius: 100px;
   font-weight: 600;
 }
@@ -136,8 +136,8 @@
 }
 
 .related-tag {
-  font-size: 0.5625rem;
-  padding: 0.0625rem 0.375rem;
+  font-size: 0.8125rem;
+  padding: 0.125rem 0.5rem;
   background: rgba(99, 102, 241, 0.08);
   border: 1px solid rgba(99, 102, 241, 0.12);
   border-radius: 100px;
@@ -217,7 +217,7 @@
   display: flex;
   align-items: center;
   gap: 0.375rem;
-  font-size: 0.6875rem;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
   cursor: pointer;
   padding: 0.25rem 0.5rem;
@@ -335,8 +335,8 @@
 }
 
 .graph-tooltip-concept {
-  font-size: 0.5625rem;
-  padding: 0.0625rem 0.375rem;
+  font-size: 0.8125rem;
+  padding: 0.125rem 0.5rem;
   background: rgba(99, 102, 241, 0.1);
   border-radius: 100px;
   color: var(--accent-tertiary);

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -61,7 +61,7 @@
   background: rgba(99, 102, 241, 0.12);
   border: 1px solid rgba(99, 102, 241, 0.2);
   border-radius: 100px;
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   font-weight: 600;
   color: var(--accent-tertiary);
   text-transform: uppercase;
@@ -105,7 +105,7 @@
 
 .continue-banner-title {
   margin: 0;
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   font-weight: 700;
   color: var(--accent-tertiary);
   text-transform: uppercase;
@@ -162,7 +162,7 @@
 }
 
 .hero-stat .stat-label {
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -261,7 +261,7 @@
 }
 
 .phase-card-title .phase-num {
-  font-size: 0.6875rem;
+  font-size: 0.8125rem;
   color: var(--accent-tertiary);
   font-weight: 600;
   text-transform: uppercase;
@@ -289,7 +289,7 @@
   padding: 0.25rem 0.625rem;
   background: rgba(148, 163, 184, 0.06);
   border-radius: 100px;
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   color: var(--text-muted);
 }
 
@@ -300,7 +300,7 @@
   gap: 0.25rem;
   padding: 0.1875rem 0.625rem;
   border-radius: 100px;
-  font-size: 0.6875rem;
+  font-size: 0.8125rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -123,10 +123,10 @@
 
 .code-block-lang {
   font-family: var(--font-mono);
-  font-size: 0.6875rem;
+  font-size: 0.8125rem;
   color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 1px;
+  letter-spacing: 0.08em;
 }
 
 .code-block-copy {
@@ -135,7 +135,7 @@
   border-radius: var(--radius-sm);
   color: var(--text-muted);
   cursor: pointer;
-  font-size: 0.6875rem;
+  font-size: 0.8125rem;
   padding: 0.25rem 0.5rem;
   font-family: var(--font-body);
   transition: all var(--transition-fast);
@@ -158,8 +158,8 @@
 
 .markdown-body pre code {
   font-family: var(--font-mono) !important;
-  font-size: 0.8125rem !important;
-  line-height: 1.65 !important;
+  font-size: 0.875rem !important;
+  line-height: 1.75 !important;
 }
 
 /* Tables */
@@ -173,7 +173,12 @@
 .markdown-body table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.875rem;
+  font-size: 0.9rem;
+}
+
+.markdown-body thead th,
+.markdown-body tbody td {
+  line-height: 1.5;
 }
 
 .markdown-body thead th {

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -76,9 +76,9 @@
 
 .toc-title {
   font-weight: 600;
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   text-transform: uppercase;
-  letter-spacing: 1px;
+  letter-spacing: 0.08em;
   color: var(--text-muted);
   margin-bottom: 0.75rem;
 }
@@ -101,6 +101,7 @@
   display: block;
   min-height: 44px;
   padding: 0.5rem 0.625rem;
+  font-size: 0.875rem;
   color: var(--text-muted);
   text-decoration: none;
   border-left: 2px solid transparent;
@@ -240,6 +241,7 @@
     border: 1px solid var(--border-card);
     background: var(--bg-primary);
     color: var(--text-primary);
+    font-size: 0.875rem;
     font-weight: 600;
     cursor: pointer;
   }


### PR DESCRIPTION
### Motivation
- Improve frequent-reading comfort by raising the practical minimum font size for small UI text across markdown, navigation, and content badges. 
- Make code blocks more readable by increasing code font size and line-height so long snippets are easier to scan. 
- Ensure the changes work in both `data-theme='light'` and `data-theme='dark'` visual modes.

### Description
- Updated `src/styles/markdown.css` to increase `.code-block-lang` and `.code-block-copy` font sizes, bump `.markdown-body pre code` to `0.875rem` with `line-height: 1.75`, and raise table font size/row rhythm (`0.9rem` and added `line-height: 1.5`).
- Updated `src/styles/navigation.css` to raise the TOC title/link/toggle typography (`.toc-title`, `.toc-link`, `.toc-toggle`) to a more legible floor and reduced letter-spacing to `0.08em` for consistency.
- Updated `src/styles/content-features.css` and `src/styles/home.css` to raise small badge/pill/tag typography (`.meta-pill`, `.prerequisite-pill`, `.related-tag`, `hero-badge`, `difficulty-badge`, etc.) and adjust compact paddings so badges remain balanced at the new sizes.

### Testing
- Ran `npm run build` successfully (production build completed without errors). 
- Executed an automated Playwright script that opened pages with `data-theme='light'` and `data-theme='dark'` and produced validation screenshots for both themes (screenshots captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2cccdb01083309c93b28b036f9e2d)