### PR TITLE
🎨 Picasso: [UX improvement] Enhance accessibility with dynamic ARIA and roles

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -1,10 +1,15 @@
-# UX and Accessibility Improvements Log
+# Picasso UX/Accessibility Learnings
 
-## 2024-03-07: Component ARIA Label Audit
-* **Goal**: Improve screen reader navigation by ensuring all icon-only or state-toggling buttons have descriptive, dynamic labels.
-* **Changes**:
-  * `TableOfContents.tsx`: Added dynamic `aria-label` to the compact mode toggle button depending on `isCompactOpen`.
-  * `ExerciseWidget.tsx`: Added `aria-hidden="true"` to the decorative lightbulb emoji in the hint button to prevent screen readers from reading "lightbulb Get Hint", allowing the dynamic text to stand alone.
-  * `SidebarPhaseGroup.tsx`: Added explicit `aria-label` to the phase toggle button including the phase number and title.
-  * `AiStudyPanel.tsx`: Refactored custom tab buttons to use correct `role="tablist"`, `role="tab"`, `role="tabpanel"`, and `aria-selected` attributes. Hid decorative emojis inside tabs with `aria-hidden="true"`.
-* **Impact**: Improved navigation for keyboard and screen reader users, satisfying WCAG guidelines for interactive elements without disrupting visual design.
+## Discovery and Prioritization
+* **CopyButton**: Identified that static `aria-label`s on buttons with dynamic states ("Copy" -> "Copied") prevent screen readers from announcing state changes.
+* **SidebarPhaseGroup**: Identified that putting a static `aria-label` on a button with rich internal `sr-only` content (like "5 of 10 completed") overrides the detailed internal text, reducing accessibility context.
+* **AiStudyPanel**: Identified that modal background overlays with `onClick` handlers need `role="presentation"` or `aria-hidden="true"` so screen readers don't misinterpret them as interactive content, while still allowing pointer users to click them to close the modal.
+
+## Implementations
+* **Dynamic ARIA Labels**: Always tie `aria-label` to the component's state if the text intent changes (e.g., `aria-label={copied ? 'Code copied to clipboard' : label}`).
+* **Avoid ARIA Overrides**: Do not use `aria-label` when a button already contains detailed visible or `sr-only` text that perfectly describes its function and state. Let the screen reader read the DOM content.
+* **Presentation Roles**: Applied `role="presentation"` to `div` elements that act as click-to-close backdrops for modals to satisfy accessibility guidelines without adding redundant keyboard handlers to decorative elements.
+
+## Verification
+* Verified changes via visual UI tests (Playwright) and unit tests (`npm run test`).
+* Ensured no linting or build regressions were introduced.

--- a/src/components/AiStudyPanel.tsx
+++ b/src/components/AiStudyPanel.tsx
@@ -206,6 +206,7 @@ export default function AiStudyPanel({ lessonContent, lessonDay, lessonTitle }: 
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               onClick={close}
+              role="presentation"
             />
             <motion.div
               className="ai-panel"

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -66,7 +66,7 @@ export default function CopyButton({
       type="button"
       className={className}
       onClick={handleCopy}
-      aria-label={label}
+      aria-label={copied ? 'Code copied to clipboard' : label}
       title={label}
     >
       {copied ? '✓ Copied' : showEmoji ? '📋 Copy' : 'Copy'}

--- a/src/components/SidebarPhaseGroup.tsx
+++ b/src/components/SidebarPhaseGroup.tsx
@@ -44,7 +44,6 @@ function SidebarPhaseGroup({
         onClick={() => onToggle(phase.phase)}
         aria-expanded={isActive}
         aria-controls={`phase-${phase.phase}-days`}
-        aria-label={`Toggle Phase ${phase.phase}: ${phase.title}`}
       >
         <span className="phase-toggle-icon" aria-hidden="true">
           {icon}


### PR DESCRIPTION
This PR implements small, targeted accessibility and UX improvements discovered during a "Picasso" design audit.

1. **CopyButton**: Modified the `aria-label` to dynamically announce "Code copied to clipboard" when the user successfully copies a code snippet, replacing the static "Copy code" label which screen readers would repeat.
2. **SidebarPhaseGroup**: Removed the explicit `aria-label="Toggle Phase [N]"`. It was overriding the rich `sr-only` internal text (e.g., "5 of 10 completed"). Removing it allows screen readers to announce the button's native content alongside its `aria-expanded` toggle state.
3. **AiStudyPanel**: Added `role="presentation"` to the modal backdrop overlay. Since it has an `onClick` handler strictly for visual convenience (clicking outside to close), this prevents screen readers from treating the background as an actionable UI element that needs keyboard focus.

### Verification
- Ran unit tests (`npm run test`) to ensure no regressions.
- Visually verified the UI with Playwright screenshots.
- Recorded learnings and patterns in `.jules/picasso.md`.

---
*PR created automatically by Jules for task [9372373993012512023](https://jules.google.com/task/9372373993012512023) started by @saint2706*