### PR TITLE
🛡️ Sentinel: Add iframe restrictions to Content Security Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -69,3 +69,7 @@
 - Confirmed that Pyodide string literal validation accurately protects execution contexts without breaking Python f-string logic.
 - Confirmed `rehype-sanitize` prevents XSS within raw HTML embedded in Markdown.
 - Validated `Content-Security-Policy` successfully restricts external connections to trusted CDNs and APIs (`connect-src`), mitigating client-side SSRF.
+
+## 2026-03-15 - CSP Hardening for Iframes
+**Vulnerability:** The application was not explicitly restricting the use of iframes, potentially allowing malicious content to be embedded or Clickjacking vectors if external content is embedded.
+**Prevention:** Hardened the Content-Security-Policy by adding `frame-src 'none'` and `child-src 'none'` to the `index.html` meta tag, strictly disallowing any iframe embedding within the application.

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     />
     <meta
       http-equiv="Content-Security-Policy"
-      content="upgrade-insecure-requests; default-src 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://saint2706.github.io; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://cdn.jsdelivr.net https://pypi.org https://files.pythonhosted.org; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self';"
+      content="upgrade-insecure-requests; default-src 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://saint2706.github.io; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://cdn.jsdelivr.net https://pypi.org https://files.pythonhosted.org; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-src 'none'; child-src 'none';"
     />
     <meta
       name="description"


### PR DESCRIPTION
This PR hardens the `Content-Security-Policy` defined in `index.html` by adding `frame-src 'none'` and `child-src 'none'`. This prevents the application from embedding malicious or unauthorized iframes, mitigating certain cross-site framing attack vectors as a defense-in-depth measure. The change follows the 'Sentinel' persona rules and has been documented in `.jules/sentinel.md`. All tests pass.

---
*PR created automatically by Jules for task [198041445409036857](https://jules.google.com/task/198041445409036857) started by @saint2706*