### PR TITLE
🎨 Picasso: Hide decorative emojis from screen readers

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -16,3 +16,8 @@
 ## Verification
 * Verified changes via visual UI tests (Playwright) and unit tests (`npm run test`).
 * Ensured no linting or build regressions were introduced.
+
+### Decorative Emojis Accessibility
+* **Observation**: Found many places (CopyButton, Sidebar streak, ProgressDashboard stats, Curriculum stats) where emojis were placed next to text strings or inside descriptive wrappers but not explicitly hidden from screen readers.
+* **Fix**: Wrapped these emojis in `<span aria-hidden="true">` to prevent screen readers from redundantly calling out "Chart showing upward trend" when the label says "Completed".
+* **Rule**: When an emoji is purely decorative and its meaning is already conveyed via text or an `aria-label`, always hide it using `aria-hidden="true"`.

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -69,7 +69,17 @@ export default function CopyButton({
       aria-label={copied ? 'Code copied to clipboard' : label}
       title={label}
     >
-      {copied ? '✓ Copied' : showEmoji ? '📋 Copy' : 'Copy'}
+      {copied ? (
+        <>
+          <span aria-hidden="true">✓</span> Copied
+        </>
+      ) : showEmoji ? (
+        <>
+          <span aria-hidden="true">📋</span> Copy
+        </>
+      ) : (
+        'Copy'
+      )}
       <span className="sr-only" aria-live="polite" aria-atomic="true">
         {copied ? 'Code copied to clipboard' : ''}
       </span>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -116,7 +116,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
           </div>
           {reviewStreak > 0 && (
             <span className="sidebar-streak-badge" title={`${reviewStreak}-day review streak`}>
-              🔥 {reviewStreak}
+              <span aria-hidden="true">🔥</span> {reviewStreak}
             </span>
           )}
           <button

--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -139,7 +139,7 @@ export default function Curriculum() {
       {/* Curriculum stat cards */}
       <div className="curriculum-stats-row">
         <div className="curriculum-stat-card glass-card">
-          <span className="curriculum-stat-icon">📅</span>
+          <span className="curriculum-stat-icon" aria-hidden="true">📅</span>
           <div>
             <p className="curriculum-stat-value">{totalLessons}</p>
             <p className="curriculum-stat-label">Total Days</p>
@@ -150,7 +150,7 @@ export default function Curriculum() {
           <p className="curriculum-stat-note">{overallPct}% Completed</p>
         </div>
         <div className="curriculum-stat-card glass-card">
-          <span className="curriculum-stat-icon">📚</span>
+          <span className="curriculum-stat-icon" aria-hidden="true">📚</span>
           <div>
             <p className="curriculum-stat-value">{phases.length}</p>
             <p className="curriculum-stat-label">Phases</p>
@@ -168,7 +168,7 @@ export default function Curriculum() {
           </p>
         </div>
         <div className="curriculum-stat-card glass-card">
-          <span className="curriculum-stat-icon">⏱️</span>
+          <span className="curriculum-stat-icon" aria-hidden="true">⏱️</span>
           <div>
             <p className="curriculum-stat-value">{completedCount}</p>
             <p className="curriculum-stat-label">Lessons Done</p>

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -148,26 +148,26 @@ export default function ProgressDashboard() {
       {/* Mobile glassmorphism stat cards grid */}
       <div className="progress-mobile-stats-grid">
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon">📊</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">📊</span>
           <p className="progress-mobile-stat-value">
             <AnimatedCounter value={overallPct} suffix="%" />
           </p>
           <p className="progress-mobile-stat-label">Completed</p>
         </div>
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon">🔥</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">🔥</span>
           <p className="progress-mobile-stat-value">
             <AnimatedCounter value={completionStreak} />
           </p>
           <p className="progress-mobile-stat-label">Day Streak</p>
         </div>
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon">⏱️</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">⏱️</span>
           <p className="progress-mobile-stat-value">{formatDuration(totalLearningMs)}</p>
           <p className="progress-mobile-stat-label">Study Time</p>
         </div>
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon">⭐</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">⭐</span>
           <p className="progress-mobile-stat-value">{xpTotal}</p>
           <p className="progress-mobile-stat-label">Total XP</p>
         </div>


### PR DESCRIPTION
# Picasso UI/UX Enhancement

## Overview
Added small touches of accessibility to the user interface by hiding decorative emojis from screen readers. This prevents redundant or confusing announcements when navigating with assistive technologies.

## Changes Made
*   **`src/components/CopyButton.tsx`**: Wrapped the clipboard `📋` and checkmark `✓` emojis in `<span aria-hidden="true">`. The surrounding `<button>` already has an `aria-label` providing full context.
*   **`src/components/Sidebar.tsx`**: Wrapped the fire emoji `🔥` within the review streak badge in `<span aria-hidden="true">`. The badge has a `title` attribute for text description.
*   **`src/pages/ProgressDashboard.tsx`**: Added `aria-hidden="true"` to the decorative stat icons (`📊`, `🔥`, `⏱️`, `⭐`) in the mobile view grid.
*   **`src/pages/Curriculum.tsx`**: Added `aria-hidden="true"` to the stat icons (`📅`, `📚`, `⏱️`) in the curriculum summary header.

## Verification
*   Tests: `npm run lint && npm run test` pass.
*   UI Verification: Playwright screenshot verified the `ProgressDashboard` icons remain visually unchanged while the HTML structure correctly hides the emojis from accessibility trees.
*   Learnings logged to `.jules/picasso.md`.

---
*PR created automatically by Jules for task [8304180275152598228](https://jules.google.com/task/8304180275152598228) started by @saint2706*