### PR TITLE
Improve mobile markdown code block wrapping

### DIFF
--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -170,6 +170,22 @@
   overflow-wrap: inherit;
 }
 
+@media (max-width: 640px) {
+  .markdown-body .code-block-wrapper pre {
+    white-space: pre-wrap !important;
+    overflow-wrap: anywhere !important;
+    word-break: break-word !important;
+  }
+
+  .markdown-body .code-block-wrapper pre code {
+    white-space: pre-wrap !important;
+    overflow-wrap: anywhere !important;
+    word-break: break-word !important;
+    font-size: 0.8125rem !important;
+    line-height: 1.6 !important;
+  }
+}
+
 /* Tables */
 .markdown-body .table-wrapper {
   overflow-x: auto;


### PR DESCRIPTION
### Motivation
- Ensure fenced code blocks in rendered markdown wrap and remain readable on small screens while overriding third-party syntax highlighter defaults.

### Description
- Added an `@media (max-width: 640px)` block to `src/styles/markdown.css` targeting `.markdown-body .code-block-wrapper pre` and `.markdown-body .code-block-wrapper pre code` to enforce `white-space: pre-wrap`, `overflow-wrap: anywhere`, and `word-break: break-word` with `!important`, and slightly reduced monospace `font-size` and `line-height` for improved mobile readability.

### Testing
- Ran `npx prettier --check src/styles/markdown.css` and it passed.
- Ran `npm run typecheck` (`tsc -b`) and it passed.
- Ran `npm run format:check` which reported unrelated formatting warnings in other files (12 files) that are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af93629054832bb825226679ac1bac)