### PR TITLE
🎨 Picasso: [UX improvement] Add missing ARIA labels to interactive buttons

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -1,5 +1,10 @@
-# Picasso UX Learnings
+# UX and Accessibility Improvements Log
 
-- **Important Correction on Overlays**: Making a modal background overlay a focusable button (e.g., adding `role="button"`, `tabIndex={0}`, and `onKeyDown`) is an accessibility anti-pattern. If the overlay wraps the modal's contents, keyboard events inside the modal will bubble up and incorrectly close the modal. Focus should be trapped inside the modal, and the `Escape` key should be used globally to close it. Overlays should generally remain `role="presentation"` or `aria-hidden="true"`.
-- Always add `aria-pressed` or similar state attributes to state-toggling `<button>` elements (e.g. Try Solution, Reset Code).
-- Add descriptive `aria-label` attributes to icon-only buttons (like `Get Hint`).
+## 2024-03-07: Component ARIA Label Audit
+* **Goal**: Improve screen reader navigation by ensuring all icon-only or state-toggling buttons have descriptive, dynamic labels.
+* **Changes**:
+  * `TableOfContents.tsx`: Added dynamic `aria-label` to the compact mode toggle button depending on `isCompactOpen`.
+  * `ExerciseWidget.tsx`: Added `aria-hidden="true"` to the decorative lightbulb emoji in the hint button to prevent screen readers from reading "lightbulb Get Hint", allowing the dynamic text to stand alone.
+  * `SidebarPhaseGroup.tsx`: Added explicit `aria-label` to the phase toggle button including the phase number and title.
+  * `AiStudyPanel.tsx`: Refactored custom tab buttons to use correct `role="tablist"`, `role="tab"`, `role="tabpanel"`, and `aria-selected` attributes. Hid decorative emojis inside tabs with `aria-hidden="true"`.
+* **Impact**: Improved navigation for keyboard and screen reader users, satisfying WCAG guidelines for interactive elements without disrupting visual design.

--- a/src/components/AiStudyPanel.tsx
+++ b/src/components/AiStudyPanel.tsx
@@ -225,26 +225,30 @@ export default function AiStudyPanel({ lessonContent, lessonDay, lessonTitle }: 
               </div>
 
               {/* Tabs */}
-              <div className="ai-panel-tabs">
+              <div className="ai-panel-tabs" role="tablist">
                 <button
                   type="button"
+                  role="tab"
                   className={`ai-panel-tab ${activeTab === 'chat' ? 'active' : ''}`}
                   onClick={() => setActiveTab('chat')}
+                  aria-selected={activeTab === 'chat'}
                 >
-                  💬 Chat
+                  <span aria-hidden="true">💬</span> Chat
                 </button>
                 <button
                   type="button"
+                  role="tab"
                   className={`ai-panel-tab ${activeTab === 'flashcards' ? 'active' : ''}`}
                   onClick={() => setActiveTab('flashcards')}
+                  aria-selected={activeTab === 'flashcards'}
                 >
-                  🃏 Flashcards
+                  <span aria-hidden="true">🃏</span> Flashcards
                 </button>
               </div>
 
               {/* Chat Tab */}
               {activeTab === 'chat' && (
-                <>
+                <div role="tabpanel" aria-label="Chat panel">
                   {messages.length === 0 && (
                     <div className="ai-quick-actions">
                       {QUICK_ACTIONS.map((action) => (
@@ -332,12 +336,12 @@ export default function AiStudyPanel({ lessonContent, lessonDay, lessonTitle }: 
                       </button>
                     </div>
                   )}
-                </>
+                </div>
               )}
 
               {/* Flashcards Tab */}
               {activeTab === 'flashcards' && (
-                <div className="ai-flashcards">
+                <div className="ai-flashcards" role="tabpanel" aria-label="Flashcards panel">
                   {flashcards.length === 0 ? (
                     <div className="ai-empty-state">
                       <span className="ai-empty-icon">🃏</span>

--- a/src/components/ExerciseWidget.tsx
+++ b/src/components/ExerciseWidget.tsx
@@ -247,7 +247,8 @@ export default function ExerciseWidget({
             }}
             disabled={hintLoading || useAiAssistantStore.getState().getHintLevel(exerciseId) >= 3}
           >
-            💡 {hintLoading ? 'Thinking...' : 'Get Hint'}
+            <span aria-hidden="true">💡 </span>
+            {hintLoading ? 'Thinking...' : 'Get Hint'}
             <span className="exercise-hint-dots">
               {[1, 2, 3].map((level) => (
                 <span

--- a/src/components/SidebarPhaseGroup.tsx
+++ b/src/components/SidebarPhaseGroup.tsx
@@ -44,6 +44,7 @@ function SidebarPhaseGroup({
         onClick={() => onToggle(phase.phase)}
         aria-expanded={isActive}
         aria-controls={`phase-${phase.phase}-days`}
+        aria-label={`Toggle Phase ${phase.phase}: ${phase.title}`}
       >
         <span className="phase-toggle-icon" aria-hidden="true">
           {icon}

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -129,6 +129,7 @@ const TableOfContents = memo(function TableOfContents({ content }: TableOfConten
           className="toc-toggle"
           aria-expanded={isCompactOpen}
           aria-controls={tocListId}
+          aria-label={isCompactOpen ? 'Close table of contents' : 'Open table of contents'}
           onClick={() => setIsCompactOpen((prev) => !prev)}
         >
           <span>Jump to section</span>


### PR DESCRIPTION
Audits various interactive components (`TableOfContents`, `ExerciseWidget`, `SidebarPhaseGroup`, `AiStudyPanel`) to ensure all buttons acting as toggles or containing predominantly icons provide sufficient ARIA attributes for screen readers. It adds dynamic `aria-label`s and proper W3C roles for custom tabbed interfaces.

---
*PR created automatically by Jules for task [4385819148942005491](https://jules.google.com/task/4385819148942005491) started by @saint2706*