### PR TITLE
docs: Add missing JSDoc comments to core utilities

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -1,0 +1,9 @@
+# Documentation Progress Log
+
+This file tracks the status and completion of documentation tasks to ensure alignment with project standards and maintain code/documentation parity.
+
+## Completed Tasks
+
+- **[2026-03-01]** Added missing JSDoc/TSDoc comments to exported functions:
+  - `src/utils/dayToken.ts`
+  - `src/utils/progressTracker.ts`

--- a/src/utils/dayToken.ts
+++ b/src/utils/dayToken.ts
@@ -25,30 +25,66 @@ export interface ParsedDayToken {
   sortKey: string
 }
 
+/**
+ * Normalizes a raw day token input into a standard format.
+ * @param {string | number} value - The raw day token input.
+ * @returns {DayToken} The normalized day token.
+ */
 export function normalizeDayToken(value: string | number): DayToken {
   return core.normalizeDayToken(value)
 }
 
+/**
+ * Parses a day token into its constituent numeric and suffix parts.
+ * @param {string | number} value - The raw day token input.
+ * @returns {ParsedDayToken | null} The parsed token object, or null if invalid.
+ */
 export function parseDayToken(value: string | number): ParsedDayToken | null {
   return core.parseDayToken(value)
 }
 
+/**
+ * Compares two day tokens for sorting purposes.
+ * @param {string | number} a - The first day token.
+ * @param {string | number} b - The second day token.
+ * @returns {number} A negative number if a < b, positive if a > b, or 0 if equal.
+ */
 export function compareDayTokens(a: string | number, b: string | number): number {
   return core.compareDayTokens(a, b)
 }
 
+/**
+ * Safely extracts and normalizes a day token from a string or number value.
+ * @param {unknown} value - The value to extract from.
+ * @returns {DayToken | null} The normalized day token, or null if invalid.
+ */
 export function extractDayToken(value: unknown): DayToken | null {
   return core.extractDayToken(value)
 }
 
+/**
+ * Extracts a normalized day token from a given file path.
+ * @param {string} path - The file path.
+ * @returns {DayToken | null} The normalized day token, or null if not found.
+ */
 export function dayTokenFromPath(path: string): DayToken | null {
   return core.dayTokenFromPath(path)
 }
 
+/**
+ * Extracts a normalized day token from a cross-reference string.
+ * @param {unknown} value - The reference string or number.
+ * @returns {DayToken | null} The normalized day token, or null if not found.
+ */
 export function dayTokenFromReference(value: unknown): DayToken | null {
   return core.dayTokenFromReference(value)
 }
 
+/**
+ * Converts a day token into a unique numeric progress ID.
+ * @param {string | number} value - The day token input.
+ * @returns {number} The numeric progress ID, or NaN if invalid.
+ */
 export function dayTokenToProgressId(value: string | number): number {
   return core.dayTokenToProgressId(value)
 }

--- a/src/utils/progressTracker.ts
+++ b/src/utils/progressTracker.ts
@@ -30,56 +30,107 @@ if (typeof window !== 'undefined') {
   })
 }
 
+/**
+ * Marks a lesson as complete.
+ * @param {string | number} day - The day token or number of the lesson to mark as complete.
+ * @returns {void}
+ */
 export function markLessonComplete(day: string | number): void {
   ensureHydrated()
   useProgressStore.getState().markLessonComplete(day)
 }
 
+/**
+ * Marks a lesson as incomplete.
+ * @param {string | number} day - The day token or number of the lesson to mark as incomplete.
+ * @returns {void}
+ */
 export function markLessonIncomplete(day: string | number): void {
   ensureHydrated()
   useProgressStore.getState().markLessonIncomplete(day)
 }
 
+/**
+ * Checks if a lesson is complete.
+ * @param {string | number} day - The day token or number of the lesson to check.
+ * @returns {boolean} True if the lesson is complete, false otherwise.
+ */
 export function isLessonComplete(day: string | number): boolean {
   ensureHydrated()
   return useProgressStore.getState().isLessonComplete(day)
 }
 
+/**
+ * Toggles the completion status of a lesson.
+ * @param {string | number} day - The day token or number of the lesson to toggle.
+ * @returns {boolean} The new completion status (true if complete, false if incomplete).
+ */
 export function toggleLessonComplete(day: string | number): boolean {
   ensureHydrated()
   return useProgressStore.getState().toggleLessonComplete(day)
 }
 
+/**
+ * Gets an array of all completed lesson IDs.
+ * @returns {number[]} Array of numeric progress IDs for completed lessons.
+ */
 export function getCompletedLessons(): number[] {
   ensureHydrated()
   return useProgressStore.getState().completedLessons
 }
 
+/**
+ * Gets the total count of completed lessons.
+ * @returns {number} The total count of completed lessons.
+ */
 export function getCompletedCount(): number {
   ensureHydrated()
   return useProgressStore.getState().completedLessonsCount()
 }
 
+/**
+ * Gets the IDs of completed lessons for a specific phase.
+ * @param {Array<string | number>} phaseLessonDays - An array of day tokens for the phase.
+ * @returns {number[]} Array of completed progress IDs for the given phase.
+ */
 export function getCompletedForPhase(phaseLessonDays: Array<string | number>): number[] {
   ensureHydrated()
   return useProgressStore.getState().getCompletedForPhase(phaseLessonDays)
 }
 
+/**
+ * Sets the last visited lesson day.
+ * @param {string | number} day - The day token or number of the visited lesson.
+ * @returns {void}
+ */
 export function setLastVisited(day: string | number): void {
   ensureHydrated()
   useProgressStore.getState().setLastVisited(day)
 }
 
+/**
+ * Gets the last visited lesson day ID.
+ * @returns {number | null} The numeric progress ID of the last visited lesson, or null if none.
+ */
 export function getLastVisited(): number | null {
   ensureHydrated()
   return useProgressStore.getState().lastVisitedLesson
 }
 
+/**
+ * Clears all user progress.
+ * @returns {void}
+ */
 export function clearAllProgress(): void {
   ensureHydrated()
   useProgressStore.getState().clearAllProgress()
 }
 
+/**
+ * Calculates progress statistics for a given phase.
+ * @param {Array<string | number>} phaseLessonDays - Array of day tokens in the phase.
+ * @returns {{ completed: number; total: number; percent: number }} Progress stats for the phase.
+ */
 export function getPhaseProgress(phaseLessonDays: Array<string | number>): {
   completed: number
   total: number
@@ -89,11 +140,20 @@ export function getPhaseProgress(phaseLessonDays: Array<string | number>): {
   return useProgressStore.getState().phaseProgress(phaseLessonDays)
 }
 
+/**
+ * Gets the current study streak in days.
+ * @param {Date} [now] - Optional current date override for calculation.
+ * @returns {number} The current study streak in days.
+ */
 export function getStreakDays(now?: Date): number {
   ensureHydrated()
   return useProgressStore.getState().streakDays(now)
 }
 
+/**
+ * Hydrates the progress store manually.
+ * @returns {void}
+ */
 export function hydrateProgressStore(): void {
   hasAttemptedHydration = true
   useProgressStore.getState().hydrate()


### PR DESCRIPTION
This PR resolves missing JSDoc/TSDoc comments in key utility files, aligning the project with strict documentation standards. 

**Changes Made:**
- Added comprehensive JSDocs (`@param`, `@returns`, description) to all exported functions in `src/utils/dayToken.ts`.
- Added comprehensive JSDocs (`@param`, `@returns`, description) to all exported functions in `src/utils/progressTracker.ts`.
- Created `.jules/docs-progress.md` to establish a tracking mechanism for documentation audits and log these completed tasks.

All linting, typechecking, and tests (`vitest`) continue to pass successfully.

---
*PR created automatically by Jules for task [12458290100540568315](https://jules.google.com/task/12458290100540568315) started by @saint2706*