### PR TITLE
⚡ Bolt: Optimized Achievements Lookup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,4 @@
 - Optimized `ProgressDashboard.tsx`, `Curriculum.tsx`, and `PhaseOverview.tsx` by using memoized sets (`completedSet`) instead of the `isLessonComplete()` facade, converting O(N*M) array lookup iterations into efficient O(1) checks during render maps.
 
 - Optimized `Lesson.tsx` handleToggleComplete method by converting the `afterCompleted` array into a `Set` before running `.every()` with `.has()`, effectively converting an O(N*M) time complexity bottleneck to O(M + N).
+- Optimized `ProgressDashboard.tsx` earned badges rendering by replacing an O(N*M) `filter(...).includes(...)` operation with an O(N+M) `Set` lookup mechanism via `useMemo`.

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -92,7 +92,13 @@ export default function ProgressDashboard() {
   const refreshDailyChallenge = useGamificationStore((state) => state.refreshDailyChallenge)
   const xpToNextMilestone = useGamificationStore((state) => state.xpToNextMilestone)
   const milestoneProgress = xpToNextMilestone()
-  const earnedBadges = ACHIEVEMENTS.filter((badge) => achievementsUnlocked.includes(badge.id))
+
+  // ⚡ Bolt: Convert achievementsUnlocked to a Set to optimize O(N*M) lookups to O(N + M) during render.
+  const earnedBadges = useMemo(() => {
+    const unlockedSet = new Set(achievementsUnlocked)
+    return ACHIEVEMENTS.filter((badge) => unlockedSet.has(badge.id))
+  }, [achievementsUnlocked])
+
   const challengeLesson = getLesson(dailyChallenge.day)
 
   useEffect(() => {


### PR DESCRIPTION
⚡ Bolt: Optimize earned badges filtering in ProgressDashboard

- Converted `achievementsUnlocked` array to a `Set` within `useMemo` in `ProgressDashboard.tsx`.
- Replaced the $O(N \times M)$ `filter(...).includes(...)` operation with an $O(N + M)$ `filter(...).has(...)` lookup.
- Optimized rendering performance of the gamification metrics section.
- Added appropriate `bolt.md` tracking log entry.

---
*PR created automatically by Jules for task [16423695789154979428](https://jules.google.com/task/16423695789154979428) started by @saint2706*