### PR TITLE
🧘 Buddha: [SEO/GEO improvement] Enhance JSON-LD Schema safety and CaseStudies discoverability

### DIFF
--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -107,9 +107,13 @@ export default function SEOHead({
 
       {/* JSON-LD Structured Data */}
       {allSchemas.map((schema, i) => (
-        <script key={`jsonld-${i}`} type="application/ld+json">
-          {JSON.stringify(schema)}
-        </script>
+        <script
+          key={`jsonld-${i}`}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(schema).replace(/</g, '\\u003c'),
+          }}
+        />
       ))}
     </Helmet>
   )

--- a/src/pages/CaseStudies.tsx
+++ b/src/pages/CaseStudies.tsx
@@ -16,6 +16,7 @@ import SEOHead from '../components/SEOHead'
 import Breadcrumb from '../components/Breadcrumb'
 import MarkdownRenderer from '../components/MarkdownRenderer'
 import { getAllCaseStudies, getAllProjects, difficultyConfig } from '../utils/contentLoader'
+import { buildCollectionPageSchema } from '../utils/seoSchemas'
 
 type Tab = 'case-studies' | 'projects'
 
@@ -51,6 +52,17 @@ export default function CaseStudies() {
     setExpandedSlug((prev) => (prev === slug ? null : slug))
   }
 
+  const collectionSchema = buildCollectionPageSchema(
+    'Case Studies & Projects',
+    'Explore real-world case studies and capstone projects covering ML, data science, BI, and SQL — designed to build your MBA portfolio.',
+    '/case-studies',
+    [...caseStudies, ...projects].slice(0, 20).map((item) => ({
+      name: item.title,
+      description: item.phasesCovered || item.difficulty,
+      url: `/case-studies`,
+    })),
+  )
+
   return (
     <div className="page-container">
       <SEOHead
@@ -61,6 +73,7 @@ export default function CaseStudies() {
           { name: 'Home', url: '/' },
           { name: 'Case Studies & Projects', url: '/case-studies' },
         ]}
+        jsonLd={[collectionSchema]}
       />
       <Breadcrumb items={[{ label: 'Home', to: '/' }, { label: 'Case Studies & Projects' }]} />
 


### PR DESCRIPTION
This PR introduces SEO and GEO optimizations for the `CaseStudies` page and the global `SEOHead` component.

### Changes:
- **[SEO] `SEOHead.tsx`**: Updated how `application/ld+json` script tags are rendered. Previous stringification via children props could result in malformed JSON entities. Now uses `dangerouslySetInnerHTML` safely by replacing `<` with `\u003c` to mitigate XSS risks.
- **[GEO] `CaseStudies.tsx`**: Implemented `buildCollectionPageSchema` from `seoSchemas.ts` to surface rich structured data for AI engines and Googlebot about the available case studies and capstone projects.

---
*PR created automatically by Jules for task [14254218340950464071](https://jules.google.com/task/14254218340950464071) started by @saint2706*