### PR TITLE
🔄 CI/CD: Harden pipelines with timeouts and format checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   typecheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -23,11 +24,15 @@ jobs:
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
 
+      - name: Check formatting
+        run: npm run format:check
+
       - name: Typecheck
         run: npm run lint:ci
 
   validate-content:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -40,6 +45,7 @@ jobs:
 
   unit-test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/deploy-surge.yml
+++ b/.github/workflows/deploy-surge.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
   build:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_repository.full_name == github.repository) }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -40,6 +41,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   validate-content:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -35,6 +36,7 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -42,11 +44,15 @@ jobs:
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
 
+      - name: Check formatting
+        run: npm run format:check
+
       - name: Typecheck
         run: npm run typecheck
 
   unit-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -60,6 +66,7 @@ jobs:
   smoke:
     needs: [validate-content, typecheck, unit-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > A structured 108-day interactive learning platform covering Python, Data Science, Machine Learning, Business Intelligence, and Enterprise SQL — designed for business professionals.
 
 [![Deploy](https://github.com/saint2706/Coding-For-MBA/actions/workflows/deploy.yml/badge.svg)](https://github.com/saint2706/Coding-For-MBA/actions/workflows/deploy.yml)
+[![CI](https://github.com/saint2706/Coding-For-MBA/actions/workflows/ci.yml/badge.svg)](https://github.com/saint2706/Coding-For-MBA/actions/workflows/ci.yml)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue?logo=typescript)](https://www.typescriptlang.org/)
 [![React](https://img.shields.io/badge/React-19-61dafb?logo=react)](https://react.dev/)
 [![Vite](https://img.shields.io/badge/Vite-7-646cff?logo=vite)](https://vite.dev/)

--- a/src/components/__tests__/ExerciseWidget.test.tsx
+++ b/src/components/__tests__/ExerciseWidget.test.tsx
@@ -24,7 +24,6 @@ let capturedCodePlaygroundProps: any
 const mockSetCode = vi.fn()
 
 vi.mock('../CodePlayground', () => ({
-
   default: React.forwardRef((props: any, ref: any) => {
     capturedCodePlaygroundProps = props
     React.useImperativeHandle(ref, () => ({

--- a/src/hooks/__tests__/usePyodide.test.tsx
+++ b/src/hooks/__tests__/usePyodide.test.tsx
@@ -94,7 +94,6 @@ describe('usePyodide', () => {
   })
 
   it('runs python code successfully and captures output', async () => {
-
     let hookResult: any
 
     function TestComponent() {
@@ -107,7 +106,6 @@ describe('usePyodide', () => {
         root.render(<TestComponent />)
       }
     })
-
 
     let result: any
     await act(async () => {
@@ -119,7 +117,6 @@ describe('usePyodide', () => {
   })
 
   it('handles python errors gracefully', async () => {
-
     let hookResult: any
 
     function TestComponent() {
@@ -133,7 +130,6 @@ describe('usePyodide', () => {
       }
     })
 
-
     let result: any
     await act(async () => {
       result = await hookResult.runPython('raise_error')
@@ -144,7 +140,6 @@ describe('usePyodide', () => {
   })
 
   it('truncates output when it exceeds the limit', async () => {
-
     let hookResult: any
 
     function TestComponent() {
@@ -174,7 +169,6 @@ describe('usePyodide', () => {
   })
 
   it('returns the return value if no stdout', async () => {
-
     let hookResult: any
 
     function TestComponent() {
@@ -188,7 +182,6 @@ describe('usePyodide', () => {
       }
     })
 
-
     let result: any
     await act(async () => {
       result = await hookResult.runPython('return_value')
@@ -198,7 +191,6 @@ describe('usePyodide', () => {
   })
 
   it('handles timeout', async () => {
-
     let hookResult: any
 
     function TestComponent() {
@@ -235,7 +227,6 @@ describe('usePyodide', () => {
       )
     }
 
-
     let result: any
     await act(async () => {
       // Small timeout
@@ -262,7 +253,6 @@ describe('usePyodide', () => {
   })
 
   it('handles abort signal', async () => {
-
     let hookResult: any
 
     function TestComponent() {
@@ -291,7 +281,6 @@ describe('usePyodide', () => {
     }
 
     const controller = new AbortController()
-
 
     let resultPromise: Promise<any>
 

--- a/src/utils/__tests__/confetti.test.ts
+++ b/src/utils/__tests__/confetti.test.ts
@@ -56,7 +56,6 @@ describe('confetti', () => {
     })
 
     it('should not throw and not call if window is undefined', () => {
-
       delete (global as any).window
 
       confettiModule.triggerSparkle()
@@ -124,7 +123,6 @@ describe('confetti', () => {
     })
 
     it('should not start interval if window is undefined', () => {
-
       delete (global as any).window
 
       confettiModule.triggerCurriculumFireworks()


### PR DESCRIPTION
As the CI/CD specialist, I have optimized and hardened the build pipelines.

### Changes:
1. **Speed & Reliability (Fail-Fast):**
   - Added `timeout-minutes` (ranging from 10 to 20 minutes) to all major GitHub Actions workflows, including `ci.yml`, `deploy.yml`, `deploy-surge.yml`, `nightly-smoke.yml`, and `dependency-review.yml`. This prevents jobs from silently hanging and consuming excess runner minutes.
2. **Pipeline Quality & Maintenance:**
   - Introduced `npm run format:check` into both `ci.yml` and `nightly-smoke.yml` to prevent spacing and styling regressions from reaching the main branch.
   - Fixed preexisting formatting issues in the codebase by running `npm run format` (affecting files like `src/components/__tests__/ExerciseWidget.test.tsx`, `src/hooks/__tests__/usePyodide.test.tsx`, and `src/utils/__tests__/confetti.test.ts`).
3. **Documentation:**
   - Added a `ci.yml` Build Status badge to the top of `README.md`.

All local tests, linting, code formatting, and content validation pass cleanly without warnings.

---
*PR created automatically by Jules for task [7704627073597591352](https://jules.google.com/task/7704627073597591352) started by @saint2706*