### PR TITLE
📚 Docs: Add missing JSDocs to exported components and utilities

### DIFF
--- a/scripts/find-missing-jsdoc.cjs
+++ b/scripts/find-missing-jsdoc.cjs
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+function findMissingJSDoc(dir) {
+  let files = [];
+  try {
+    const list = fs.readdirSync(dir);
+    list.forEach((file) => {
+      file = path.join(dir, file);
+      const stat = fs.statSync(file);
+      if (stat && stat.isDirectory() && !file.includes('__tests__')) {
+        files = files.concat(findMissingJSDoc(file));
+      } else {
+        if (file.endsWith('.ts') || file.endsWith('.tsx')) {
+          files.push(file);
+        }
+      }
+    });
+  } catch(e) {}
+  return files;
+}
+
+const allFiles = [...findMissingJSDoc('src/utils'), ...findMissingJSDoc('src/components')];
+
+const missing = [];
+
+for (const file of allFiles) {
+  const content = fs.readFileSync(file, 'utf8');
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.match(/^export (function|const) [A-Za-z0-9_]+/)) {
+      if (i === 0 || !lines[i-1].includes('*/')) {
+        missing.push(`${file}:${i+1}:${line}`);
+      }
+    }
+  }
+}
+
+console.log(missing.join('\n'));

--- a/src/components/EmptyStateIllustrations.tsx
+++ b/src/components/EmptyStateIllustrations.tsx
@@ -15,6 +15,11 @@ interface IllustrationProps {
   className?: string
 }
 
+/**
+ * Renders an illustration indicating an empty search result.
+ * @param props - Component props containing optional className
+ * @returns SVG element representing the search empty state
+ */
 export function SearchEmptyIllustration({ className = '' }: IllustrationProps) {
   const reducedMotion = !!useReducedMotion()
   return (
@@ -62,6 +67,11 @@ export function SearchEmptyIllustration({ className = '' }: IllustrationProps) {
   )
 }
 
+/**
+ * Renders an illustration indicating no exercises are available.
+ * @param props - Component props containing optional className
+ * @returns SVG element representing the exercises empty state
+ */
 export function ExercisesEmptyIllustration({ className = '' }: IllustrationProps) {
   const reducedMotion = !!useReducedMotion()
   return (
@@ -124,6 +134,11 @@ export function ExercisesEmptyIllustration({ className = '' }: IllustrationProps
   )
 }
 
+/**
+ * Renders an illustration indicating a fresh start or empty history.
+ * @param props - Component props containing optional className
+ * @returns SVG element representing the fresh start state
+ */
 export function FreshStartIllustration({ className = '' }: IllustrationProps) {
   const reducedMotion = !!useReducedMotion()
   return (

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -35,7 +35,7 @@ const TocItem = memo(
       </li>
     )
   },
-  (prevProps, nextProps) => prevProps.isActive === nextProps.isActive
+  (prevProps, nextProps) => prevProps.isActive === nextProps.isActive,
 )
 
 interface TableOfContentsProps {

--- a/src/utils/__tests__/frontmatter.test.ts
+++ b/src/utils/__tests__/frontmatter.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { parseMarkdown, normalizeMarkdownLineEndings, parseNormalizedMarkdown } from '../frontmatter'
+import {
+  parseMarkdown,
+  normalizeMarkdownLineEndings,
+  parseNormalizedMarkdown,
+} from '../frontmatter'
 import {
   parseMarkdown as parseMarkdownCore,
   normalizeMarkdownLineEndings as normalizeMarkdownLineEndingsCore,
@@ -23,21 +27,27 @@ describe('frontmatter parser parity', () => {
     expect(Object.getPrototypeOf(appResult.frontmatter)).toBeNull()
   })
 
-  it.each(samples)('normalizeMarkdownLineEndings returns identical output across app and core for sample %#', (raw) => {
-    const appResult = normalizeMarkdownLineEndings(raw)
-    const coreResult = normalizeMarkdownLineEndingsCore(raw)
+  it.each(samples)(
+    'normalizeMarkdownLineEndings returns identical output across app and core for sample %#',
+    (raw) => {
+      const appResult = normalizeMarkdownLineEndings(raw)
+      const coreResult = normalizeMarkdownLineEndingsCore(raw)
 
-    expect(coreResult).toEqual(appResult)
-  })
+      expect(coreResult).toEqual(appResult)
+    },
+  )
 
-  it.each(samples)('parseNormalizedMarkdown returns identical output across app and core for sample %#', (raw) => {
-    // Normalizing first to strictly test parseNormalizedMarkdown.
-    const normalizedRaw = normalizeMarkdownLineEndings(raw)
+  it.each(samples)(
+    'parseNormalizedMarkdown returns identical output across app and core for sample %#',
+    (raw) => {
+      // Normalizing first to strictly test parseNormalizedMarkdown.
+      const normalizedRaw = normalizeMarkdownLineEndings(raw)
 
-    const appResult = parseNormalizedMarkdown(normalizedRaw)
-    const coreResult = parseNormalizedMarkdownCore(normalizedRaw)
+      const appResult = parseNormalizedMarkdown(normalizedRaw)
+      const coreResult = parseNormalizedMarkdownCore(normalizedRaw)
 
-    expect(coreResult).toEqual(appResult)
-    expect(Object.getPrototypeOf(appResult.frontmatter)).toBeNull()
-  })
+      expect(coreResult).toEqual(appResult)
+      expect(Object.getPrototypeOf(appResult.frontmatter)).toBeNull()
+    },
+  )
 })

--- a/src/utils/__tests__/toast.test.ts
+++ b/src/utils/__tests__/toast.test.ts
@@ -1,103 +1,103 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { toast } from 'react-hot-toast';
-import { toastSuccess, toastError, toastInfo, TOAST_DEFAULT_OPTIONS } from '../toast';
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { toast } from 'react-hot-toast'
+import { toastSuccess, toastError, toastInfo, TOAST_DEFAULT_OPTIONS } from '../toast'
 
 vi.mock('react-hot-toast', () => {
-  const toastMock: any = vi.fn();
-  toastMock.success = vi.fn();
-  toastMock.error = vi.fn();
+  const toastMock: any = vi.fn()
+  toastMock.success = vi.fn()
+  toastMock.error = vi.fn()
   return {
     toast: toastMock,
-  };
-});
+  }
+})
 
 describe('toast utility', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-  });
+    vi.clearAllMocks()
+  })
 
   describe('toastSuccess', () => {
     it('should call toast.success with the correct message and options', () => {
       // Arrange
-      const message = 'Success message';
-      const options = { duration: 2000 };
+      const message = 'Success message'
+      const options = { duration: 2000 }
 
       // Act
-      toastSuccess(message, options);
+      toastSuccess(message, options)
 
       // Assert
-      expect(toast.success).toHaveBeenCalledWith(message, options);
-    });
+      expect(toast.success).toHaveBeenCalledWith(message, options)
+    })
 
     it('should call toast.success with only the message when options are omitted', () => {
       // Arrange
-      const message = 'Success message';
+      const message = 'Success message'
 
       // Act
-      toastSuccess(message);
+      toastSuccess(message)
 
       // Assert
-      expect(toast.success).toHaveBeenCalledWith(message, undefined);
-    });
-  });
+      expect(toast.success).toHaveBeenCalledWith(message, undefined)
+    })
+  })
 
   describe('toastError', () => {
     it('should call toast.error with the correct message and options', () => {
       // Arrange
-      const message = 'Error message';
-      const options = { duration: 5000 };
+      const message = 'Error message'
+      const options = { duration: 5000 }
 
       // Act
-      toastError(message, options);
+      toastError(message, options)
 
       // Assert
-      expect(toast.error).toHaveBeenCalledWith(message, options);
-    });
+      expect(toast.error).toHaveBeenCalledWith(message, options)
+    })
 
     it('should call toast.error with only the message when options are omitted', () => {
       // Arrange
-      const message = 'Error message';
+      const message = 'Error message'
 
       // Act
-      toastError(message);
+      toastError(message)
 
       // Assert
-      expect(toast.error).toHaveBeenCalledWith(message, undefined);
-    });
-  });
+      expect(toast.error).toHaveBeenCalledWith(message, undefined)
+    })
+  })
 
   describe('toastInfo', () => {
     it('should call toast with the correct message and options', () => {
       // Arrange
-      const message = 'Info message';
-      const options = { duration: 3000 };
+      const message = 'Info message'
+      const options = { duration: 3000 }
 
       // Act
-      toastInfo(message, options);
+      toastInfo(message, options)
 
       // Assert
-      expect(toast).toHaveBeenCalledWith(message, options);
-    });
+      expect(toast).toHaveBeenCalledWith(message, options)
+    })
 
     it('should call toast with only the message when options are omitted', () => {
       // Arrange
-      const message = 'Info message';
+      const message = 'Info message'
 
       // Act
-      toastInfo(message);
+      toastInfo(message)
 
       // Assert
-      expect(toast).toHaveBeenCalledWith(message, undefined);
-    });
-  });
+      expect(toast).toHaveBeenCalledWith(message, undefined)
+    })
+  })
 
   describe('TOAST_DEFAULT_OPTIONS', () => {
     it('should have the correct default options defined', () => {
       // Assert
-      expect(TOAST_DEFAULT_OPTIONS.duration).toBe(3500);
-      expect(TOAST_DEFAULT_OPTIONS.style).toBeDefined();
-      expect(TOAST_DEFAULT_OPTIONS.success).toBeDefined();
-      expect(TOAST_DEFAULT_OPTIONS.error).toBeDefined();
-    });
-  });
-});
+      expect(TOAST_DEFAULT_OPTIONS.duration).toBe(3500)
+      expect(TOAST_DEFAULT_OPTIONS.style).toBeDefined()
+      expect(TOAST_DEFAULT_OPTIONS.success).toBeDefined()
+      expect(TOAST_DEFAULT_OPTIONS.error).toBeDefined()
+    })
+  })
+})

--- a/src/utils/reviewTracker.ts
+++ b/src/utils/reviewTracker.ts
@@ -253,4 +253,7 @@ export function clearReviewState(): void {
   removeStoredValue(REVIEW_STORAGE_KEY)
 }
 
+/**
+ * Storage key for persisting review state in localStorage.
+ */
 export const reviewStorageKey = REVIEW_STORAGE_KEY


### PR DESCRIPTION
Audited the repository for missing documentation on exported constants and functions, acting as "Docs". Identified specific missing elements using a custom Node.js script.

Added missing JSDoc comments to:
- `SearchEmptyIllustration`, `ExercisesEmptyIllustration`, `FreshStartIllustration` in `src/components/EmptyStateIllustrations.tsx`
- `reviewStorageKey` in `src/utils/reviewTracker.ts`

Fixed lingering formatting violations via `npm run format`. Tests, build, and linters pass cleanly.

---
*PR created automatically by Jules for task [6970955320878859958](https://jules.google.com/task/6970955320878859958) started by @saint2706*