### PR TITLE
🎨 Picasso: Added aria-label to phase filter buttons in Concept Graph

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -16,3 +16,4 @@
 ## Verification
 * Verified changes via visual UI tests (Playwright) and unit tests (`npm run test`).
 * Ensured no linting or build regressions were introduced.
+\n- Added `aria-label` to phase filter buttons in `ConceptGraphPage.tsx` because they only display 'P1', 'P2' etc. which lacks context for screen reader users. The `aria-label` now explicitly states 'Filter by Phase X: [Phase Name]'.

--- a/src/pages/ConceptGraphPage.tsx
+++ b/src/pages/ConceptGraphPage.tsx
@@ -119,6 +119,7 @@ export default function ConceptGraphPage() {
               style={activePhase === i + 1 ? { background: 'rgba(255,255,255,0.1)' } : undefined}
               aria-pressed={activePhase === i + 1}
               title={`Phase ${i + 1}: ${name}`}
+              aria-label={`Filter by Phase ${i + 1}: ${name}`}
             >
               <span className="legend-dot" style={{ background: PHASE_COLORS[i] }} />P{i + 1}
             </button>


### PR DESCRIPTION
## 🎨 Picasso: Added \`aria-label\` to phase filter buttons

**Discovery:**
During an accessibility audit, it was discovered that the phase filter buttons in \`ConceptGraphPage.tsx\` only displayed "P1", "P2", etc. visually. This text provides insufficient context for screen reader users when navigating the application.

**Implementation:**
- Added a descriptive \`aria-label\` to the `.legend-item` buttons inside the Concept Graph, dynamically reading \`Filter by Phase \${i + 1}: \${name}\` (e.g., "Filter by Phase 1: Python Foundations").
- Validated keyboard navigation and screen reader compatibility.
- Recorded the improvements in \`.jules/picasso.md\`.

**Verification:**
- Ran \`npm run lint\` and \`npm run test\` - both pass successfully.
- Conducted frontend verification via Playwright to ensure the ARIA labels are present in the DOM.

Changes are isolated, accessible, and add less than 50 lines.

---
*PR created automatically by Jules for task [5741205325491327013](https://jules.google.com/task/5741205325491327013) started by @saint2706*