### PR TITLE
📚 Docs: Update curriculum duration to 140 days and enhance JSDoc

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -21,3 +21,5 @@
   - Added missing typed JSDoc comments to `src/stores/quizStore.ts`
   - Added missing typed JSDoc comments to `src/stores/userPreferencesStore.ts`
   - Created a Python script `/home/jules/self_created_tools/check_jsdoc4.py` to identify missing JSDoc comments for exported functions and arrow functions across `src/stores/`.
+- Updated README.md and CONTRIBUTING.md to reflect the new 140-day curriculum (incorporating Phases 10-12).
+- Updated TSDoc tags for exported functions in `src/utils/codeSecurity.ts` and `src/utils/confetti.ts` for better clarity and API completeness.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Please take a moment to review this guide to ensure a smooth contribution proces
   - `components/`: Reusable UI components.
   - `utils/`: Core logic (content loading, Pyodide integration, state).
   - `stores/`: Zustand state stores.
-- `content/lessons/`: Markdown content for the 108-day curriculum.
+- `content/lessons/`: Markdown content for the 140-day curriculum.
 - `docs/`: Documentation files (Roadmap, Architecture).
 - `scripts/`: Build and validation scripts.
 - `tests/`: E2E tests (Playwright).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Coding for MBA
 
-> A structured 108-day interactive learning platform covering Python, Data Science, Machine Learning, Business Intelligence, and Enterprise SQL — designed for business professionals.
+> A structured 140-day interactive learning platform covering Python, Data Science, Machine Learning, Business Intelligence, Enterprise SQL, Generative AI, Cloud Data Engineering, and Analytics Engineering — designed for business professionals.
 
 [![Deploy](https://github.com/saint2706/Coding-For-MBA/actions/workflows/deploy.yml/badge.svg)](https://github.com/saint2706/Coding-For-MBA/actions/workflows/deploy.yml)
 [![CI](https://github.com/saint2706/Coding-For-MBA/actions/workflows/ci.yml/badge.svg)](https://github.com/saint2706/Coding-For-MBA/actions/workflows/ci.yml)
@@ -36,6 +36,9 @@
 | 7 | BI & Analytics | 73–84 |
 | 8 | SQL Mastery | 85–96 |
 | 9 | Enterprise SQL | 97–108 |
+| 10 | Generative AI & LLM Engineering | 109–120 |
+| 11 | Cloud Data Engineering | 121–132 |
+| 12 | Analytics Engineering & Data Products | 133–140 |
 
 ## 🛠️ Tech Stack
 
@@ -84,7 +87,7 @@ src/
 ├── stores/            # Zustand state stores
 ├── App.tsx
 └── main.tsx
-content/lessons/       # 108 lesson markdown files
+content/lessons/       # 140 lesson markdown files
 docs/                  # Documentation (Roadmap, Architecture)
 scripts/               # Build and validation scripts
 ```

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -137,7 +137,15 @@ const TableComponent = ({ children }: { children?: React.ReactNode }) => {
 const ImageComponent = (props: JSX.IntrinsicElements['img'] & ExtraProps) => {
   // Respect fetchpriority for LCP (Hero) optimization
   // If fetchpriority="high", we should not lazy load.
-  const { fetchpriority, fetchPriority, loading: _loading, ...rest } = props as JSX.IntrinsicElements['img'] & { fetchpriority?: 'high' | 'low' | 'auto'; fetchPriority?: 'high' | 'low' | 'auto' }
+  const {
+    fetchpriority,
+    fetchPriority,
+    loading: _loading,
+    ...rest
+  } = props as JSX.IntrinsicElements['img'] & {
+    fetchpriority?: 'high' | 'low' | 'auto'
+    fetchPriority?: 'high' | 'low' | 'auto'
+  }
 
   const isHighPriority = fetchpriority === 'high' || fetchPriority === 'high'
 

--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -139,7 +139,9 @@ export default function Curriculum() {
       {/* Curriculum stat cards */}
       <div className="curriculum-stats-row">
         <div className="curriculum-stat-card glass-card">
-          <span className="curriculum-stat-icon" aria-hidden="true">📅</span>
+          <span className="curriculum-stat-icon" aria-hidden="true">
+            📅
+          </span>
           <div>
             <p className="curriculum-stat-value">{totalLessons}</p>
             <p className="curriculum-stat-label">Total Days</p>
@@ -150,7 +152,9 @@ export default function Curriculum() {
           <p className="curriculum-stat-note">{overallPct}% Completed</p>
         </div>
         <div className="curriculum-stat-card glass-card">
-          <span className="curriculum-stat-icon" aria-hidden="true">📚</span>
+          <span className="curriculum-stat-icon" aria-hidden="true">
+            📚
+          </span>
           <div>
             <p className="curriculum-stat-value">{phases.length}</p>
             <p className="curriculum-stat-label">Phases</p>
@@ -168,7 +172,9 @@ export default function Curriculum() {
           </p>
         </div>
         <div className="curriculum-stat-card glass-card">
-          <span className="curriculum-stat-icon" aria-hidden="true">⏱️</span>
+          <span className="curriculum-stat-icon" aria-hidden="true">
+            ⏱️
+          </span>
           <div>
             <p className="curriculum-stat-value">{completedCount}</p>
             <p className="curriculum-stat-label">Lessons Done</p>

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -40,7 +40,10 @@ import {
   setLastVisited,
   getCompletedLessons,
 } from '../utils/progressTracker'
-import MarkdownRenderer, { findInteractiveBlocks, type ParsedMasteryQuestion } from '../components/MarkdownRenderer'
+import MarkdownRenderer, {
+  findInteractiveBlocks,
+  type ParsedMasteryQuestion,
+} from '../components/MarkdownRenderer'
 import Breadcrumb from '../components/Breadcrumb'
 import BackToTop from '../components/BackToTop'
 import TableOfContents from '../components/TableOfContents'

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -154,26 +154,34 @@ export default function ProgressDashboard() {
       {/* Mobile glassmorphism stat cards grid */}
       <div className="progress-mobile-stats-grid">
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon" aria-hidden="true">📊</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">
+            📊
+          </span>
           <p className="progress-mobile-stat-value">
             <AnimatedCounter value={overallPct} suffix="%" />
           </p>
           <p className="progress-mobile-stat-label">Completed</p>
         </div>
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon" aria-hidden="true">🔥</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">
+            🔥
+          </span>
           <p className="progress-mobile-stat-value">
             <AnimatedCounter value={completionStreak} />
           </p>
           <p className="progress-mobile-stat-label">Day Streak</p>
         </div>
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon" aria-hidden="true">⏱️</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">
+            ⏱️
+          </span>
           <p className="progress-mobile-stat-value">{formatDuration(totalLearningMs)}</p>
           <p className="progress-mobile-stat-label">Study Time</p>
         </div>
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon" aria-hidden="true">⭐</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">
+            ⭐
+          </span>
           <p className="progress-mobile-stat-value">{xpTotal}</p>
           <p className="progress-mobile-stat-label">Total XP</p>
         </div>

--- a/src/utils/__tests__/prefetchRoutes.test.ts
+++ b/src/utils/__tests__/prefetchRoutes.test.ts
@@ -40,13 +40,13 @@ describe('prefetchRoutes', () => {
       // Act
       expect(() => prefetchRoute('/does-not-exist')).not.toThrow()
       // Give a little time for any promises to settle
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
     })
 
     it('should prefetch a valid home route ("/")', async () => {
       // Act
       prefetchRoute('/')
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
       // Can't easily assert the dynamic import was called without intercepting it at the module bundler level,
       // but we can ensure it doesn't throw.
       expect(true).toBe(true)
@@ -55,7 +55,7 @@ describe('prefetchRoutes', () => {
     it('should not throw when prefetching the same route multiple times', async () => {
       prefetchRoute('/curriculum')
       prefetchRoute('/curriculum')
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
       expect(true).toBe(true)
     })
 
@@ -63,7 +63,7 @@ describe('prefetchRoutes', () => {
       prefetchRoute('/phase/1')
       prefetchRoute('/lesson/2')
       prefetchRoute('/solutions/3')
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
       expect(true).toBe(true)
     })
 
@@ -74,7 +74,7 @@ describe('prefetchRoutes', () => {
       prefetchRoute('/concepts')
       prefetchRoute('/stats')
       prefetchRoute('/review')
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
       expect(true).toBe(true)
     })
   })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -33,8 +33,8 @@ export interface ValidationResult {
  * 3. Comments (# ...):
  *    - Removed entirely as they are not executable.
  *
- * @param code - The Python code to process
- * @returns The code with SAFE strings and comments removed
+ * @param {string} code - The Python code to process
+ * @returns {string} The code with SAFE strings and comments removed
  */
 export function stripPythonCommentsAndStrings(code: string): string {
   let stripped = code
@@ -76,8 +76,8 @@ export function stripPythonCommentsAndStrings(code: string): string {
  * Note: This validation runs on code STRIPPED of safe strings and comments.
  * f-strings are preserved to catch hidden execution.
  *
- * @param code - The Python code to validate
- * @returns Validation result
+ * @param {string} code - The Python code to validate
+ * @returns {ValidationResult} Validation result
  */
 export function validatePythonCode(code: string): ValidationResult {
   if (!code) return { valid: true }

--- a/src/utils/confetti.ts
+++ b/src/utils/confetti.ts
@@ -34,6 +34,8 @@ function safeConfetti(options: confetti.Options): void {
 /**
  * Triggers a small, subtle sparkle effect.
  * Useful for minor achievements or interactions.
+ *
+ * @returns {void}
  */
 export function triggerSparkle(): void {
   safeConfetti({
@@ -47,6 +49,8 @@ export function triggerSparkle(): void {
 
 /**
  * Triggers a medium-sized burst for acing a quiz.
+ *
+ * @returns {void}
  */
 export function triggerQuizAcedConfetti(): void {
   safeConfetti({
@@ -59,6 +63,8 @@ export function triggerQuizAcedConfetti(): void {
 
 /**
  * Triggers a large burst for completing all daily exercises.
+ *
+ * @returns {void}
  */
 export function triggerDayExercisesCompleteConfetti(): void {
   safeConfetti({
@@ -71,6 +77,8 @@ export function triggerDayExercisesCompleteConfetti(): void {
 
 /**
  * Triggers a major celebration effect for unlocking a new phase.
+ *
+ * @returns {void}
  */
 export function triggerPhaseUnlockConfetti(): void {
   safeConfetti({
@@ -84,6 +92,8 @@ export function triggerPhaseUnlockConfetti(): void {
 /**
  * Triggers an extended fireworks-style animation sequence.
  * Used for major curriculum milestones or completion.
+ *
+ * @returns {void}
  */
 export function triggerCurriculumFireworks(): void {
   if (typeof window === 'undefined' || prefersReducedMotion()) return


### PR DESCRIPTION
This PR updates project-level documentation to reflect the expanded curriculum length from 108 days to 140 days, following the addition of Generative AI, Cloud Data Engineering, and Analytics Engineering phases. Additionally, it improves developer documentation by adding explicit, typed JSDoc comments to `src/utils/codeSecurity.ts` and `src/utils/confetti.ts`.

Key Changes:
- **README.md** and **CONTRIBUTING.md**: Changed references of "108-day" to "140-day" and updated the content index in README to include Phases 10-12.
- **src/utils/codeSecurity.ts**: Added typed JSDoc tags (`@param {string}`, `@returns {string}`) to `stripPythonCommentsAndStrings` and `validatePythonCode`.
- **src/utils/confetti.ts**: Added typed JSDoc `@returns {void}` tags to `triggerSparkle`, `triggerQuizAcedConfetti`, `triggerDayExercisesCompleteConfetti`, `triggerPhaseUnlockConfetti`, and `triggerCurriculumFireworks`.
- **.jules/docs-progress.md**: Logged the documentation updates.

No production code logic has been changed, ensuring maximum safety. Build, formatting, and lint checks have been verified.

---
*PR created automatically by Jules for task [17545026323547003708](https://jules.google.com/task/17545026323547003708) started by @saint2706*