### PR TITLE
Scope markdown code block styling to wrapped class

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -59,7 +59,7 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
   }
 
   return (
-    <div className="code-block-wrapper">
+    <div className="code-block-wrapper code-block--wrapped">
       <div className="code-block-header">
         <span className="code-block-lang">{lang}</span>
         <div style={{ display: 'flex', gap: '0.4rem', alignItems: 'center' }}>

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -106,7 +106,7 @@
 }
 
 /* Code blocks */
-.markdown-body .code-block-wrapper {
+.markdown-body .code-block--wrapped {
   margin: 1.25rem 0;
   max-width: 100%;
   border-radius: var(--radius-md);
@@ -150,7 +150,7 @@
   border-color: var(--border-active);
 }
 
-.markdown-body pre {
+.markdown-body .code-block--wrapped pre {
   margin: 0 !important;
   max-width: 100%;
   padding: 1rem !important;
@@ -162,7 +162,7 @@
   overflow-wrap: anywhere;
 }
 
-.markdown-body pre code {
+.markdown-body .code-block--wrapped pre code {
   font-family: var(--font-mono) !important;
   font-size: 0.875rem !important;
   line-height: 1.75 !important;
@@ -171,13 +171,13 @@
 }
 
 @media (max-width: 640px) {
-  .markdown-body .code-block-wrapper pre {
+  .markdown-body .code-block--wrapped pre {
     white-space: pre-wrap !important;
     overflow-wrap: anywhere !important;
     word-break: break-word !important;
   }
 
-  .markdown-body .code-block-wrapper pre code {
+  .markdown-body .code-block--wrapped pre code {
     white-space: pre-wrap !important;
     overflow-wrap: anywhere !important;
     word-break: break-word !important;
@@ -341,7 +341,7 @@
   color: color-mix(in srgb, var(--accent-tertiary) 88%, var(--text-primary) 12%);
 }
 
-.lesson-reading-surface .markdown-body .code-block-wrapper,
+.lesson-reading-surface .markdown-body .code-block--wrapped,
 .lesson-reading-surface .markdown-body .table-wrapper,
 .lesson-reading-surface .markdown-body details {
   border-color: color-mix(in srgb, var(--border-card) 84%, transparent);


### PR DESCRIPTION
### Motivation
- Provide a stable CSS extension point for fenced code blocks so mobile wrapping and future opt-outs can be applied without touching syntax-highlighter internals.

### Description
- Emit a stable wrapper class by changing `CodeBlock` to use `className="code-block-wrapper code-block--wrapped"` for fenced blocks in `src/components/MarkdownRenderer.tsx`.
- Narrow CSS rules in `src/styles/markdown.css` to target `.code-block--wrapped` for block-level `pre`/`code` styling and mobile wrapping behavior instead of the broad `.markdown-body pre` selectors.
- Update lesson-surface overrides to use `.code-block--wrapped` for consistent theming and border color behavior.

### Testing
- Ran `npm run typecheck` (invokes `tsc -b`) and it completed successfully.
- Launched the dev server with `npm run dev` and the site started successfully for visual verification.
- Captured a Playwright screenshot of the running app to validate the rendered code-block markup and styling, and the capture completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af946774c0832b96b2f4361eddfbcb)