### PR TITLE
🧪 Testing: Fix Suspense warning in Lesson.test.tsx

### DIFF
--- a/src/pages/__tests__/Lesson.test.tsx
+++ b/src/pages/__tests__/Lesson.test.tsx
@@ -68,6 +68,10 @@ vi.mock('../../components/SEOHead', () => ({ default: () => null }))
 vi.mock('../../components/MarkdownRenderer', () => ({ default: () => null }))
 vi.mock('../../components/Breadcrumb', () => ({ default: () => null }))
 vi.mock('../../components/BackToTop', () => ({ default: () => null }))
+vi.mock('../../components/AiStudyPanel', () => ({
+  default: () => null,
+  __esModule: true,
+}))
 vi.mock('../../components/TableOfContents', () => ({ default: () => null }))
 vi.mock('../../components/ReadingTime', () => ({ default: () => null }))
 vi.mock('../../components/PrerequisitePills', () => ({ default: () => null }))


### PR DESCRIPTION
Fixes a warning in the Vitest test suite `A suspended resource finished loading inside a test, but the event was not wrapped in act(...)` by properly mocking the lazy-loaded `AiStudyPanel` in `src/pages/__tests__/Lesson.test.tsx`.

---
*PR created automatically by Jules for task [11336089311495673653](https://jules.google.com/task/11336089311495673653) started by @saint2706*