### PR TITLE
🔄 CI/CD: Enforce timeout-minutes on all GitHub Actions jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   typecheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -28,6 +29,7 @@ jobs:
 
   validate-content:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -40,6 +42,7 @@ jobs:
 
   unit-test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/dependabot-on-demand.yml
+++ b/.github/workflows/dependabot-on-demand.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   explain-manual-trigger-support:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Explain Dependabot manual trigger limitations
         uses: actions/github-script@v7

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/deploy-surge.yml
+++ b/.github/workflows/deploy-surge.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
   build:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_repository.full_name == github.repository) }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -40,6 +41,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   validate-content:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -35,6 +36,7 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -47,6 +49,7 @@ jobs:
 
   unit-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -60,6 +63,7 @@ jobs:
   smoke:
     needs: [validate-content, typecheck, unit-test]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
Added `timeout-minutes` limits to all jobs in the GitHub Actions workflows to conform to CI/CD fail-fast requirements and avoid hung processes from taking up resources unnecessarily.

---
*PR created automatically by Jules for task [5377842957867177713](https://jules.google.com/task/5377842957867177713) started by @saint2706*