### PR TITLE
Expand MarkdownRenderer wrapping coverage for long code lines

### DIFF
--- a/src/components/__tests__/MarkdownRenderer.test.tsx
+++ b/src/components/__tests__/MarkdownRenderer.test.tsx
@@ -3,15 +3,19 @@ import { act } from 'react'
 import { createRoot, Root } from 'react-dom/client'
 import MarkdownRenderer from '../MarkdownRenderer'
 
-const syntaxHighlighterMock = vi.fn(({ children, wrapLongLines, codeTagProps }: any) => (
-  <div
-    className="syntax-highlighter"
-    data-wrap-long-lines={String(Boolean(wrapLongLines))}
-    data-white-space={codeTagProps?.style?.whiteSpace ?? ''}
-  >
-    {children}
-  </div>
-))
+const syntaxHighlighterMock = vi.fn(
+  ({ children, wrapLongLines, codeTagProps, customStyle }: any) => (
+    <div
+      className="syntax-highlighter"
+      data-wrap-long-lines={String(Boolean(wrapLongLines))}
+      data-white-space={codeTagProps?.style?.whiteSpace ?? ''}
+      data-overflow-wrap={codeTagProps?.style?.overflowWrap ?? ''}
+      data-overflow-x={customStyle?.overflowX ?? ''}
+    >
+      {children}
+    </div>
+  ),
+)
 
 // Mock Child Components
 vi.mock('../CodePlayground', () => ({
@@ -54,6 +58,7 @@ describe('MarkdownRenderer', () => {
   let root: Root
 
   beforeEach(() => {
+    syntaxHighlighterMock.mockClear()
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -98,6 +103,24 @@ describe('MarkdownRenderer', () => {
     const syntaxHighlighter = container.querySelector('.syntax-highlighter')
     expect(syntaxHighlighter?.getAttribute('data-wrap-long-lines')).toBe('true')
     expect(syntaxHighlighter?.getAttribute('data-white-space')).toBe('pre-wrap')
+    expect(syntaxHighlighter?.getAttribute('data-overflow-wrap')).toBe('anywhere')
+    expect(syntaxHighlighter?.getAttribute('data-overflow-x')).toBe('visible')
+  })
+
+  it('applies wrapping props for unbroken long tokens to avoid horizontal scrolling', () => {
+    const longToken = 'https://example.com/' + 'averylongsegment'.repeat(30)
+    const content = `\`\`\`python\n${longToken}\n\`\`\``
+
+    act(() => {
+      root.render(<MarkdownRenderer content={content} />)
+    })
+
+    const [highlighterProps] = syntaxHighlighterMock.mock.calls.at(-1) ?? []
+    expect(highlighterProps).toBeTruthy()
+    expect(highlighterProps.wrapLongLines).toBe(true)
+    expect(highlighterProps.codeTagProps?.style?.whiteSpace).toBe('pre-wrap')
+    expect(highlighterProps.codeTagProps?.style?.overflowWrap).toBe('anywhere')
+    expect(highlighterProps.customStyle?.overflowX).toBe('visible')
   })
 
   it('renders "Try It" button for Python code blocks', () => {


### PR DESCRIPTION
### Motivation
- Ensure code blocks avoid horizontal scrolling by verifying wrapping-related props are applied to the syntax highlighter and code tag.
- Keep tests deterministic and fast by continuing to use the existing `syntaxHighlighterMock` data-attribute pattern for assertions.

### Description
- Extend the test mock to expose `codeTagProps.style.overflowWrap` and `customStyle.overflowX` via data attributes on the `syntaxHighlighterMock` element.
- Clear `syntaxHighlighterMock` in `beforeEach` with `syntaxHighlighterMock.mockClear()` to make per-test call-level assertions deterministic.
- Strengthen the existing `enables long-line wrapping for fenced code blocks` test to assert `overflowWrap` is `anywhere` and `overflowX` is `visible`.
- Add a new test that renders an unbroken long token (a very long URL) and asserts the syntax-highlighter mock received `wrapLongLines`, `codeTagProps.style.whiteSpace`, `codeTagProps.style.overflowWrap`, and `customStyle.overflowX` to prevent horizontal scrolling.

### Testing
- Ran the file-local test suite with `npm test -- src/components/__tests__/MarkdownRenderer.test.tsx` and all tests passed.
- Test run summary: `1 file, 16 tests` executed and `16 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af954dfc48832bb30fd6c80ab708e6)