### PR TITLE
Tighten narrow-screen overflow coverage for lesson code blocks

### DIFF
--- a/tests/e2e/accessibility-responsive.spec.ts
+++ b/tests/e2e/accessibility-responsive.spec.ts
@@ -140,7 +140,7 @@ test.describe('accessibility and responsive layout', () => {
             const style = window.getComputedStyle(element)
             if (style.display === 'none' || style.visibility === 'hidden') return false
             if (element.closest('.sidebar') && !element.closest('.sidebar.open')) return false
-            if (element.closest('.table-wrapper, .code-block-wrapper, pre, code')) return false
+            if (element.closest('.table-wrapper')) return false
 
             const rect = element.getBoundingClientRect()
             return rect.right > viewport + 1 && rect.left < viewport + 1
@@ -157,6 +157,38 @@ test.describe('accessibility and responsive layout', () => {
         overflowOffenders,
         `${route.url} should not visibly overflow on a narrow viewport`,
       ).toEqual([])
+
+      if (route.url === '/#/lesson/1') {
+        const codeBlockOverflow = await page.evaluate(() => {
+          const viewport = window.innerWidth
+
+          return Array.from(document.querySelectorAll<HTMLElement>('.code-block-wrapper'))
+            .filter((element) => {
+              const rect = element.getBoundingClientRect()
+              return rect.width > viewport + 1 || rect.right > viewport + 1 || rect.left < -1
+            })
+            .map((element) => ({
+              tag: element.tagName.toLowerCase(),
+              className: typeof element.className === 'string' ? element.className : '',
+              text: (element.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 80),
+            }))
+            .slice(0, 10)
+        })
+
+        expect(
+          codeBlockOverflow,
+          'Lesson 1 code blocks should fit within the viewport width',
+        ).toEqual([])
+
+        const hasHorizontalPageScroll = await page.evaluate(
+          () => document.documentElement.scrollWidth > window.innerWidth + 1,
+        )
+
+        expect(
+          hasHorizontalPageScroll,
+          'Lesson 1 should not introduce horizontal page scrolling',
+        ).toBe(false)
+      }
     }
   })
 })


### PR DESCRIPTION
### Motivation
- Ensure fenced code blocks are included in the narrow-viewport overflow scan so broken layouts in rendered lessons are caught. 
- Add an explicit check for Lesson 1 code blocks to make failures easy to diagnose and to verify the page does not introduce horizontal scrolling.

### Description
- Updated `tests/e2e/accessibility-responsive.spec.ts` so the overflow filter only exempts `.table-wrapper` and no longer excludes code-related nodes. 
- Added a focused assertion for the `/#/lesson/1` route that selects `.code-block-wrapper` elements and fails with diagnostic payload (`tag`, `className`, `text`) if any code block exceeds the viewport bounds. 
- Added a page-level assertion for Lesson 1 to ensure no horizontal page scroll is introduced by the lesson (`document.documentElement.scrollWidth <= window.innerWidth + 1`).

### Testing
- Ran `npx playwright install chromium` successfully to download Playwright Chromium. 
- Ran `npx playwright test tests/e2e/accessibility-responsive.spec.ts` which could not complete in this environment because Chromium failed to launch due to a missing system library (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af92b07298832b896c1b97cc27d836)