### PR TITLE
Improve code-block wrapping and playground rendering; remove site canonical link

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="manifest" href="/Coding-For-MBA/manifest.json" />
-    <link rel="canonical" href="https://saint2706.github.io/Coding-For-MBA/" />
     <meta name="author" content="Coding for MBA" />
     <meta name="robots" content="index, follow" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/components/CodePlayground.tsx
+++ b/src/components/CodePlayground.tsx
@@ -253,6 +253,7 @@ const CodePlayground = forwardRef<CodePlaygroundHandle, CodePlaygroundProps>(
               style={highlightTheme}
               language="python"
               PreTag="div"
+              wrapLongLines
               customStyle={{
                 margin: 0,
                 padding: '0.6rem 0.75rem',
@@ -260,9 +261,18 @@ const CodePlayground = forwardRef<CodePlaygroundHandle, CodePlaygroundProps>(
                 fontSize: '0.875rem',
                 lineHeight: '1.6',
                 fontFamily: 'var(--font-mono)',
+                whiteSpace: 'pre-wrap',
+                overflowWrap: 'anywhere',
+                wordBreak: 'break-word',
+                overflowX: 'hidden',
               }}
               codeTagProps={{
-                style: { fontFamily: 'var(--font-mono)' },
+                style: {
+                  fontFamily: 'var(--font-mono)',
+                  whiteSpace: 'pre-wrap',
+                  overflowWrap: 'anywhere',
+                  wordBreak: 'break-word',
+                },
               }}
             >
               {deferredCode + '\n'}

--- a/src/components/ExerciseWidget.tsx
+++ b/src/components/ExerciseWidget.tsx
@@ -300,6 +300,7 @@ export default function ExerciseWidget({
                       style={solutionTheme}
                       language="python"
                       PreTag="div"
+                      wrapLongLines
                       customStyle={{
                         margin: 0,
                         padding: '0.75rem',
@@ -307,10 +308,17 @@ export default function ExerciseWidget({
                         fontSize: '0.8125rem',
                         lineHeight: '1.65',
                         borderRadius: 'var(--radius-sm)',
+                        whiteSpace: 'pre-wrap',
+                        overflowWrap: 'anywhere',
+                        wordBreak: 'break-word',
+                        overflowX: 'hidden',
                       }}
                       codeTagProps={{
                         style: {
                           fontFamily: 'var(--font-mono)',
+                          whiteSpace: 'pre-wrap',
+                          overflowWrap: 'anywhere',
+                          wordBreak: 'break-word',
                         },
                       }}
                     >

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -87,7 +87,10 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
           background: 'transparent',
           fontSize: '0.8125rem',
           lineHeight: '1.65',
-          overflowX: 'visible',
+          overflowX: 'hidden',
+          whiteSpace: 'pre-wrap',
+          overflowWrap: 'anywhere',
+          wordBreak: 'break-word',
         }}
         tabIndex={0}
         codeTagProps={{
@@ -95,6 +98,7 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
             fontFamily: 'var(--font-mono)',
             whiteSpace: 'pre-wrap',
             overflowWrap: 'anywhere',
+            wordBreak: 'break-word',
           },
         }}
       >

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -106,6 +106,32 @@
 }
 
 /* Code blocks */
+
+.markdown-body pre {
+  margin: 1.25rem 0;
+  max-width: 100%;
+  overflow-x: auto;
+  padding: 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-card);
+  background: var(--bg-code);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.markdown-body pre code {
+  white-space: inherit;
+  overflow-wrap: inherit;
+  word-break: inherit;
+}
+
+.markdown-body pre code * {
+  white-space: inherit;
+  overflow-wrap: inherit;
+  word-break: inherit;
+}
+
 .markdown-body .code-block--wrapped {
   margin: 1.25rem 0;
   max-width: 100%;
@@ -167,7 +193,26 @@
   font-size: 0.875rem !important;
   line-height: 1.75 !important;
   white-space: inherit !important;
-  overflow-wrap: inherit;
+  overflow-wrap: anywhere !important;
+  word-break: break-word !important;
+}
+
+.markdown-body .code-block--wrapped pre code * {
+  white-space: inherit !important;
+  overflow-wrap: inherit !important;
+  word-break: inherit !important;
+}
+
+.markdown-body .code-block--wrapped code[class*='language-'] {
+  white-space: pre-wrap !important;
+  overflow-wrap: anywhere !important;
+  word-break: break-word !important;
+}
+
+.markdown-body .code-block--wrapped code[class*='language-'] * {
+  white-space: inherit !important;
+  overflow-wrap: inherit !important;
+  word-break: inherit !important;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
### Motivation

- Prevent long code lines from causing horizontal scroll and overflow in rendered code blocks and the interactive playground. 
- Ensure code copy/playground UI remains usable with very long tokens/lines by enabling wrapping and word-breaking. 
- Remove an explicit site `rel="canonical"` tag that pointed to the GitHub Pages URL to avoid hard-coded canonicalization.

### Description

- Enabled `wrapLongLines` and added `white-space: 'pre-wrap'`, `overflow-wrap: 'anywhere'`, and `word-break: 'break-word'` (and related styles) for `SyntaxHighlighter` instances in `CodePlayground.tsx`, `ExerciseWidget.tsx`, and `MarkdownRenderer.tsx` to improve wrapping behavior. 
- Updated `markdown.css` with new rules for `.markdown-body pre`, `pre code`, and `.code-block--wrapped` to normalize wrapping/word-break across code blocks and remove horizontal overflow. 
- Changed `overflowX` handling in `MarkdownRenderer.tsx` from `visible` to `hidden` to avoid horizontal scroll artifacts. 
- Removed the hard-coded `<link rel="canonical">` entry from `index.html`.

### Testing

- Ran a production build with `npm run build`, and the build completed successfully. 
- Executed the test suite with `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afb00af970832b8c5a2e48a35319ce)