### PR TITLE
⚡ Bolt: [improvement] Improve curriculum rendering, sidebar tracking, and search ranking performance

### DIFF
--- a/src/components/SidebarPhaseGroup.tsx
+++ b/src/components/SidebarPhaseGroup.tsx
@@ -139,4 +139,38 @@ function SidebarPhaseGroup({
   )
 }
 
-export default memo(SidebarPhaseGroup)
+function propsAreEqual(
+  prevProps: Readonly<SidebarPhaseGroupProps>,
+  nextProps: Readonly<SidebarPhaseGroupProps>,
+): boolean {
+  if (prevProps.isActive !== nextProps.isActive) return false
+  if (prevProps.dueCount !== nextProps.dueCount) return false
+  if (prevProps.phase.phase !== nextProps.phase.phase) return false
+
+  // Only re-render if currentPath changes to/from a lesson in THIS phase
+  // Optimization: check if either the old path or the new path is relevant to this phase
+  const isRelevantPath = (path: string) =>
+    path === `/phase/${nextProps.phase.phase}` ||
+    path.startsWith('/lesson/') && getLessonsByPhase(nextProps.phase.phase).some(l => path === `/lesson/${l.day}`)
+
+  if (prevProps.currentPath !== nextProps.currentPath) {
+    if (isRelevantPath(prevProps.currentPath) || isRelevantPath(nextProps.currentPath)) {
+      return false
+    }
+  }
+
+  // Check if completion status of ANY lesson IN THIS PHASE changed
+  if (prevProps.completedSet !== nextProps.completedSet) {
+    const lessons = getLessonsByPhase(nextProps.phase.phase)
+    for (const lesson of lessons) {
+      const id = dayTokenToProgressId(lesson.day)
+      if (prevProps.completedSet.has(id) !== nextProps.completedSet.has(id)) {
+        return false
+      }
+    }
+  }
+
+  return true
+}
+
+export default memo(SidebarPhaseGroup, propsAreEqual)

--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -33,6 +33,10 @@ import ProgressBar from '../components/ProgressBar'
  *
  * @returns The rendered curriculum roadmap page
  */
+import { useMemo } from 'react'
+
+import { useProgressStore } from '../stores/progressStore'
+
 export default function Curriculum() {
   const phases = getAllPhases()
   const prefersReducedMotion = useReducedMotion()
@@ -43,16 +47,33 @@ export default function Curriculum() {
   })
   const timelineScaleY = useTransform(scrollYProgress, [0, 1], [0.1, 1])
 
-  const totalLessons = phases.reduce((sum, p) => sum + getLessonsByPhase(p.phase).length, 0)
+  const completedLessons = useProgressStore((state) => state.completedLessons)
+
+  const phasesData = useMemo(() => {
+    return phases.map((phase) => {
+      const lessons = getLessonsByPhase(phase.phase)
+      const completedInPhase = getCompletedForPhase(lessons.map((l) => l.day))
+      const isPhaseComplete = completedInPhase.length === lessons.length && lessons.length > 0
+      const isPhaseStarted = completedInPhase.length > 0
+      const diff = difficultyConfig[phase.difficulty || 'beginner'] || difficultyConfig.beginner!
+      const icon = phaseIcons[phase.phase - 1] || '📖'
+
+      return {
+        ...phase,
+        lessons,
+        completedInPhase,
+        isPhaseComplete,
+        isPhaseStarted,
+        diff,
+        icon,
+      }
+    })
+  }, [phases, completedLessons])
+
+  const totalLessons = phasesData.reduce((sum, p) => sum + p.lessons.length, 0)
   const completedCount = getCompletedCount()
   const overallPct = totalLessons > 0 ? Math.round((completedCount / totalLessons) * 100) : 0
-  const completedPhasesCount = phases.filter((p) => {
-    const lessons = getLessonsByPhase(p.phase)
-    return (
-      lessons.length > 0 &&
-      getCompletedForPhase(lessons.map((l) => l.day)).length === lessons.length
-    )
-  }).length
+  const completedPhasesCount = phasesData.filter((p) => p.isPhaseComplete).length
 
   const containerVariants = {
     hidden: { opacity: 0 },
@@ -76,11 +97,11 @@ export default function Curriculum() {
   const itemListSchema = buildItemListSchema(
     'Full Curriculum Roadmap',
     'Browse the complete 108-day curriculum roadmap across 9 phases — from Python foundations to enterprise SQL.',
-    phases.map((phase) => ({
+    phasesData.map((phase) => ({
       name: `Phase ${phase.phase}: ${phase.title}`,
       url: `/phase/${phase.phase}`,
       position: phase.phase,
-      description: `Phase ${phase.phase} covers ${getLessonsByPhase(phase.phase).length} lessons on ${phase.title}.`,
+      description: `Phase ${phase.phase} covers ${phase.lessons.length} lessons on ${phase.title}.`,
     })),
   )
 
@@ -161,32 +182,24 @@ export default function Curriculum() {
         whileInView="visible"
         viewport={{ once: true, amount: 0.15 }}
       >
-        {phases.map((phase) => {
-          const lessons = getLessonsByPhase(phase.phase)
-          const diff =
-            difficultyConfig[phase.difficulty || 'beginner'] || difficultyConfig.beginner!
-          const icon = phaseIcons[phase.phase - 1] || '📖'
-          const completedInPhase = getCompletedForPhase(lessons.map((l) => l.day))
-          const isPhaseComplete = completedInPhase.length === lessons.length && lessons.length > 0
-          const isPhaseStarted = completedInPhase.length > 0
-
+        {phasesData.map((phase) => {
           return (
             <motion.div
-              className={`curriculum-phase glass-card ${isPhaseComplete ? 'curriculum-phase--complete' : ''}`}
+              className={`curriculum-phase glass-card ${phase.isPhaseComplete ? 'curriculum-phase--complete' : ''}`}
               key={phase.phase}
               variants={phaseVariants}
               transition={{ duration: prefersReducedMotion ? 0 : 0.28 }}
             >
               <Link to={`/phase/${phase.phase}`} className="curriculum-phase-header">
-                <span style={{ fontSize: '1.25rem' }}>{icon}</span>
+                <span style={{ fontSize: '1.25rem' }}>{phase.icon}</span>
                 <h3>
                   Phase {phase.phase}: {phase.title}
                 </h3>
-                {isPhaseComplete ? (
+                {phase.isPhaseComplete ? (
                   <span className="curriculum-phase-status curriculum-phase-status--done">
                     ✓ Done
                   </span>
-                ) : isPhaseStarted ? (
+                ) : phase.isPhaseStarted ? (
                   <span className="curriculum-phase-status curriculum-phase-status--active">
                     Active
                   </span>
@@ -194,21 +207,21 @@ export default function Curriculum() {
                 <span
                   className="difficulty-badge"
                   style={{
-                    color: diff.color,
-                    background: diff.bg,
-                    marginLeft: isPhaseComplete || isPhaseStarted ? '0' : 'auto',
+                    color: phase.diff.color,
+                    background: phase.diff.bg,
+                    marginLeft: phase.isPhaseComplete || phase.isPhaseStarted ? '0' : 'auto',
                   }}
                 >
-                  {diff.label}
+                  {phase.diff.label}
                 </span>
               </Link>
 
               <div style={{ marginBottom: '0.75rem', paddingRight: '1rem' }}>
-                <ProgressBar completed={completedInPhase.length} total={lessons.length} />
+                <ProgressBar completed={phase.completedInPhase.length} total={phase.lessons.length} />
               </div>
 
               <div className="curriculum-days">
-                {lessons.map((lesson) => (
+                {phase.lessons.map((lesson) => (
                   <Link
                     to={`/lesson/${lesson.day}`}
                     className="curriculum-day-link"

--- a/src/utils/__tests__/searchIndex-functions.test.ts
+++ b/src/utils/__tests__/searchIndex-functions.test.ts
@@ -143,10 +143,10 @@ _Italic_
     const docs = createSearchDocuments(lessons)
     const [titleDoc, tagDoc, conceptDoc] = docs
 
-    const query = 'python variables'
-    const titleBoost = computeRankingBoost(titleDoc!, query)
-    const conceptBoost = computeRankingBoost(conceptDoc!, query)
-    const tagBoost = computeRankingBoost(tagDoc!, query)
+    const terms = ['python', 'variables']
+    const titleBoost = computeRankingBoost(titleDoc!, terms)
+    const conceptBoost = computeRankingBoost(conceptDoc!, terms)
+    const tagBoost = computeRankingBoost(tagDoc!, terms)
 
     expect(titleBoost).toBeGreaterThan(conceptBoost)
     expect(conceptBoost).toBeGreaterThan(tagBoost)

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -556,8 +556,15 @@ export function getPrerequisiteLessons(lesson: Readonly<Lesson>): readonly Immut
 }
 
 /** Return top related lessons ranked by shared tags/concepts and phase proximity. */
+let relatedLessonsCache: Record<string, readonly ImmutableLesson[]> = {}
+
 export function getRelatedLessons(lesson: Readonly<Lesson>, count = 4): readonly ImmutableLesson[] {
   initializeContent()
+  const cacheKey = `${lesson.day}-${count}`
+  if (relatedLessonsCache[cacheKey]) {
+    return relatedLessonsCache[cacheKey]!
+  }
+
   const prereqs = new Set(
     ((lesson.prerequisites as readonly unknown[]) || [])
       .map((entry) => dayTokenFromReference(entry))
@@ -588,7 +595,7 @@ export function getRelatedLessons(lesson: Readonly<Lesson>, count = 4): readonly
     .sort((a, b) => b.score - a.score)
     .slice(0, count)
 
-  return Object.freeze(
+  const result = Object.freeze(
     scored.map((s) =>
       Object.freeze({
         ...s.lesson,
@@ -598,6 +605,9 @@ export function getRelatedLessons(lesson: Readonly<Lesson>, count = 4): readonly
       }),
     ),
   )
+
+  relatedLessonsCache[cacheKey] = result
+  return result
 }
 
 export { difficultyConfig, phaseIcons }

--- a/src/utils/searchIndex.ts
+++ b/src/utils/searchIndex.ts
@@ -135,8 +135,7 @@ function scoreField(text: string | undefined, terms: readonly string[], weight: 
   return terms.reduce((acc, term) => (text.includes(term) ? acc + weight : acc), 0)
 }
 
-export function computeRankingBoost(doc: SearchDocument, query: string): number {
-  const terms = normalizeQuery(query)
+export function computeRankingBoost(doc: SearchDocument, terms: readonly string[]): number {
   return (
     scoreField(doc.titleLower, terms, TITLE_WEIGHT) +
     scoreField(doc.conceptsLower, terms, CONCEPT_WEIGHT) +
@@ -269,10 +268,12 @@ export function search(query: string, limit = 20): SearchResult[] {
   if (!engine) return []
   const rawResults = engine.search(query, { limit: Math.max(limit * 2, 20) })
 
+  const terms = normalizeQuery(query)
+
   return rawResults
     .map((result) => ({
       item: result.item,
-      score: (result.score ?? 1) - computeRankingBoost(result.item, query) / 100,
+      score: (result.score ?? 1) - computeRankingBoost(result.item, terms) / 100,
     }))
     .sort((a, b) => (a.score ?? 1) - (b.score ?? 1))
     .slice(0, limit)


### PR DESCRIPTION
I have made the following improvements to improve the overall performance:

*   **Search Ranking Boost (`searchIndex.ts`)**: Extracted `normalizeQuery(query)` before the `engine.search` loop and modified `computeRankingBoost` to accept `terms: readonly string[]` rather than repeatedly splitting the query for every item matched. This saves continuous memory allocations on every search keystroke.
*   **Related Lessons Caching (`contentLoader.ts`)**: Added an in-memory cache `relatedLessonsCache` mapped by lesson day and count (`${lesson.day}-${count}`) for `getRelatedLessons`, skipping expensive set similarity scoring for all lessons whenever the user navigates between them.
*   **Sidebar Re-renders (`SidebarPhaseGroup.tsx`)**: The Sidebar component recalculates the `completedSet` and passes it to the `SidebarPhaseGroup` component. Before, `SidebarPhaseGroup` re-rendered whenever the completion state of *any* lesson changed. I added a custom `propsAreEqual` check to `React.memo` that specifically checks if the updated `completedSet` actually toggled a lesson belonging to that specific phase group, skipping re-renders otherwise.
*   **Curriculum Page (`Curriculum.tsx`)**: Instead of repeatedly resolving phase statistics (like `completedInPhase` or `lessons`) throughout the render cycles inside `.map()` functions, I gathered these metrics once into a single memoized array (`phasesData`), streamlining the roadmap UI loop.

---
*PR created automatically by Jules for task [14241859161397547401](https://jules.google.com/task/14241859161397547401) started by @saint2706*