### PR TITLE
🧪 Testing: increase coverage for `linkSafety.ts`, `shortcuts.ts`, and `toc.ts`

### DIFF
--- a/src/utils/__tests__/linkSafety.test.ts
+++ b/src/utils/__tests__/linkSafety.test.ts
@@ -2,6 +2,28 @@ import { describe, it, expect } from 'vitest'
 import { getSecureLinkAttributes, normalizeAndValidateHref } from '../linkSafety'
 
 describe('getSecureLinkAttributes', () => {
+  it('should preserve external links that are mailto:', () => {
+    // mailto: is considered safe but isExternal might evaluate to false since it's not http/https
+    // wait, url.protocol === 'mailto:' means isExternal = false
+    const result = getSecureLinkAttributes('mailto:test@example.com')
+    expect(result).toEqual({
+      href: 'mailto:test@example.com',
+      target: undefined,
+      rel: undefined,
+    })
+  })
+
+  it('should return null if href is null or not a string', () => {
+    expect(getSecureLinkAttributes(null)).toBeNull()
+    // @ts-expect-error
+    expect(getSecureLinkAttributes(123)).toBeNull()
+  })
+
+  it('should return null if href is an empty string', () => {
+    expect(getSecureLinkAttributes('')).toBeNull()
+    expect(getSecureLinkAttributes('   ')).toBeNull()
+  })
+
   it('should handle safe external links', () => {
     const result = getSecureLinkAttributes('https://example.com')
     expect(result).toEqual({
@@ -69,9 +91,64 @@ describe('getSecureLinkAttributes', () => {
     const result = getSecureLinkAttributes('https://example.com', { rel: 'noopener' })
     expect(result?.rel).toBe('noopener noreferrer')
   })
+
+  it('should not duplicate noreferrer if it already exists', () => {
+    const result = getSecureLinkAttributes('https://example.com', { rel: 'noreferrer' })
+    expect(result?.rel).toBe('noreferrer noopener')
+  })
 })
 
 describe('normalizeAndValidateHref', () => {
+  it('rejects unparseable URLs with valid scheme', () => {
+    // A string starting with a scheme but throwing in new URL()
+    // It's hard to make new URL() throw if it has a valid scheme.
+    // e.g. "http://[::1]" might throw if IPv6 is malformed.
+    expect(normalizeAndValidateHref('http://[1:2:3:4:5:6:7:8:9]')).toEqual({
+      normalizedHref: null,
+      isExternal: false,
+      isSafe: false,
+    })
+  })
+
+  it('rejects protocol-relative URLs (starting with //)', () => {
+    expect(normalizeAndValidateHref('//example.com')).toEqual({
+      normalizedHref: null,
+      isExternal: false,
+      isSafe: false,
+    })
+  })
+
+  it('allows relative path starting with ./', () => {
+    expect(normalizeAndValidateHref('./relative/path')).toEqual({
+      normalizedHref: './relative/path',
+      isExternal: false,
+      isSafe: true,
+    })
+  })
+
+  it('allows relative path starting with ../', () => {
+    expect(normalizeAndValidateHref('../relative/path')).toEqual({
+      normalizedHref: '../relative/path',
+      isExternal: false,
+      isSafe: true,
+    })
+  })
+
+  it('rejects non-string inputs', () => {
+    expect(normalizeAndValidateHref(null)).toEqual({
+      normalizedHref: null,
+      isExternal: false,
+      isSafe: false,
+    })
+
+    // @ts-expect-error testing invalid input
+    expect(normalizeAndValidateHref(123)).toEqual({
+      normalizedHref: null,
+      isExternal: false,
+      isSafe: false,
+    })
+  })
+
   it('rejects javascript URLs', () => {
     expect(normalizeAndValidateHref('javascript:alert(1)')).toEqual({
       normalizedHref: null,

--- a/src/utils/__tests__/shortcuts.test.ts
+++ b/src/utils/__tests__/shortcuts.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { SHORTCUTS, isTypingInEditableElement } from '../shortcuts'
+
+describe('shortcuts utils', () => {
+  describe('SHORTCUTS', () => {
+    it('should define a list of shortcuts', () => {
+      expect(Array.isArray(SHORTCUTS)).toBe(true)
+      expect(SHORTCUTS.length).toBeGreaterThan(0)
+
+      SHORTCUTS.forEach((shortcut) => {
+        expect(shortcut).toHaveProperty('keys')
+        expect(shortcut).toHaveProperty('description')
+        expect(shortcut).toHaveProperty('scope')
+      })
+    })
+  })
+
+  describe('isTypingInEditableElement', () => {
+    it('returns false if target is null', () => {
+      expect(isTypingInEditableElement(null)).toBe(false)
+    })
+
+    it('returns false if target is not an HTMLElement', () => {
+      // e.g., text node or document
+      expect(isTypingInEditableElement({} as EventTarget)).toBe(false)
+    })
+
+    it('returns true for INPUT element', () => {
+      const input = document.createElement('input')
+      expect(isTypingInEditableElement(input)).toBe(true)
+    })
+
+    it('returns true for TEXTAREA element', () => {
+      const textarea = document.createElement('textarea')
+      expect(isTypingInEditableElement(textarea)).toBe(true)
+    })
+
+    it('returns true for element with isContentEditable true', () => {
+      const div = document.createElement('div')
+      // Simulate isContentEditable for testing environment if needed
+      Object.defineProperty(div, 'isContentEditable', { value: true })
+      expect(isTypingInEditableElement(div)).toBe(true)
+    })
+
+    it('returns false for element with isContentEditable false', () => {
+      const div = document.createElement('div')
+      Object.defineProperty(div, 'isContentEditable', { value: false })
+      expect(isTypingInEditableElement(div)).toBe(false)
+    })
+
+    it('returns true for element with role="textbox"', () => {
+      const div = document.createElement('div')
+      div.setAttribute('role', 'textbox')
+      expect(isTypingInEditableElement(div)).toBe(true)
+    })
+
+    it('returns false for non-editable elements', () => {
+      const div = document.createElement('div')
+      const span = document.createElement('span')
+      const button = document.createElement('button')
+
+      expect(isTypingInEditableElement(div)).toBe(false)
+      expect(isTypingInEditableElement(span)).toBe(false)
+      expect(isTypingInEditableElement(button)).toBe(false)
+    })
+  })
+})

--- a/src/utils/__tests__/toc.test.ts
+++ b/src/utils/__tests__/toc.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { parseHeadings } from '../toc'
+
+describe('parseHeadings', () => {
+  it('should extract H2 and H3 headings correctly', () => {
+    const markdown = `
+# Title (should be ignored)
+
+## Subtitle 1
+
+Some text.
+
+### Sub-subtitle 1.1
+
+More text.
+
+## Subtitle 2
+    `
+    const result = parseHeadings(markdown)
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toEqual({ id: 'subtitle-1', text: 'Subtitle 1', level: 2 })
+    expect(result[1]).toEqual({ id: 'sub-subtitle-1-1', text: 'Sub-subtitle 1.1', level: 3 })
+    expect(result[2]).toEqual({ id: 'subtitle-2', text: 'Subtitle 2', level: 2 })
+  })
+
+  it('should ignore headings outside H2 and H3', () => {
+    const markdown = `
+# H1
+## H2
+### H3
+#### H4
+##### H5
+###### H6
+    `
+    const result = parseHeadings(markdown)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({ id: 'h2', text: 'H2', level: 2 })
+    expect(result[1]).toEqual({ id: 'h3', text: 'H3', level: 3 })
+  })
+
+  it('should ignore headings inside code blocks', () => {
+    const markdown = `
+## Main Heading
+
+\`\`\`python
+# This is a comment, not a heading
+## This looks like a heading but is in a code block
+\`\`\`
+
+### Another Heading
+    `
+    const result = parseHeadings(markdown)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({ id: 'main-heading', text: 'Main Heading', level: 2 })
+    expect(result[1]).toEqual({ id: 'another-heading', text: 'Another Heading', level: 3 })
+  })
+
+  it('should strip markdown inline formatting from heading text', () => {
+    const markdown = `
+## **Bold** and *Italic* Heading
+
+### \`Code\` Heading [Link](https://example.com)
+    `
+    const result = parseHeadings(markdown)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({
+      id: 'bold-and-italic-heading',
+      text: 'Bold and Italic Heading',
+      level: 2,
+    })
+    // Links and code will be stripped as per stripMarkdownInlineFormatting behaviour
+    expect(result[1]).toEqual({ id: 'code-heading-link', text: 'Code Heading Link', level: 3 })
+  })
+})


### PR DESCRIPTION
As requested, I've improved unit test coverage across a couple utility files:
- `linkSafety.ts`: Added tests for null string inputs, unexpected input types, and more precise validations of protocol-relative strings and external URL resolution edges, bringing it up to full coverage.
- `shortcuts.ts`: Added tests for the `SHORTCUTS` export, and for checking the boolean return values of `isTypingInEditableElement` (with special care around JSDOM's missing `isContentEditable` reflection).
- `toc.ts`: Added tests verifying correct parsing of markdown headings (`##`, `###`), exclusion of out-of-bounds heading levels, removal of inline formatting syntax, and ignorance of comments/headings inside python code blocks.

No build errors/warnings. Test suite passes.

---
*PR created automatically by Jules for task [7442147803008518574](https://jules.google.com/task/7442147803008518574) started by @saint2706*