### PR TITLE
🧪 Testing: Increase test coverage for frontmatter.ts

### DIFF
--- a/src/utils/__tests__/frontmatter.test.ts
+++ b/src/utils/__tests__/frontmatter.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { parseMarkdown } from '../frontmatter'
-import { parseMarkdown as parseMarkdownCore } from '../frontmatter-core.js'
+import { parseMarkdown, normalizeMarkdownLineEndings, parseNormalizedMarkdown } from '../frontmatter'
+import {
+  parseMarkdown as parseMarkdownCore,
+  normalizeMarkdownLineEndings as normalizeMarkdownLineEndingsCore,
+  parseNormalizedMarkdown as parseNormalizedMarkdownCore,
+} from '../frontmatter-core.js'
 
 describe('frontmatter parser parity', () => {
   const samples = [
@@ -14,6 +18,24 @@ describe('frontmatter parser parity', () => {
   it.each(samples)('returns identical parse output across app and core for sample %#', (raw) => {
     const appResult = parseMarkdown(raw)
     const coreResult = parseMarkdownCore(raw)
+
+    expect(coreResult).toEqual(appResult)
+    expect(Object.getPrototypeOf(appResult.frontmatter)).toBeNull()
+  })
+
+  it.each(samples)('normalizeMarkdownLineEndings returns identical output across app and core for sample %#', (raw) => {
+    const appResult = normalizeMarkdownLineEndings(raw)
+    const coreResult = normalizeMarkdownLineEndingsCore(raw)
+
+    expect(coreResult).toEqual(appResult)
+  })
+
+  it.each(samples)('parseNormalizedMarkdown returns identical output across app and core for sample %#', (raw) => {
+    // Normalizing first to strictly test parseNormalizedMarkdown.
+    const normalizedRaw = normalizeMarkdownLineEndings(raw)
+
+    const appResult = parseNormalizedMarkdown(normalizedRaw)
+    const coreResult = parseNormalizedMarkdownCore(normalizedRaw)
 
     expect(coreResult).toEqual(appResult)
     expect(Object.getPrototypeOf(appResult.frontmatter)).toBeNull()


### PR DESCRIPTION
- Added tests for `normalizeMarkdownLineEndings` in `src/utils/__tests__/frontmatter.test.ts`
- Added tests for `parseNormalizedMarkdown` in `src/utils/__tests__/frontmatter.test.ts`
- Verified tests pass and code coverage for `src/utils/frontmatter.ts` reaches 100%.

---
*PR created automatically by Jules for task [4256333219422279063](https://jules.google.com/task/4256333219422279063) started by @saint2706*