### PR TITLE
⚡ Bolt: [improvement] Lazy load AiStudyPanel in Lesson page

### DIFF
--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -8,7 +8,7 @@
  * @module pages/Lesson
  */
 
-import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
+import { useEffect, useState, useCallback, useMemo, useRef, lazy, Suspense } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
 import { motion } from 'motion/react'
 import SEOHead from '../components/SEOHead'
@@ -57,7 +57,8 @@ import {
   triggerPhaseUnlockConfetti,
   triggerCurriculumFireworks,
 } from '../utils/confetti'
-import AiStudyPanel from '../components/AiStudyPanel'
+
+const AiStudyPanel = lazy(() => import('../components/AiStudyPanel'))
 
 /**
  * Lesson page component displaying a single day's lesson.
@@ -359,11 +360,13 @@ export default function Lesson() {
 
       {/* AI Study Assistant */}
       {!readingMode && (
-        <AiStudyPanel
-          lessonContent={lesson.content}
-          lessonDay={lesson.day}
-          lessonTitle={lesson.title}
-        />
+        <Suspense fallback={null}>
+          <AiStudyPanel
+            lessonContent={lesson.content}
+            lessonDay={lesson.day}
+            lessonTitle={lesson.title}
+          />
+        </Suspense>
       )}
     </div>
   )


### PR DESCRIPTION
Implements React `lazy` and `Suspense` for the `AiStudyPanel` component within `Lesson.tsx`. This change defers the loading of the large AI-related chunks (including Gemini API clients and related markdown parsing libraries) until they are actually rendered on the lesson page. 

This addresses the "Large JS bundles" priority area and improves initial page load performance. Verified via `npm run analyze`, showing `ai-assistant-D9OLb1c2.js` bundle chunk is loaded separately from the main routing bundle. Tested with `npm run test:coverage` and `npm run lint` and a visual Playwright verification of the page structure.

---
*PR created automatically by Jules for task [17875395643349878650](https://jules.google.com/task/17875395643349878650) started by @saint2706*