### PR TITLE
🛡️ Sentinel: Fix Pyodide sandbox escape via exception tracebacks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -54,3 +54,9 @@
 **Learning:** Simple import regexes must account for comma-separated module lists and other valid Python import syntaxes.
 **Prevention:** Replaced literal regexes with a broader `\bimport\b[^;\n]*\b(js|pyodide|micropip)\b` and `\bfrom\b\s+(js|pyodide|micropip)\b` pattern to securely catch all occurrences of restricted modules in import statements.
 - Added `__class__`, `__base__`, and `__dict__` to the list of `globalKeywords` inside `validatePythonCode` to prevent Python Sandbox Escapes using Dunder Method Reflection/Object Instantiation (e.g. `().__class__.__base__.__dict__["__subclasses__"]`).
+
+## 2025-06-20 - Pyodide Sandbox Escape via Traceback Frames
+**Vulnerability:** A vulnerability existed where an attacker could use an exception's `__traceback__` property to traverse frame objects (`tb_frame`, `f_globals`, `f_builtins`), ultimately gaining access to the blocked `__builtins__` dictionary. For example: `e.__traceback__.tb_frame.f_globals["__builtins__"]`. Since string literals are stripped prior to the keyword validation in `validatePythonCode`, the keyword `__builtins__` was hidden in the string index, bypassing the blocklist.
+**Learning:** Pyodide's JavaScript/Python boundary and execution environment expose raw traceback objects on exceptions. Frame objects contain a full reference back to global and builtin namespaces. Blocking the entry points like `globals()` is insufficient if those same namespaces can be reflected through raised exceptions.
+**Prevention:**
+- Added `__traceback__`, `tb_frame`, `f_globals`, `f_back`, `f_builtins`, and `f_code` to the `globalKeywords` strict deny list in `validatePythonCode`. This effectively blocks exception-based traceback traversal and prevents retrieving frame locals/globals to execute arbitrary code.

--- a/src/utils/__tests__/codeSecurity.bypass.test.ts
+++ b/src/utils/__tests__/codeSecurity.bypass.test.ts
@@ -85,4 +85,21 @@ describe('validatePythonCode - Bypass Attempts', () => {
     expect(validatePythonCode('b = __base__').valid).toBe(false)
     expect(validatePythonCode('d = __dict__').valid).toBe(false)
   })
+
+  it('should block sandbox escape via frame and traceback attributes', () => {
+    const tracebackEscape = `
+try:
+    1/0
+except Exception as e:
+    tb = e.__traceback__
+    f = tb.tb_frame
+    g = f.f_globals
+    b = g["__builtins__"]
+    b["__import__"]("os").system("echo exploited")
+`
+    expect(validatePythonCode(tracebackEscape).valid).toBe(false)
+    expect(validatePythonCode('x = f_back').valid).toBe(false)
+    expect(validatePythonCode('y = f_builtins').valid).toBe(false)
+    expect(validatePythonCode('z = f_code').valid).toBe(false)
+  })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -144,6 +144,12 @@ export function validatePythonCode(code: string): ValidationResult {
     '__class__',
     '__base__',
     '__dict__',
+    '__traceback__',
+    'tb_frame',
+    'f_globals',
+    'f_back',
+    'f_builtins',
+    'f_code',
   ]
   const globalRegex = new RegExp(`\\b(${globalKeywords.join('|')})\\b`)
   if (globalRegex.test(strippedCode)) {


### PR DESCRIPTION
- Pyodide's JavaScript/Python execution boundary exposes traceback objects on exceptions. Frame objects contain a full reference back to global and builtin namespaces.
- This PR adds `__traceback__`, `tb_frame`, `f_globals`, `f_back`, `f_builtins`, and `f_code` to the strict deny blocklist in `validatePythonCode`. This effectively blocks exception-based traceback traversal and prevents retrieving frame locals/globals to execute arbitrary code.
- Added explicit unit tests to ensure this bypass path is correctly flagged as invalid code.

---
*PR created automatically by Jules for task [10163741117070605066](https://jules.google.com/task/10163741117070605066) started by @saint2706*