### PR TITLE
⚡ Bolt: [PERF] Optimize curriculum lesson counts and lookups

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -137,7 +137,15 @@ const TableComponent = ({ children }: { children?: React.ReactNode }) => {
 const ImageComponent = (props: JSX.IntrinsicElements['img'] & ExtraProps) => {
   // Respect fetchpriority for LCP (Hero) optimization
   // If fetchpriority="high", we should not lazy load.
-  const { fetchpriority, fetchPriority, loading: _loading, ...rest } = props as JSX.IntrinsicElements['img'] & { fetchpriority?: 'high' | 'low' | 'auto'; fetchPriority?: 'high' | 'low' | 'auto' }
+  const {
+    fetchpriority,
+    fetchPriority,
+    loading: _loading,
+    ...rest
+  } = props as JSX.IntrinsicElements['img'] & {
+    fetchpriority?: 'high' | 'low' | 'auto'
+    fetchPriority?: 'high' | 'low' | 'auto'
+  }
 
   const isHighPriority = fetchpriority === 'high' || fetchPriority === 'high'
 

--- a/src/components/SidebarPhaseGroup.tsx
+++ b/src/components/SidebarPhaseGroup.tsx
@@ -9,7 +9,7 @@
 import { memo } from 'react'
 import { Link } from 'react-router-dom'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
-import { getLessonsByPhase, phaseIcons, type Phase } from '../utils/contentLoader'
+import { getLessonsByPhase, getLesson, phaseIcons, type Phase } from '../utils/contentLoader'
 import { dayTokenToProgressId } from '../utils/dayToken'
 
 interface SidebarPhaseGroupProps {
@@ -149,10 +149,17 @@ function propsAreEqual(
 
   // Only re-render if currentPath changes to/from a lesson in THIS phase
   // Optimization: check if either the old path or the new path is relevant to this phase
-  const isRelevantPath = (path: string) =>
-    path === `/phase/${nextProps.phase.phase}` ||
-    (path.startsWith('/lesson/') &&
-      getLessonsByPhase(nextProps.phase.phase).some((l) => path === `/lesson/${l.day}`))
+  const isRelevantPath = (path: string) => {
+    if (path === `/phase/${nextProps.phase.phase}`) return true
+    if (path.startsWith('/lesson/')) {
+      const match = path.match(/\/lesson\/(.+)/)
+      if (match && match[1]) {
+        const lesson = getLesson(match[1])
+        return lesson?.phase === nextProps.phase.phase
+      }
+    }
+    return false
+  }
 
   if (prevProps.currentPath !== nextProps.currentPath) {
     if (isRelevantPath(prevProps.currentPath) || isRelevantPath(nextProps.currentPath)) {

--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -139,7 +139,9 @@ export default function Curriculum() {
       {/* Curriculum stat cards */}
       <div className="curriculum-stats-row">
         <div className="curriculum-stat-card glass-card">
-          <span className="curriculum-stat-icon" aria-hidden="true">📅</span>
+          <span className="curriculum-stat-icon" aria-hidden="true">
+            📅
+          </span>
           <div>
             <p className="curriculum-stat-value">{totalLessons}</p>
             <p className="curriculum-stat-label">Total Days</p>
@@ -150,7 +152,9 @@ export default function Curriculum() {
           <p className="curriculum-stat-note">{overallPct}% Completed</p>
         </div>
         <div className="curriculum-stat-card glass-card">
-          <span className="curriculum-stat-icon" aria-hidden="true">📚</span>
+          <span className="curriculum-stat-icon" aria-hidden="true">
+            📚
+          </span>
           <div>
             <p className="curriculum-stat-value">{phases.length}</p>
             <p className="curriculum-stat-label">Phases</p>
@@ -168,7 +172,9 @@ export default function Curriculum() {
           </p>
         </div>
         <div className="curriculum-stat-card glass-card">
-          <span className="curriculum-stat-icon" aria-hidden="true">⏱️</span>
+          <span className="curriculum-stat-icon" aria-hidden="true">
+            ⏱️
+          </span>
           <div>
             <p className="curriculum-stat-value">{completedCount}</p>
             <p className="curriculum-stat-label">Lessons Done</p>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -81,10 +81,7 @@ export default function Home() {
     : 0
   const completedCount = getCompletedCount()
   const streakDays = useMemo(() => getStreakDays(), [completedCount])
-  const totalLessons = useMemo(
-    () => phases.reduce((sum, p) => sum + getLessonsByPhase(p.phase).length, 0),
-    [phases],
-  )
+  const totalLessons = useMemo(() => getAllLessons().length, [])
   const prefersReducedMotion = useReducedMotion()
   const { scrollYProgress } = useScroll()
   const heroY = useTransform(scrollYProgress, [0, 0.35], [0, prefersReducedMotion ? 0 : -50])

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -41,7 +41,10 @@ import {
   setLastVisited,
   getCompletedLessons,
 } from '../utils/progressTracker'
-import MarkdownRenderer, { findInteractiveBlocks, type ParsedMasteryQuestion } from '../components/MarkdownRenderer'
+import MarkdownRenderer, {
+  findInteractiveBlocks,
+  type ParsedMasteryQuestion,
+} from '../components/MarkdownRenderer'
 import Breadcrumb from '../components/Breadcrumb'
 import BackToTop from '../components/BackToTop'
 import TableOfContents from '../components/TableOfContents'

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -33,6 +33,7 @@ import {
   difficultyConfig,
   getAllPhases,
   getLessonsByPhase,
+  getAllLessons,
 } from '../utils/contentLoader'
 import {
   isLessonComplete,
@@ -177,10 +178,7 @@ export default function Lesson() {
         }
       }
 
-      const totalLessonCount = getAllPhases().reduce(
-        (sum, phase) => sum + getLessonsByPhase(phase.phase).length,
-        0,
-      )
+      const totalLessonCount = getAllLessons().length
       if (afterCompleted.length === totalLessonCount) {
         triggerCurriculumFireworks()
         toastSuccess('🎓 Curriculum complete! Incredible work.')

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -17,6 +17,7 @@ import {
   getAllPhases,
   getLessonsByPhase,
   getLesson,
+  getAllLessons,
   phaseIcons,
   difficultyConfig,
 } from '../utils/contentLoader'
@@ -50,10 +51,7 @@ export default function ProgressDashboard() {
   const completedLessons = getCompletedLessons()
   const completedSet = useMemo(() => new Set(completedLessons), [completedLessons])
 
-  const totalLessons = useMemo(
-    () => phases.reduce((sum, p) => sum + getLessonsByPhase(p.phase).length, 0),
-    [phases],
-  )
+  const totalLessons = useMemo(() => getAllLessons().length, [])
   const overallPct =
     totalLessons > 0 ? Math.round((completedLessons.length / totalLessons) * 100) : 0
 

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -152,26 +152,34 @@ export default function ProgressDashboard() {
       {/* Mobile glassmorphism stat cards grid */}
       <div className="progress-mobile-stats-grid">
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon" aria-hidden="true">📊</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">
+            📊
+          </span>
           <p className="progress-mobile-stat-value">
             <AnimatedCounter value={overallPct} suffix="%" />
           </p>
           <p className="progress-mobile-stat-label">Completed</p>
         </div>
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon" aria-hidden="true">🔥</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">
+            🔥
+          </span>
           <p className="progress-mobile-stat-value">
             <AnimatedCounter value={completionStreak} />
           </p>
           <p className="progress-mobile-stat-label">Day Streak</p>
         </div>
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon" aria-hidden="true">⏱️</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">
+            ⏱️
+          </span>
           <p className="progress-mobile-stat-value">{formatDuration(totalLearningMs)}</p>
           <p className="progress-mobile-stat-label">Study Time</p>
         </div>
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon" aria-hidden="true">⭐</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">
+            ⭐
+          </span>
           <p className="progress-mobile-stat-value">{xpTotal}</p>
           <p className="progress-mobile-stat-label">Total XP</p>
         </div>

--- a/src/pages/__tests__/Lesson.test.tsx
+++ b/src/pages/__tests__/Lesson.test.tsx
@@ -41,6 +41,7 @@ vi.mock('../../utils/contentLoader', () => ({
   getAdjacentLessons: () => ({ prev: null, next: null }),
   getAllPhases: () => [{ phase: 1 }, { phase: 2 }],
   getLessonsByPhase: (phase: number) => (phase === 1 ? [{ day: '1B' }] : [{ day: '2' }]),
+  getAllLessons: () => [{ day: '1B' }, { day: '2' }],
   difficultyConfig: {
     beginner: { label: 'Beginner', color: '#000', bg: '#fff' },
   },

--- a/src/utils/__tests__/prefetchRoutes.test.ts
+++ b/src/utils/__tests__/prefetchRoutes.test.ts
@@ -40,13 +40,13 @@ describe('prefetchRoutes', () => {
       // Act
       expect(() => prefetchRoute('/does-not-exist')).not.toThrow()
       // Give a little time for any promises to settle
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
     })
 
     it('should prefetch a valid home route ("/")', async () => {
       // Act
       prefetchRoute('/')
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
       // Can't easily assert the dynamic import was called without intercepting it at the module bundler level,
       // but we can ensure it doesn't throw.
       expect(true).toBe(true)
@@ -55,7 +55,7 @@ describe('prefetchRoutes', () => {
     it('should not throw when prefetching the same route multiple times', async () => {
       prefetchRoute('/curriculum')
       prefetchRoute('/curriculum')
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
       expect(true).toBe(true)
     })
 
@@ -63,7 +63,7 @@ describe('prefetchRoutes', () => {
       prefetchRoute('/phase/1')
       prefetchRoute('/lesson/2')
       prefetchRoute('/solutions/3')
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
       expect(true).toBe(true)
     })
 
@@ -74,7 +74,7 @@ describe('prefetchRoutes', () => {
       prefetchRoute('/concepts')
       prefetchRoute('/stats')
       prefetchRoute('/review')
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
       expect(true).toBe(true)
     })
   })


### PR DESCRIPTION
⚡ Bolt: Optimized curriculum lesson lookups to prevent unnecessary iterative $O(N)$ operations during render.

These changes prevent the repetitive and unnecessary phase lesson parsing on rendering, avoiding scaling issues with large numbers of lessons by using `$O(1)$` cached lookups.

---
*PR created automatically by Jules for task [2380631002652883011](https://jules.google.com/task/2380631002652883011) started by @saint2706*