### PR TITLE
🛡️ Sentinel: [Security Fix] Prevent Sandbox Escapes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -53,3 +53,4 @@
 **Vulnerability:** The previous regex checks for internal module imports (like `\bimport\s+js\b`) could be bypassed by importing multiple modules in a single statement (e.g., `import math, js`), allowing dangerous module execution.
 **Learning:** Simple import regexes must account for comma-separated module lists and other valid Python import syntaxes.
 **Prevention:** Replaced literal regexes with a broader `\bimport\b[^;\n]*\b(js|pyodide|micropip)\b` and `\bfrom\b\s+(js|pyodide|micropip)\b` pattern to securely catch all occurrences of restricted modules in import statements.
+- Added `__class__`, `__base__`, and `__dict__` to the list of `globalKeywords` inside `validatePythonCode` to prevent Python Sandbox Escapes using Dunder Method Reflection/Object Instantiation (e.g. `().__class__.__base__.__dict__["__subclasses__"]`).

--- a/src/utils/__tests__/codeSecurity.bypass.test.ts
+++ b/src/utils/__tests__/codeSecurity.bypass.test.ts
@@ -78,4 +78,11 @@ describe('validatePythonCode - Bypass Attempts', () => {
   it('should not block from js import if js is a variable', () => {
     expect(validatePythonCode('from some_module import json').valid).toBe(true)
   })
+
+  it('should block sandbox escape via dunder dict reflection', () => {
+    expect(validatePythonCode('().__class__.__base__.__dict__["__subclasses__"]()').valid).toBe(false)
+    expect(validatePythonCode('c = __class__').valid).toBe(false)
+    expect(validatePythonCode('b = __base__').valid).toBe(false)
+    expect(validatePythonCode('d = __dict__').valid).toBe(false)
+  })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -141,6 +141,9 @@ export function validatePythonCode(code: string): ValidationResult {
     '__closure__',
     '__loader__',
     '__spec__',
+    '__class__',
+    '__base__',
+    '__dict__',
   ]
   const globalRegex = new RegExp(`\\b(${globalKeywords.join('|')})\\b`)
   if (globalRegex.test(strippedCode)) {


### PR DESCRIPTION
### 🛡️ Sentinel: Security Enhancement

#### Vulnerability Discovered
During security discovery, it was identified that an attacker could bypass the `validatePythonCode` regex checks and achieve restricted module imports or execute system commands by leveraging Python object instantiation reflection (dunder methods). 

For example, a user could execute:
```python
().__class__.__base__.__dict__["__subclasses__"]()
```
Because the properties `__class__`, `__base__`, and `__dict__` were not globally blocked, the attacker could navigate the Python object hierarchy dynamically via strings and completely bypass the `__subclasses__` and `importlib` blocked keywords.

#### Fix Implemented
- **Mitigation:** Added `__class__`, `__base__`, and `__dict__` to the `globalKeywords` array in `src/utils/codeSecurity.ts`. 
- **Tests Added:** Added robust unit tests to `src/utils/__tests__/codeSecurity.bypass.test.ts` to ensure that dictionary reflection attacks are successfully caught and blocked by the engine.
- **Verification:** All tests and the linting pipeline (`npm run test` and `npm run lint`) pass seamlessly.

#### Documentation
Critical security learnings have been logged internally within `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [13951997711684689810](https://jules.google.com/task/13951997711684689810) started by @saint2706*