### PR TITLE
Harden deploy workflow_run trigger conditions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_repository.full_name == github.repository) }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
### Motivation
- Remediate a GitHub Actions authorization bypass where the `deploy` workflow could be triggered by successful CI runs from pull requests (including forks), allowing untrusted code to deploy to GitHub Pages.
- Ensure only trusted upstream runs (pushes from the same repository) or manual dispatch can perform site deployments.

### Description
- Tighten the `build` job `if` condition in `.github/workflows/deploy.yml` to run only when `github.event_name == 'workflow_dispatch'` or when the triggering `workflow_run` both concluded successfully and was a `push` from the same repository by checking `github.event.workflow_run.event == 'push'` and `github.event.workflow_run.head_repository.full_name == github.repository`.
- Preserve manual `workflow_dispatch` deployments and avoid changing other workflow behavior.

### Testing
- Ran `actionlint .github/workflows/*.yml` against the modified workflows and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b114c275f883309e0762055f98c16c)