### PR TITLE
🛡️ Sentinel: Fix Unicode Normalization Sandbox Escape

### DIFF
--- a/src/utils/__tests__/codeSecurity.unicode.test.ts
+++ b/src/utils/__tests__/codeSecurity.unicode.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { validatePythonCode } from '../codeSecurity'
+
+describe('validatePythonCode - Unicode Normalization Bypass Attempts', () => {
+  it('should block unicode identifier bypass for globals', () => {
+    // 𝕘lobals() -> normalizes to globals()
+    expect(validatePythonCode('\uD835\uDD58lobals()').valid).toBe(false)
+  })
+
+  it('should block unicode identifier bypass for eval', () => {
+    // e𝕧al -> normalizes to eval
+    expect(validatePythonCode('e\uD835\uDD67al("import js")').valid).toBe(false)
+  })
+
+  it('should block unicode identifier bypass for getattr', () => {
+    // 𝔤etattr -> normalizes to getattr
+    expect(validatePythonCode('\uD835\uDD24etattr(print, "__globals__")').valid).toBe(false)
+  })
+
+  it('should block unicode identifier bypass for __builtins__', () => {
+    // __𝖇uiltins__ -> normalizes to __builtins__
+    expect(validatePythonCode('__\uD835\uDD87uiltins__').valid).toBe(false)
+  })
+})
+
+describe('validatePythonCode - Additional Frame Attributes', () => {
+  it('should block f_locals', () => {
+    expect(validatePythonCode('f.f_locals').valid).toBe(false)
+  })
+
+  it('should block gi_frame', () => {
+    expect(validatePythonCode('g.gi_frame').valid).toBe(false)
+  })
+
+  it('should block cr_frame', () => {
+    expect(validatePythonCode('c.cr_frame').valid).toBe(false)
+  })
+
+  it('should block ag_frame', () => {
+    expect(validatePythonCode('a.ag_frame').valid).toBe(false)
+  })
+})

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -82,8 +82,9 @@ export function stripPythonCommentsAndStrings(code: string): string {
 export function validatePythonCode(code: string): ValidationResult {
   if (!code) return { valid: true }
 
-  // Normalize code to handle line continuations
-  const normalizedCode = code.replace(/\\(\r\n|\r|\n)/g, '')
+  // Normalize code to NFKC (matching Python's internal identifier normalization)
+  // and handle line continuations
+  const normalizedCode = code.normalize('NFKC').replace(/\\(\r\n|\r|\n)/g, '')
 
   // Strip safe strings and comments to focus on logic
   const strippedCode = stripPythonCommentsAndStrings(normalizedCode)
@@ -147,9 +148,13 @@ export function validatePythonCode(code: string): ValidationResult {
     '__traceback__',
     'tb_frame',
     'f_globals',
+    'f_locals',
     'f_back',
     'f_builtins',
     'f_code',
+    'gi_frame',
+    'cr_frame',
+    'ag_frame',
   ]
   const globalRegex = new RegExp(`\\b(${globalKeywords.join('|')})\\b`)
   if (globalRegex.test(strippedCode)) {


### PR DESCRIPTION
🛡️ Sentinel: Fix Unicode Normalization Sandbox Escape and Add Missing Frame Attributes

### Vulnerability Context
During an internal security review of the Pyodide Sandbox validation wrapper (`validatePythonCode`), it was discovered that Python 3 implicitly normalizes Unicode identifiers to their ASCII equivalents using NFKC normalization prior to evaluating the Abstract Syntax Tree (AST). 

Because the security regex checked against raw input, an attacker could use characters like `𝕘lobals()` (U+1D558) or `e𝕧al` (U+1D567) to bypass the `globalKeywords` and `propertySafeKeywords` blacklists. The Pyodide interpreter would then evaluate the normalized identifier `globals()` successfully.

Additionally, while testing the frame traversal escape mitigation implemented previously (`f_globals`, `f_builtins`, `tb_frame`), I found that `f_locals` and generator/coroutine frame attributes (`gi_frame`, `cr_frame`, `ag_frame`) were not properly blocked, providing a potential secondary escape vector.

### Fix
1.  **Input Normalization**: Applied `.normalize('NFKC')` to the source code string *before* any regex checks, aligning the validation process with Python's internal tokenizer.
2.  **Expanded Blocklist**: Added `f_locals`, `gi_frame`, `cr_frame`, and `ag_frame` to the strict deny `globalKeywords` list.
3.  **Tests Added**: Covered the unicode identifier bypass patterns with explicit unit tests in `codeSecurity.unicode.test.ts`.

---
*PR created automatically by Jules for task [11651751412840785551](https://jules.google.com/task/11651751412840785551) started by @saint2706*