### PR TITLE
🧘 Buddha: [SEO] Fix skip-level headings across multiple pages

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -93,3 +93,12 @@ This scroll records the harmonization of the `Coding-For-MBA` codebase for human
 - Updated `scripts/generate-llms-txt.js` to extract and incorporate the `description` frontmatter field for phases and individual lessons.
 - Added descriptive fallback strings where descriptions are omitted.
 - Provides explicit sentences in `llms.txt` helping AI crawlers index and understand the routing structure effectively, fulfilling "Vector Friendliness".
+
+### [Date: Current] - Deep Semantic HTML Hierarchy Refactoring
+
+**Priority Areas:**
+1.  **SEO (Visibility)**: Perfect semantic HTML hierarchy and no skipped levels.
+2.  **GEO (Intelligence)**: Ensured headings map gracefully to AI chunking outlines.
+
+**Changes:**
+-   [x] **[SEO] Semantic HTML Fixes**: Fixed heading tag hierarchy on `CaseStudies.tsx`, `Review.tsx`, `SearchResults.tsx`, `Exercises.tsx`, and `PhaseOverview.tsx` to prevent skip-level headings (e.g. going from `<h1>` directly to `<h3>` or `<h4>`).

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -137,7 +137,15 @@ const TableComponent = ({ children }: { children?: React.ReactNode }) => {
 const ImageComponent = (props: JSX.IntrinsicElements['img'] & ExtraProps) => {
   // Respect fetchpriority for LCP (Hero) optimization
   // If fetchpriority="high", we should not lazy load.
-  const { fetchpriority, fetchPriority, loading: _loading, ...rest } = props as JSX.IntrinsicElements['img'] & { fetchpriority?: 'high' | 'low' | 'auto'; fetchPriority?: 'high' | 'low' | 'auto' }
+  const {
+    fetchpriority,
+    fetchPriority,
+    loading: _loading,
+    ...rest
+  } = props as JSX.IntrinsicElements['img'] & {
+    fetchpriority?: 'high' | 'low' | 'auto'
+    fetchPriority?: 'high' | 'low' | 'auto'
+  }
 
   const isHighPriority = fetchpriority === 'high' || fetchPriority === 'high'
 

--- a/src/pages/CaseStudies.tsx
+++ b/src/pages/CaseStudies.tsx
@@ -165,7 +165,7 @@ export default function CaseStudies() {
                   </span>
                   {item.estimatedTime && <span className="meta-pill">⏱ {item.estimatedTime}</span>}
                 </div>
-                <h3 className="cs-card__title">{item.title}</h3>
+                <h2 className="cs-card__title">{item.title}</h2>
                 {item.phasesCovered && <p className="cs-card__phases">{item.phasesCovered}</p>}
               </div>
 

--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -139,7 +139,9 @@ export default function Curriculum() {
       {/* Curriculum stat cards */}
       <div className="curriculum-stats-row">
         <div className="curriculum-stat-card glass-card">
-          <span className="curriculum-stat-icon" aria-hidden="true">📅</span>
+          <span className="curriculum-stat-icon" aria-hidden="true">
+            📅
+          </span>
           <div>
             <p className="curriculum-stat-value">{totalLessons}</p>
             <p className="curriculum-stat-label">Total Days</p>
@@ -150,7 +152,9 @@ export default function Curriculum() {
           <p className="curriculum-stat-note">{overallPct}% Completed</p>
         </div>
         <div className="curriculum-stat-card glass-card">
-          <span className="curriculum-stat-icon" aria-hidden="true">📚</span>
+          <span className="curriculum-stat-icon" aria-hidden="true">
+            📚
+          </span>
           <div>
             <p className="curriculum-stat-value">{phases.length}</p>
             <p className="curriculum-stat-label">Phases</p>
@@ -168,7 +172,9 @@ export default function Curriculum() {
           </p>
         </div>
         <div className="curriculum-stat-card glass-card">
-          <span className="curriculum-stat-icon" aria-hidden="true">⏱️</span>
+          <span className="curriculum-stat-icon" aria-hidden="true">
+            ⏱️
+          </span>
           <div>
             <p className="curriculum-stat-value">{completedCount}</p>
             <p className="curriculum-stat-label">Lessons Done</p>

--- a/src/pages/Exercises.tsx
+++ b/src/pages/Exercises.tsx
@@ -125,7 +125,7 @@ export default function Exercises() {
 
       {/* Solution Notebooks Banner */}
       <div className="exercises-notebooks">
-        <h3 className="exercises-notebooks__title">📓 Phase Solution Notebooks</h3>
+        <h2 className="exercises-notebooks__title">📓 Phase Solution Notebooks</h2>
         <div className="exercises-notebooks__grid">
           {phases.map((p) => {
             const icon = phaseIcons[p - 1] || '📖'
@@ -141,7 +141,7 @@ export default function Exercises() {
 
       {lowScoringTopics.length > 0 && (
         <div className="exercises-low-scoring">
-          <h3>📉 Spaced Repetition Focus</h3>
+          <h2>📉 Spaced Repetition Focus</h2>
           <p>Revisit these lower-scoring quiz topics to improve retention:</p>
           <ul>
             {lowScoringTopics.map((topic) => (

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -40,7 +40,10 @@ import {
   setLastVisited,
   getCompletedLessons,
 } from '../utils/progressTracker'
-import MarkdownRenderer, { findInteractiveBlocks, type ParsedMasteryQuestion } from '../components/MarkdownRenderer'
+import MarkdownRenderer, {
+  findInteractiveBlocks,
+  type ParsedMasteryQuestion,
+} from '../components/MarkdownRenderer'
 import Breadcrumb from '../components/Breadcrumb'
 import BackToTop from '../components/BackToTop'
 import TableOfContents from '../components/TableOfContents'

--- a/src/pages/PhaseOverview.tsx
+++ b/src/pages/PhaseOverview.tsx
@@ -144,7 +144,7 @@ export default function PhaseOverview() {
                 {lesson.day}
               </motion.div>
               <div className="day-card-info">
-                <h4>{lesson.title}</h4>
+                <h3>{lesson.title}</h3>
                 {lesson.duration && <span>⏱ {lesson.duration} min</span>}
               </div>
               {completedSet.has(dayTokenToProgressId(lesson.day)) && (

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -154,26 +154,34 @@ export default function ProgressDashboard() {
       {/* Mobile glassmorphism stat cards grid */}
       <div className="progress-mobile-stats-grid">
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon" aria-hidden="true">📊</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">
+            📊
+          </span>
           <p className="progress-mobile-stat-value">
             <AnimatedCounter value={overallPct} suffix="%" />
           </p>
           <p className="progress-mobile-stat-label">Completed</p>
         </div>
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon" aria-hidden="true">🔥</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">
+            🔥
+          </span>
           <p className="progress-mobile-stat-value">
             <AnimatedCounter value={completionStreak} />
           </p>
           <p className="progress-mobile-stat-label">Day Streak</p>
         </div>
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon" aria-hidden="true">⏱️</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">
+            ⏱️
+          </span>
           <p className="progress-mobile-stat-value">{formatDuration(totalLearningMs)}</p>
           <p className="progress-mobile-stat-label">Study Time</p>
         </div>
         <div className="progress-mobile-stat-card glass-card">
-          <span className="progress-mobile-stat-icon" aria-hidden="true">⭐</span>
+          <span className="progress-mobile-stat-icon" aria-hidden="true">
+            ⭐
+          </span>
           <p className="progress-mobile-stat-value">{xpTotal}</p>
           <p className="progress-mobile-stat-label">Total XP</p>
         </div>

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -119,7 +119,7 @@ export default function Review() {
             </span>
             <span>{currentCard.sourceType}</span>
           </div>
-          <h3>{currentCard.prompt}</h3>
+          <h2>{currentCard.prompt}</h2>
           <p className="review-card-lesson">From: {currentCard.lessonTitle}</p>
 
           {showAnswer ? (

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -122,9 +122,9 @@ export default function SearchResults() {
               >
                 <div className="search-result-card-header">
                   <span className="search-result-card-day">Day {result.item.day}</span>
-                  <h3 className="search-result-card-title">
+                  <h2 className="search-result-card-title">
                     {highlightText(result.item.title, terms)}
-                  </h3>
+                  </h2>
                   <span
                     className="difficulty-badge"
                     style={{ color: diff.color, background: diff.bg }}

--- a/src/utils/__tests__/prefetchRoutes.test.ts
+++ b/src/utils/__tests__/prefetchRoutes.test.ts
@@ -40,13 +40,13 @@ describe('prefetchRoutes', () => {
       // Act
       expect(() => prefetchRoute('/does-not-exist')).not.toThrow()
       // Give a little time for any promises to settle
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
     })
 
     it('should prefetch a valid home route ("/")', async () => {
       // Act
       prefetchRoute('/')
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
       // Can't easily assert the dynamic import was called without intercepting it at the module bundler level,
       // but we can ensure it doesn't throw.
       expect(true).toBe(true)
@@ -55,7 +55,7 @@ describe('prefetchRoutes', () => {
     it('should not throw when prefetching the same route multiple times', async () => {
       prefetchRoute('/curriculum')
       prefetchRoute('/curriculum')
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
       expect(true).toBe(true)
     })
 
@@ -63,7 +63,7 @@ describe('prefetchRoutes', () => {
       prefetchRoute('/phase/1')
       prefetchRoute('/lesson/2')
       prefetchRoute('/solutions/3')
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
       expect(true).toBe(true)
     })
 
@@ -74,7 +74,7 @@ describe('prefetchRoutes', () => {
       prefetchRoute('/concepts')
       prefetchRoute('/stats')
       prefetchRoute('/review')
-      await new Promise(r => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
       expect(true).toBe(true)
     })
   })


### PR DESCRIPTION
This PR implements strict semantic HTML hierarchy across multiple pages.

**Changes Implemented:**
- Adjusted `<h3>` and `<h4>` heading levels in `CaseStudies.tsx`, `Review.tsx`, `SearchResults.tsx`, `Exercises.tsx`, and `PhaseOverview.tsx` to prevent skip-level headings (i.e. jumping from `<h1>` to `<h3>`).
- Logged improvements in `.jules/buddha-scroll.md`.

**Validation:**
- Verified no lint or build errors (`npm run lint` and `npm run build` pass).
- Evaluated frontend changes through a custom Playwright script to confirm correct element targeting via semantic heading selectors and took screenshots.
- Ran all unit tests which continue to pass cleanly.

---
*PR created automatically by Jules for task [2331671549705548440](https://jules.google.com/task/2331671549705548440) started by @saint2706*