### PR TITLE
📚 Docs: Add missing TSDoc comments to src/utils/slug.ts

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -7,3 +7,4 @@ This file tracks the status and completion of documentation tasks to ensure alig
 - **[2026-03-01]** Added missing JSDoc/TSDoc comments to exported functions:
   - `src/utils/dayToken.ts`
   - `src/utils/progressTracker.ts`
+  - `src/utils/slug.ts`

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -29,6 +29,12 @@ function normalizeForSlug(value: string): string {
     .replace(/[\s-]+/g, '-')
 }
 
+/**
+ * Removes common inline Markdown formatting from a string.
+ *
+ * @param value - The input markdown string.
+ * @returns The plain text string without formatting.
+ */
 export function stripMarkdownInlineFormatting(value: string): string {
   return value
     .replace(/\s+#+\s*$/, '')
@@ -42,6 +48,12 @@ export function stripMarkdownInlineFormatting(value: string): string {
     .trim()
 }
 
+/**
+ * Recursively extracts plain text from a React node tree.
+ *
+ * @param node - The React node to extract text from.
+ * @returns The concatenated plain text string.
+ */
 export function extractTextFromReactNode(node: ReactNode): string {
   if (node == null || typeof node === 'boolean') return ''
   if (typeof node === 'string' || typeof node === 'number') return String(node)
@@ -52,6 +64,11 @@ export function extractTextFromReactNode(node: ReactNode): string {
   return ''
 }
 
+/**
+ * Creates a stateful slug generator that ensures unique slugs.
+ *
+ * @returns An object with a `slug` method.
+ */
 export function createSlugger() {
   const counts = new Map<string, number>()
 


### PR DESCRIPTION
Addressed missing TSDoc comments for exported functions `stripMarkdownInlineFormatting`, `extractTextFromReactNode`, and `createSlugger` in `src/utils/slug.ts` to adhere to documentation guidelines. Also verified `frontmatter-core.js` and `exercise-extractor-core.js` which already met the criteria. Updated `.jules/docs-progress.md` with the new changes.

---
*PR created automatically by Jules for task [594760630248497697](https://jules.google.com/task/594760630248497697) started by @saint2706*