### PR TITLE
🧪 Testing: fix invalid DOM property fetchpriority warning

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -145,7 +145,7 @@ const ImageComponent = (props: JSX.IntrinsicElements['img'] & ExtraProps) => {
     <img
       loading={isHighPriority ? 'eager' : 'lazy'}
       decoding="async"
-      fetchpriority={isHighPriority ? 'high' : undefined}
+      fetchPriority={isHighPriority ? 'high' : undefined}
       alt={rest.alt || 'Course image'}
       {...rest}
     />


### PR DESCRIPTION
Replaced `fetchpriority` with `fetchPriority` in `MarkdownRenderer.tsx` ImageComponent to resolve the React warning `Invalid DOM property 'fetchpriority'. Did you mean 'fetchPriority'?`. This cleans up the testing/build logs and ensures strict adherence to React's attribute conventions. Validated by ensuring `npm run test:coverage` and `npm run build` finish successfully without warnings.

---
*PR created automatically by Jules for task [11791429879197103047](https://jules.google.com/task/11791429879197103047) started by @saint2706*