### PR TITLE
📚 Docs: Ignore anti-bot urls returning 403 in link check

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -15,6 +15,9 @@
     {"pattern": "^https://python\\.useinstructor\\.com/"},
     {"pattern": "^https://restfulapi\\.net/"},
     {"pattern": "^https://www\\.dataengineeringweekly\\.com/"},
-    {"pattern": "^https://jsonplaceholder\\.typicode\\.com/"}
+    {"pattern": "^https://jsonplaceholder\\.typicode\\.com/"},
+    {"pattern": "^https://feature-engine\\.readthedocs\\.io/"},
+    {"pattern": "^https://joblib\\.readthedocs\\.io/"},
+    {"pattern": "^https://reddit\\.com/r/localllama"}
   ]
 }


### PR DESCRIPTION
Adds `feature-engine.readthedocs.io`, `joblib.readthedocs.io` and `reddit.com/r/localllama` to `mlc_config.json`'s ignore list. These domains block automated scrapers/checkers and return 403 or 0 status, causing false positive build failures. Verified with `npm run validate-content`.

---
*PR created automatically by Jules for task [13520212776065861657](https://jules.google.com/task/13520212776065861657) started by @saint2706*