### PR TITLE
🧘‍♂️ Buddha: [SEO] Semantic HTML Fixes

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -73,6 +73,14 @@ This scroll records the harmonization of the `Coding-For-MBA` codebase for human
 - Added `FAQPage` schema to `src/utils/seoSchemas.ts`.
 - Integrated `FAQPage` schema into mastery checks to improve GEO discoverability of Q&As.
 
+### [Date: Current] - Semantic HTML Fixes
+
+**Priority Areas:**
+1.  **SEO (Visibility)**: Strict semantic HTML hierarchy.
+
+**Changes:**
+-   [x] **[SEO] Semantic HTML Fixes**: Converted top-level `<h2>` tags to `<h1>` across multiple pages (`Curriculum.tsx`, `ProgressDashboard.tsx`, `Exercises.tsx`, `Review.tsx`, `CaseStudies.tsx`) to ensure strict `h1`-`h6` hierarchy. This improves screen reader accessibility and helps search engines properly understand the page outline.
+
 ### [Date: Current] - Static Route Descriptions for AI Manifest
 
 **Priority Areas:**

--- a/src/pages/CaseStudies.tsx
+++ b/src/pages/CaseStudies.tsx
@@ -78,7 +78,7 @@ export default function CaseStudies() {
       <Breadcrumb items={[{ label: 'Home', to: '/' }, { label: 'Case Studies & Projects' }]} />
 
       <div className="section-header" style={{ marginBottom: '1.5rem' }}>
-        <h2>📂 Case Studies &amp; Projects</h2>
+        <h1>📂 Case Studies &amp; Projects</h1>
         <p>
           {caseStudies.length} case studies · {projects.length} capstone projects — apply your
           skills to real-world business problems.

--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -129,7 +129,7 @@ export default function Curriculum() {
       />
       <Breadcrumb items={[{ label: 'Home', to: '/' }, { label: 'Curriculum' }]} />
       <div className="section-header" style={{ marginBottom: '1.5rem' }}>
-        <h2>Full Curriculum Roadmap</h2>
+        <h1>Full Curriculum Roadmap</h1>
         <p>
           {totalLessons} days of structured learning across {phases.length} phases — from Python
           foundations to enterprise SQL.

--- a/src/pages/Exercises.tsx
+++ b/src/pages/Exercises.tsx
@@ -116,7 +116,7 @@ export default function Exercises() {
       <Breadcrumb items={[{ label: 'Home', to: '/' }, { label: 'Exercises' }]} />
 
       <div className="section-header" style={{ marginBottom: '1.5rem' }}>
-        <h2>🧪 Exercise Browser</h2>
+        <h1>🧪 Exercise Browser</h1>
         <p>
           {exercises.length} exercises across {phases.length} phases — filter by topic, difficulty,
           or search.

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -131,7 +131,7 @@ export default function ProgressDashboard() {
       <Breadcrumb items={[{ label: 'Home', to: '/' }, { label: 'Progress' }]} />
 
       <div className="section-header" style={{ marginBottom: '2rem' }}>
-        <h2>Your Progress</h2>
+        <h1>Your Progress</h1>
         <p>Track your journey through the {totalLessons}-day curriculum.</p>
       </div>
 

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -101,7 +101,7 @@ export default function Review() {
       <Breadcrumb items={[{ label: 'Home', to: '/' }, { label: 'Review' }]} />
 
       <div className="section-header" style={{ marginBottom: '1.5rem' }}>
-        <h2>Spaced Repetition Review</h2>
+        <h1>Spaced Repetition Review</h1>
         <p>
           Due cards: {dueCards.length} · Streak: {streak} day(s)
         </p>


### PR DESCRIPTION
Converted top-level `<h2>` tags to `<h1>` across multiple pages (`Curriculum.tsx`, `ProgressDashboard.tsx`, `Exercises.tsx`, `Review.tsx`, `CaseStudies.tsx`) to ensure strict `h1`-`h6` hierarchy. This improves screen reader accessibility and helps search engines properly understand the page outline. Added log to `.jules/buddha-scroll.md`.

---
*PR created automatically by Jules for task [5746532854328875620](https://jules.google.com/task/5746532854328875620) started by @saint2706*