### PR TITLE
feat(ScrollProgress): add scoped mode and lesson-specific styles

### DIFF
--- a/patch.cjs
+++ b/patch.cjs
@@ -1,30 +1,28 @@
-/**
- * Scroll Progress Indicator
- *
- * A horizontal bar fixed to the top of the viewport indicating reading progress.
- *
- * Key Responsibilities:
- * - Calculate scroll percentage (scrollTop / (scrollHeight - clientHeight)).
- * - Update width style on scroll.
- * - Provide accessible progress role attributes.
- */
+const fs = require('fs');
+const file = 'src/components/ScrollProgress.tsx';
+let content = fs.readFileSync(file, 'utf8');
 
-import { useEffect, useState } from 'react'
-
-interface ScrollProgressProps {
+content = content.replace(
+  `export default function ScrollProgress() {`,
+  `interface ScrollProgressProps {
   targetSelector?: string
   isLesson?: boolean
 }
 
-export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
-  const [progress, setProgress] = useState(0)
+export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {`
+);
 
-  useEffect(() => {
-    const handleScroll = () => {
+content = content.replace(
+  `    const handleScroll = () => {
+      const scrollTop = window.scrollY
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight
+      setProgress(docHeight > 0 ? (scrollTop / docHeight) * 100 : 0)
+    }`,
+  `    const handleScroll = () => {
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        const element = document.querySelector(targetSelector)
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight
@@ -57,22 +55,13 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       }
 
       setProgress(calcProgress)
-    }
+    }`
+);
 
-    window.addEventListener('scroll', handleScroll, { passive: true })
-    return () => window.removeEventListener('scroll', handleScroll)
-  }, [targetSelector])
+content = content.replace(
+  `className="scroll-progress"`,
+  `className={\`scroll-progress \${isLesson ? 'lesson-progress' : ''}\`.trim()}`
+);
 
-  return (
-    <div
-      className={`scroll-progress ${isLesson ? 'lesson-progress' : ''}`.trim()}
-      role="progressbar"
-      aria-valuenow={Math.round(progress)}
-      aria-valuemin={0}
-      aria-valuemax={100}
-      aria-label="Reading progress"
-    >
-      <div className="scroll-progress-bar" style={{ width: `${progress}%` }} />
-    </div>
-  )
-}
+fs.writeFileSync(file, content);
+console.log('patched');

--- a/patch.js
+++ b/patch.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const file = 'src/components/ScrollProgress.tsx';
+let content = fs.readFileSync(file, 'utf8');
+
+content = content.replace(
+  `export default function ScrollProgress() {`,
+  `interface ScrollProgressProps {
+  targetSelector?: string
+  isLesson?: boolean
+}
+
+export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {`
+);
+
+content = content.replace(
+  `    const handleScroll = () => {
+      const scrollTop = window.scrollY
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight
+      setProgress(docHeight > 0 ? (scrollTop / docHeight) * 100 : 0)
+    }`,
+  `    const handleScroll = () => {
+      let calcProgress = 0
+
+      if (targetSelector) {
+        const element = document.querySelector(targetSelector)
+        if (element) {
+          const rect = element.getBoundingClientRect()
+          const elementHeight = element.clientHeight
+          const windowHeight = window.innerHeight
+
+          const scrollableDistance = elementHeight - windowHeight
+          if (scrollableDistance <= 0) {
+            calcProgress = 100
+          } else {
+            // rect.top is relative to the viewport.
+            // when scrolled 0 past the element, rect.top is where it starts (could be positive if below top).
+            // We want progress relative to the element's start.
+            // -rect.top is how much of the element is scrolled past its initial position relative to viewport.
+            const scrolled = -rect.top
+            calcProgress = (scrolled / scrollableDistance) * 100
+            calcProgress = Math.max(0, Math.min(100, calcProgress))
+          }
+        }
+      }
+
+      if (!calcProgress && !targetSelector) {
+        const scrollTop = window.scrollY
+        const docHeight = document.documentElement.scrollHeight - window.innerHeight
+        calcProgress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0
+      } else if (!calcProgress && targetSelector) {
+         // fallback if target is not yet found or progress is 0
+         const scrollTop = window.scrollY
+         const docHeight = document.documentElement.scrollHeight - window.innerHeight
+         if (docHeight > 0 && scrollTop > 0 && !document.querySelector(targetSelector)) {
+            calcProgress = (scrollTop / docHeight) * 100
+         }
+      }
+
+      setProgress(calcProgress)
+    }`
+);
+
+content = content.replace(
+  `className="scroll-progress"`,
+  `className={\`scroll-progress \${isLesson ? 'lesson-progress' : ''}\`.trim()}`
+);
+
+fs.writeFileSync(file, content);
+console.log('patched');

--- a/patch_app.cjs
+++ b/patch_app.cjs
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const file = 'src/App.tsx';
+let content = fs.readFileSync(file, 'utf8');
+
+// The `useLocation` import is already present.
+// I just need to determine `isLesson` inside App.
+
+content = content.replace(
+  `useLearningAnalytics(location.pathname)`,
+  `useLearningAnalytics(location.pathname)
+
+  const isLesson = location.pathname.startsWith('/lesson/')`
+);
+
+content = content.replace(
+  `<ScrollProgress />`,
+  `<ScrollProgress isLesson={isLesson} targetSelector={isLesson ? 'article' : undefined} />`
+);
+
+fs.writeFileSync(file, content);
+console.log('patched');

--- a/patch_css.cjs
+++ b/patch_css.cjs
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const file = 'src/styles/ux-features.css';
+let content = fs.readFileSync(file, 'utf8');
+
+content = content.replace(
+  `.scroll-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  z-index: 9999;
+  background: transparent;
+  pointer-events: none;
+}`,
+  `.scroll-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  z-index: 9999;
+  background: transparent;
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.scroll-progress.lesson-progress {
+  height: 4px;
+  opacity: 1;
+}`
+);
+
+content = content.replace(
+  `.scroll-progress-bar {
+  height: 100%;
+  background: var(--gradient-hero);
+  transition: width 50ms linear;
+  border-radius: 0 2px 2px 0;
+}`,
+  `.scroll-progress-bar {
+  height: 100%;
+  background: var(--accent-primary);
+  transition: width 50ms linear;
+  border-radius: 0 2px 2px 0;
+}
+
+.scroll-progress.lesson-progress .scroll-progress-bar {
+  background: var(--gradient-hero);
+}`
+);
+
+fs.writeFileSync(file, content);
+console.log('patched');

--- a/patch_scroll.cjs
+++ b/patch_scroll.cjs
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const file = 'src/components/ScrollProgress.tsx';
+let content = fs.readFileSync(file, 'utf8');
+
+content = content.replace(
+  `    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])`,
+  `    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [targetSelector])`
+);
+
+content = content.replace(
+  `    const handleScroll = () => {
+      let calcProgress = 0
+
+      if (targetSelector) {
+        const element = document.querySelector(targetSelector)`,
+  `    let element: HTMLElement | null = null
+
+    const handleScroll = () => {
+      let calcProgress = 0
+
+      if (targetSelector) {
+        if (!element) {
+          element = document.querySelector<HTMLElement>(targetSelector)
+        }
+        if (element) {`
+);
+
+fs.writeFileSync(file, content);
+console.log('patched');

--- a/patch_scroll2.cjs
+++ b/patch_scroll2.cjs
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const file = 'src/components/ScrollProgress.tsx';
+let content = fs.readFileSync(file, 'utf8');
+
+content = content.replace(
+  `        if (element) {
+        if (element) {
+          const rect = element.getBoundingClientRect()`,
+  `        if (element) {
+          const rect = element.getBoundingClientRect()`
+);
+
+fs.writeFileSync(file, content);
+console.log('patched');

--- a/patch_scroll3.cjs
+++ b/patch_scroll3.cjs
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const file = 'src/components/ScrollProgress.tsx';
+let content = fs.readFileSync(file, 'utf8');
+
+content = content.replace(
+  `  useEffect(() => {
+    let element: HTMLElement | null = null
+
+    const handleScroll = () => {
+      let calcProgress = 0
+
+      if (targetSelector) {
+        if (!element) {
+          element = document.querySelector<HTMLElement>(targetSelector)
+        }
+        if (element) {
+          const rect = element.getBoundingClientRect()`,
+  `  useEffect(() => {
+    const handleScroll = () => {
+      let calcProgress = 0
+
+      if (targetSelector) {
+        const element = document.querySelector<HTMLElement>(targetSelector)
+        if (element) {
+          const rect = element.getBoundingClientRect()`
+);
+
+fs.writeFileSync(file, content);
+console.log('patched');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,8 @@ export default function App() {
 
   useLearningAnalytics(location.pathname)
 
+  const isLesson = location.pathname.startsWith('/lesson/')
+
   useEffect(() => {
     hydrateProgressStore()
     hydrateQuizStore()
@@ -72,7 +74,7 @@ export default function App() {
     <ThemeProvider>
       <div className="app-layout">
         <SkipToContent />
-        <ScrollProgress />
+        <ScrollProgress isLesson={isLesson} targetSelector={isLesson ? 'article' : undefined} />
         <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
         <Navbar onToggleSidebar={() => setSidebarOpen((prev) => !prev)} />
         <main className="main-content" id="main-content" tabIndex={-1}>

--- a/src/styles/ux-features.css
+++ b/src/styles/ux-features.css
@@ -176,17 +176,27 @@
   top: 0;
   left: 0;
   width: 100%;
-  height: 3px;
+  height: 2px;
   z-index: 9999;
   background: transparent;
   pointer-events: none;
+  opacity: 0.6;
+}
+
+.scroll-progress.lesson-progress {
+  height: 4px;
+  opacity: 1;
 }
 
 .scroll-progress-bar {
   height: 100%;
-  background: var(--gradient-hero);
+  background: var(--accent-primary);
   transition: width 50ms linear;
   border-radius: 0 2px 2px 0;
+}
+
+.scroll-progress.lesson-progress .scroll-progress-bar {
+  background: var(--gradient-hero);
 }
 
 /* ---------- Mobile Bottom Nav ---------- */


### PR DESCRIPTION
- Updated `ScrollProgress` to accept `targetSelector` and `isLesson` props.
- Implemented scoped scroll calculation using `getBoundingClientRect()` to measure progress within a specific element.
- Avoided caching DOM elements across SPA navigations.
- Updated `App.tsx` to pass `isLesson` state and the `'article'` selector to the progress component for lesson routes.
- Adjusted `ux-features.css` to make the default scroll progress bar subtler (2px, 0.6 opacity) and more prominent on lesson pages (4px, full opacity, gradient).
- Preserved existing accessibility attributes (`role=progressbar`, `aria-valuenow`).

---
*PR created automatically by Jules for task [4518263840813025617](https://jules.google.com/task/4518263840813025617) started by @saint2706*