### PR TITLE
📚 Docs: Add missing JSDoc/TSDoc to core utility functions

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -4,6 +4,12 @@ This file tracks the status and completion of documentation tasks to ensure alig
 
 ## Completed Tasks
 
+- **[2026-03-07]** Added missing JSDoc/TSDoc comments to exported functions:
+  - `src/utils/contentLoader.ts`
+  - `src/utils/geminiClient.ts`
+  - `src/utils/searchIndex.ts`
+  - `src/utils/semanticSearch.ts`
+  - `src/utils/toc.ts`
 - **[2026-03-01]** Added missing JSDoc/TSDoc comments to exported functions:
   - `src/utils/dayToken.ts`
   - `src/utils/progressTracker.ts`

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -375,6 +375,12 @@ export function getAllExercises(): readonly ImmutableExercise[] {
   return immutableExercises
 }
 
+/**
+ * Retrieves all review card seeds from the lessons.
+ * Seeds are used to initialize the spaced repetition review system.
+ *
+ * @returns {readonly ImmutableReviewCardSeed[]} An immutable array of review card seeds extracted from all lessons.
+ */
 export function getAllReviewCardSeeds(): readonly ImmutableReviewCardSeed[] {
   initializeContent()
   if (!immutableReviewCards) {

--- a/src/utils/geminiClient.ts
+++ b/src/utils/geminiClient.ts
@@ -94,6 +94,12 @@ const FLASHCARD_BACK_MAX_LENGTH = 400
 const FLASHCARD_RETRY_ERROR_MESSAGE =
   'We could not generate valid flashcards this time. Please try again.'
 
+/**
+ * Synchronously checks if the Gemini API is believed to be available based on presence of API key
+ * and a cached availability flag. Note: this does not make a network request.
+ *
+ * @returns {boolean} True if Gemini API key exists and the API is not known to be unavailable.
+ */
 export function isGeminiAvailable(): boolean {
   const now = Date.now()
   const apiKey = getGeminiApiKey()
@@ -104,6 +110,12 @@ export function isGeminiAvailable(): boolean {
   return true
 }
 
+/**
+ * Asynchronously checks if the Gemini API is available.
+ * This is effectively a thin wrapper around `isGeminiAvailable` but returns a Promise.
+ *
+ * @returns {Promise<boolean>} Resolves to true if the Gemini API key exists.
+ */
 export async function checkGeminiAvailability(): Promise<boolean> {
   const now = Date.now()
   const available = !!getGeminiApiKey()
@@ -173,6 +185,15 @@ Rules:
 - Keep answers focused and under 300 words unless complexity demands more.
 - Use bullet points for multi-part answers.`
 
+/**
+ * Asks a question about a lesson using the Gemini API.
+ * The lesson content is injected as context into the prompt.
+ *
+ * @param {string} lessonContent - The markdown content of the lesson for context.
+ * @param {string} question - The user's question about the lesson.
+ * @param {ChatMessage[]} [history=[]] - Previous messages in the conversation.
+ * @returns {Promise<string>} The AI's response to the question.
+ */
 export async function askAboutLesson(
   lessonContent: string,
   question: string,
@@ -196,6 +217,13 @@ Rules:
 
 Format: [{"front": "question", "back": "answer"}, ...]`
 
+/**
+ * Uses Gemini API to automatically generate study flashcards based on lesson content.
+ * Flashcards cover definitions, conceptual questions, code output, and comparisons.
+ *
+ * @param {string} lessonContent - The markdown content of the lesson to generate flashcards from.
+ * @returns {Promise<Flashcard[]>} An array of flashcards parsed from the AI response.
+ */
 export async function generateFlashcards(lessonContent: string): Promise<Flashcard[]> {
   const system = `${FLASHCARD_SYSTEM}\n\n--- LESSON CONTENT ---\n${truncateContent(lessonContent)}\n--- END LESSON ---`
   const raw = await callGemini(system, 'Generate 8 flashcards from this lesson.')
@@ -256,6 +284,16 @@ const HINT_SYSTEMS: Record<1 | 2 | 3, string> = {
 - Include which specific methods to use.`,
 }
 
+/**
+ * Uses Gemini API to get progressive hints for an interactive coding exercise.
+ * Hints range from general conceptual guidance to specific code skeletons based on the level.
+ *
+ * @param {string} exerciseTitle - The title of the coding exercise.
+ * @param {string} exerciseGoal - The goal/instructions of the exercise.
+ * @param {string} starterCode - The initial starter code provided to the user.
+ * @param {1 | 2 | 3} level - The requested hint level (1=conceptual, 2=detailed, 3=skeleton).
+ * @returns {Promise<string>} The AI's generated hint response.
+ */
 export async function getExerciseHint(
   exerciseTitle: string,
   exerciseGoal: string,
@@ -269,6 +307,13 @@ export async function getExerciseHint(
 
 // ─── Feature 4: Text Embeddings ──────────────────────────────────────────────
 
+/**
+ * Uses Gemini API to generate text embeddings for semantic search.
+ * Text embeddings allow for conceptual matching rather than strict keyword matching.
+ *
+ * @param {string} text - The input text to generate an embedding for.
+ * @returns {Promise<number[]>} The generated text embedding vector.
+ */
 export async function embedText(text: string): Promise<number[]> {
   const genAI = getGenerativeAI()
   if (!genAI) throw new GeminiClientError('apiKeyInvalid')

--- a/src/utils/searchIndex.ts
+++ b/src/utils/searchIndex.ts
@@ -135,6 +135,14 @@ function scoreField(text: string | undefined, terms: readonly string[], weight: 
   return terms.reduce((acc, term) => (text.includes(term) ? acc + weight : acc), 0)
 }
 
+/**
+ * Calculates a ranking boost score for a search document based on query term occurrences.
+ * Weighted fields (title, concepts, tags, phase, day, body) contribute to the final boost.
+ *
+ * @param {SearchDocument} doc - The search document to evaluate.
+ * @param {readonly string[]} terms - The normalized search query terms.
+ * @returns {number} The calculated ranking boost score.
+ */
 export function computeRankingBoost(doc: SearchDocument, terms: readonly string[]): number {
   return (
     scoreField(doc.titleLower, terms, TITLE_WEIGHT) +
@@ -146,10 +154,23 @@ export function computeRankingBoost(doc: SearchDocument, terms: readonly string[
   )
 }
 
+/**
+ * Creates search-optimized documents from an array of lessons.
+ * Converts markdown content into plain text and extracts metadata for indexing.
+ *
+ * @param {readonly Lesson[]} lessons - An array of lessons to index.
+ * @returns {SearchDocument[]} An array of generated search documents.
+ */
 export function createSearchDocuments(lessons: readonly Lesson[]): SearchDocument[] {
   return lessons.map(toDocument)
 }
 
+/**
+ * Initializes a new Fuse.js search engine instance.
+ *
+ * @param {readonly Lesson[]} [lessons=getAllLessons()] - An array of lessons to populate the index.
+ * @returns {Fuse<SearchDocument>} The initialized Fuse.js search engine.
+ */
 export function createSearchEngine(lessons = getAllLessons()): Fuse<SearchDocument> {
   return new Fuse(createSearchDocuments(lessons), FUSE_OPTIONS)
 }
@@ -175,6 +196,11 @@ function emitStatus() {
   statusListeners.forEach((listener) => listener(status))
 }
 
+/**
+ * Retrieves the current status of the background search indexing process.
+ *
+ * @returns {SearchIndexStatus} The current indexing status object.
+ */
 export function getSearchIndexStatus(): SearchIndexStatus {
   const lessons = getAllLessonsCached()
   return {
@@ -185,6 +211,12 @@ export function getSearchIndexStatus(): SearchIndexStatus {
   }
 }
 
+/**
+ * Subscribes a listener to receive real-time search indexing status updates.
+ *
+ * @param {(status: SearchIndexStatus) => void} listener - The callback function to invoke with status updates.
+ * @returns {() => void} A cleanup function to unsubscribe the listener.
+ */
 export function subscribeSearchIndexStatus(
   listener: (status: SearchIndexStatus) => void,
 ): () => void {
@@ -238,6 +270,11 @@ function processChunk() {
   }
 }
 
+/**
+ * Initiates background processing to build the search index.
+ * It chunks document processing during browser idle time to avoid freezing the UI.
+ * Once complete, the cached engine is available for fast searching.
+ */
 export function startBackgroundIndexing(): void {
   if (isIndexing || indexingComplete || cachedEngine) return
   isIndexing = true
@@ -262,6 +299,14 @@ function getEngine(): Fuse<SearchDocument> | null {
   return partialEngine
 }
 
+/**
+ * Executes a full-text search against the curriculum index.
+ * Automatically triggers background indexing if not already started.
+ *
+ * @param {string} query - The search term or phrase.
+ * @param {number} [limit=20] - The maximum number of results to return.
+ * @returns {SearchResult[]} An array of search results, sorted by relevance score.
+ */
 export function search(query: string, limit = 20): SearchResult[] {
   if (!query.trim()) return []
   const engine = getEngine()
@@ -279,10 +324,26 @@ export function search(query: string, limit = 20): SearchResult[] {
     .slice(0, limit)
 }
 
+/**
+ * Extracts and normalizes individual unique terms from a search query.
+ * Useful for highlighting matched terms in UI components.
+ *
+ * @param {string} query - The raw search query.
+ * @returns {string[]} An array of normalized query terms.
+ */
 export function extractMatchedTerms(query: string): string[] {
   return Array.from(new Set(normalizeQuery(query)))
 }
 
+/**
+ * Generates a context-aware snippet from document text based on a search query.
+ * Attempts to extract a substring containing the first matched term, centered if possible.
+ *
+ * @param {string} content - The plain text document content.
+ * @param {string} query - The original search query.
+ * @param {number} [maxLength=180] - The maximum length of the generated snippet.
+ * @returns {string} The text snippet, optionally truncated with ellipses.
+ */
 export function getSearchSnippet(content: string, query: string, maxLength = 180): string {
   const plain = content.trim()
   if (!plain) return ''
@@ -304,6 +365,10 @@ export function getSearchSnippet(content: string, query: string, maxLength = 180
   return `${start > 0 ? '…' : ''}${snippet}${end < plain.length ? '…' : ''}`
 }
 
+/**
+ * Safely triggers the background preloading of the search index.
+ * Designed to be called on idle, deferring the heavy work of parsing documents.
+ */
 export function preloadSearchIndex(): void {
   try {
     startBackgroundIndexing()

--- a/src/utils/semanticSearch.ts
+++ b/src/utils/semanticSearch.ts
@@ -113,6 +113,12 @@ function notifyIndexingListeners(): void {
   indexingListeners.forEach((listener) => listener())
 }
 
+/**
+ * Subscribes a listener to semantic indexing status changes.
+ *
+ * @param {() => void} listener - The callback to execute when status changes.
+ * @returns {() => void} A function to unsubscribe the listener.
+ */
 export function subscribeSemanticIndexing(listener: () => void): () => void {
   indexingListeners.add(listener)
   return () => {
@@ -169,6 +175,11 @@ function buildHybridResults(
     .slice(0, limit)
 }
 
+/**
+ * Retrieves the current state and progress of background semantic indexing.
+ *
+ * @returns {SemanticIndexingStatus} An object describing the indexing status and progress.
+ */
 export function getSemanticIndexingStatus(): SemanticIndexingStatus {
   const cache = loadCache()
   const totalLessons = getAllLessons().length
@@ -225,6 +236,15 @@ function ensureBackgroundIndexing(
   return indexingPromise
 }
 
+/**
+ * Executes a hybrid semantic and lexical search against the lesson curriculum.
+ * Triggers background semantic indexing if not already complete.
+ *
+ * @param {string} query - The search query.
+ * @param {number} [limit=15] - Maximum number of results to return.
+ * @param {(results: SemanticResult[]) => void} [onProgress] - Optional callback to receive partial results while indexing.
+ * @returns {Promise<SemanticResult[]>} Resolves to an array of search results ordered by score.
+ */
 export async function semanticSearch(
   query: string,
   limit = 15,
@@ -253,11 +273,20 @@ export async function semanticSearch(
   return enrichedResults
 }
 
+/**
+ * Clears the local storage cache of document embeddings.
+ * Forces the system to re-index all documents on the next search.
+ */
 export function clearEmbeddingCache(): void {
   localStorage.removeItem(CACHE_KEY)
   notifyIndexingListeners()
 }
 
+/**
+ * Returns the number of cached text embeddings currently stored.
+ *
+ * @returns {number} The count of cached embeddings.
+ */
 export function getEmbeddingCacheSize(): number {
   const cache = loadCache()
   return Object.keys(cache.embeddings).length

--- a/src/utils/toc.ts
+++ b/src/utils/toc.ts
@@ -17,6 +17,13 @@ interface TocEntry {
   level: number
 }
 
+/**
+ * Parses markdown content to extract H2 and H3 headings for a Table of Contents.
+ * Ignores headings inside code blocks and generates unique URL-safe anchor IDs.
+ *
+ * @param {string} content - The markdown text to parse.
+ * @returns {TocEntry[]} An array of extracted headings with their text, level, and anchor ID.
+ */
 export function parseHeadings(content: string): TocEntry[] {
   const entries: TocEntry[] = []
   const lines = content.split('\n')


### PR DESCRIPTION
As requested by the "Docs" persona instructions to ensure all exported functions have JSDoc/TSDoc comments, I've audited the `src/utils` directory and added missing documentation.

### Changes Made:
*   **`src/utils/contentLoader.ts`**: Documented `getAllReviewCardSeeds`.
*   **`src/utils/geminiClient.ts`**: Documented `isGeminiAvailable`, `checkGeminiAvailability`, `askAboutLesson`, `generateFlashcards`, `getExerciseHint`, and `embedText`.
*   **`src/utils/searchIndex.ts`**: Documented `computeRankingBoost`, `createSearchDocuments`, `createSearchEngine`, `getSearchIndexStatus`, `subscribeSearchIndexStatus`, `startBackgroundIndexing`, `search`, `extractMatchedTerms`, `getSearchSnippet`, and `preloadSearchIndex`.
*   **`src/utils/semanticSearch.ts`**: Documented `subscribeSemanticIndexing`, `getSemanticIndexingStatus`, `semanticSearch`, `clearEmbeddingCache`, and `getEmbeddingCacheSize`.
*   **`src/utils/toc.ts`**: Documented `parseHeadings`.
*   **`.jules/docs-progress.md`**: Logged the completed documentation tasks.

### Verification:
*   Ran `npm run lint` (`tsc -b`) - Passed cleanly.
*   Ran `npm run test` (Vitest) - All 383 tests passed cleanly.
*   Ran `npm run validate-content` - Passed cleanly.

---
*PR created automatically by Jules for task [7169059124996907636](https://jules.google.com/task/7169059124996907636) started by @saint2706*