### PR TITLE
🧪 Testing: Improve coverage for useSwipe and useLearningAnalytics

### DIFF
--- a/src/hooks/__tests__/useLearningAnalytics.test.tsx
+++ b/src/hooks/__tests__/useLearningAnalytics.test.tsx
@@ -1,0 +1,151 @@
+import { createRoot } from 'react-dom/client'
+import { act } from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useLearningAnalytics } from '../useLearningAnalytics'
+import { useLearningAnalyticsStore } from '../../stores/learningAnalyticsStore'
+
+// Mock the store
+vi.mock('../../stores/learningAnalyticsStore', () => {
+  return {
+    useLearningAnalyticsStore: {
+      getState: vi.fn(),
+    },
+  }
+})
+
+describe('useLearningAnalytics', () => {
+  let container: HTMLDivElement | null = null
+  let root: ReturnType<typeof createRoot> | null = null
+  let mockStoreState: any
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    mockStoreState = {
+      hydrate: vi.fn(),
+      startTrackingRoute: vi.fn(),
+      pauseTracking: vi.fn(),
+      resumeTracking: vi.fn(),
+      stopTracking: vi.fn(),
+    }
+
+    vi.mocked(useLearningAnalyticsStore.getState).mockReturnValue(mockStoreState)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount()
+    })
+    container?.remove()
+    container = null
+    root = null
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+
+    // Restore document.hidden if it was mocked
+    if (Object.getOwnPropertyDescriptor(document, 'hidden')?.configurable) {
+      Object.defineProperty(document, 'hidden', { configurable: true, get: () => false })
+    }
+  })
+
+  function TestComponent({ route }: { route: string }) {
+    useLearningAnalytics(route)
+    return null
+  }
+
+  it('hydrates and starts tracking on mount', () => {
+    act(() => {
+      root?.render(<TestComponent route="Lesson 1" />)
+    })
+
+    expect(mockStoreState.hydrate).toHaveBeenCalledTimes(1)
+    expect(mockStoreState.startTrackingRoute).toHaveBeenCalledWith('Lesson 1')
+  })
+
+  it('re-starts tracking when route changes', () => {
+    act(() => {
+      root?.render(<TestComponent route="Lesson 1" />)
+    })
+
+    expect(mockStoreState.startTrackingRoute).toHaveBeenCalledWith('Lesson 1')
+
+    act(() => {
+      root?.render(<TestComponent route="Lesson 2" />)
+    })
+
+    expect(mockStoreState.startTrackingRoute).toHaveBeenCalledWith('Lesson 2')
+    // hydrate should have been called twice (once for each mount/update)
+    expect(mockStoreState.hydrate).toHaveBeenCalledTimes(2)
+  })
+
+  it('pauses tracking when document becomes hidden', () => {
+    act(() => {
+      root?.render(<TestComponent route="Lesson 1" />)
+    })
+
+    // Mock document.hidden
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => true })
+
+    act(() => {
+      const event = new Event('visibilitychange')
+      document.dispatchEvent(event)
+    })
+
+    expect(mockStoreState.pauseTracking).toHaveBeenCalledTimes(1)
+    expect(mockStoreState.resumeTracking).not.toHaveBeenCalled()
+  })
+
+  it('resumes tracking when document becomes visible', () => {
+    act(() => {
+      root?.render(<TestComponent route="Lesson 1" />)
+    })
+
+    // Mock document.hidden
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => false })
+
+    act(() => {
+      const event = new Event('visibilitychange')
+      document.dispatchEvent(event)
+    })
+
+    expect(mockStoreState.resumeTracking).toHaveBeenCalledTimes(1)
+    expect(mockStoreState.pauseTracking).not.toHaveBeenCalled()
+  })
+
+  it('stops tracking on beforeunload', () => {
+    act(() => {
+      root?.render(<TestComponent route="Lesson 1" />)
+    })
+
+    act(() => {
+      const event = new Event('beforeunload')
+      window.dispatchEvent(event)
+    })
+
+    expect(mockStoreState.stopTracking).toHaveBeenCalled()
+  })
+
+  it('stops tracking and cleans up on unmount', () => {
+    const addEventListenerSpy = vi.spyOn(document, 'addEventListener')
+    const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener')
+    const windowAddEventListenerSpy = vi.spyOn(window, 'addEventListener')
+    const windowRemoveEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+
+    act(() => {
+      root?.render(<TestComponent route="Lesson 1" />)
+    })
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    expect(windowAddEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+
+    act(() => {
+      root?.unmount()
+    })
+
+    expect(mockStoreState.stopTracking).toHaveBeenCalled()
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    expect(windowRemoveEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function))
+  })
+})

--- a/src/hooks/__tests__/useSwipe.test.tsx
+++ b/src/hooks/__tests__/useSwipe.test.tsx
@@ -1,0 +1,212 @@
+import { createRoot } from 'react-dom/client'
+import { act } from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useSwipe } from '../useSwipe'
+
+describe('useSwipe', () => {
+  let container: HTMLDivElement | null = null
+  let root: ReturnType<typeof createRoot> | null = null
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount()
+    })
+    container?.remove()
+    container = null
+    root = null
+    vi.clearAllMocks()
+  })
+
+  // A simple component to test the useSwipe hook
+  function SwipeTestComponent({
+    onSwipeLeft,
+    onSwipeRight,
+    threshold,
+  }: {
+    onSwipeLeft?: () => void
+    onSwipeRight?: () => void
+    threshold?: number
+  }) {
+    const swipeRef = useSwipe({ onSwipeLeft, onSwipeRight, threshold })
+
+    // We assign the ref to a div we can target
+    return (
+      <div ref={swipeRef} data-testid="swipe-area" style={{ width: 100, height: 100 }}>
+        Swipe Area
+      </div>
+    )
+  }
+
+  function simulateTouch(
+    element: Element,
+    type: 'touchstart' | 'touchend',
+    clientX: number,
+    clientY: number,
+  ) {
+    const touch = {
+      clientX,
+      clientY,
+    }
+
+    const eventOptions = type === 'touchstart' ? { touches: [touch] } : { changedTouches: [touch] }
+
+    const event = new TouchEvent(type, eventOptions as any)
+    element.dispatchEvent(event)
+  }
+
+  it('triggers onSwipeLeft when swiping left past threshold', () => {
+    const onSwipeLeft = vi.fn()
+    const onSwipeRight = vi.fn()
+
+    act(() => {
+      root?.render(<SwipeTestComponent onSwipeLeft={onSwipeLeft} onSwipeRight={onSwipeRight} />)
+    })
+
+    const swipeArea = container!.querySelector('[data-testid="swipe-area"]')!
+
+    // Swipe left: Start at x=100, end at x=20 (diff is -80)
+    act(() => {
+      simulateTouch(swipeArea, 'touchstart', 100, 50)
+      simulateTouch(swipeArea, 'touchend', 20, 50)
+    })
+
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1)
+    expect(onSwipeRight).not.toHaveBeenCalled()
+  })
+
+  it('triggers onSwipeRight when swiping right past threshold', () => {
+    const onSwipeLeft = vi.fn()
+    const onSwipeRight = vi.fn()
+
+    act(() => {
+      root?.render(<SwipeTestComponent onSwipeLeft={onSwipeLeft} onSwipeRight={onSwipeRight} />)
+    })
+
+    const swipeArea = container!.querySelector('[data-testid="swipe-area"]')!
+
+    // Swipe right: Start at x=20, end at x=100 (diff is 80)
+    act(() => {
+      simulateTouch(swipeArea, 'touchstart', 20, 50)
+      simulateTouch(swipeArea, 'touchend', 100, 50)
+    })
+
+    expect(onSwipeRight).toHaveBeenCalledTimes(1)
+    expect(onSwipeLeft).not.toHaveBeenCalled()
+  })
+
+  it('does not trigger callbacks if swipe is below threshold', () => {
+    const onSwipeLeft = vi.fn()
+    const onSwipeRight = vi.fn()
+
+    // Default threshold is 60, so a diff of 50 shouldn't trigger
+    act(() => {
+      root?.render(<SwipeTestComponent onSwipeLeft={onSwipeLeft} onSwipeRight={onSwipeRight} />)
+    })
+
+    const swipeArea = container!.querySelector('[data-testid="swipe-area"]')!
+
+    act(() => {
+      simulateTouch(swipeArea, 'touchstart', 50, 50)
+      simulateTouch(swipeArea, 'touchend', 90, 50) // Right swipe of 40
+    })
+
+    act(() => {
+      simulateTouch(swipeArea, 'touchstart', 90, 50)
+      simulateTouch(swipeArea, 'touchend', 50, 50) // Left swipe of 40
+    })
+
+    expect(onSwipeRight).not.toHaveBeenCalled()
+    expect(onSwipeLeft).not.toHaveBeenCalled()
+  })
+
+  it('does not trigger callbacks if vertical movement is dominant', () => {
+    const onSwipeLeft = vi.fn()
+    const onSwipeRight = vi.fn()
+
+    act(() => {
+      root?.render(<SwipeTestComponent onSwipeLeft={onSwipeLeft} onSwipeRight={onSwipeRight} />)
+    })
+
+    const swipeArea = container!.querySelector('[data-testid="swipe-area"]')!
+
+    // Swipe right by 80, but down by 100
+    act(() => {
+      simulateTouch(swipeArea, 'touchstart', 20, 20)
+      simulateTouch(swipeArea, 'touchend', 100, 120)
+    })
+
+    // Swipe left by 80, but up by 100
+    act(() => {
+      simulateTouch(swipeArea, 'touchstart', 100, 120)
+      simulateTouch(swipeArea, 'touchend', 20, 20)
+    })
+
+    expect(onSwipeRight).not.toHaveBeenCalled()
+    expect(onSwipeLeft).not.toHaveBeenCalled()
+  })
+
+  it('supports custom threshold', () => {
+    const onSwipeLeft = vi.fn()
+    const onSwipeRight = vi.fn()
+
+    act(() => {
+      root?.render(
+        <SwipeTestComponent
+          onSwipeLeft={onSwipeLeft}
+          onSwipeRight={onSwipeRight}
+          threshold={100}
+        />,
+      )
+    })
+
+    const swipeArea = container!.querySelector('[data-testid="swipe-area"]')!
+
+    // Swipe right by 80, which is below the new threshold of 100
+    act(() => {
+      simulateTouch(swipeArea, 'touchstart', 20, 50)
+      simulateTouch(swipeArea, 'touchend', 100, 50)
+    })
+
+    expect(onSwipeRight).not.toHaveBeenCalled()
+
+    // Swipe right by 110, which is above threshold
+    act(() => {
+      simulateTouch(swipeArea, 'touchstart', 20, 50)
+      simulateTouch(swipeArea, 'touchend', 130, 50)
+    })
+
+    expect(onSwipeRight).toHaveBeenCalledTimes(1)
+  })
+
+  it('cleans up event listeners on unmount', () => {
+    const addEventListenerSpy = vi.spyOn(HTMLDivElement.prototype, 'addEventListener')
+    const removeEventListenerSpy = vi.spyOn(HTMLDivElement.prototype, 'removeEventListener')
+
+    act(() => {
+      root?.render(<SwipeTestComponent />)
+    })
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('touchstart', expect.any(Function), {
+      passive: true,
+    })
+    expect(addEventListenerSpy).toHaveBeenCalledWith('touchend', expect.any(Function), {
+      passive: true,
+    })
+
+    act(() => {
+      root?.unmount()
+    })
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('touchstart', expect.any(Function))
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('touchend', expect.any(Function))
+
+    addEventListenerSpy.mockRestore()
+    removeEventListenerSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
Added comprehensive unit tests for `useSwipe` and `useLearningAnalytics` hooks.
- `useSwipe`: Covered swipe directions, thresholds, and unmount cleanups using `TouchEvents`.
- `useLearningAnalytics`: Mocked the Zustand store to test hydration, routing, visibility changes, and unmounts.
- Ensured test files utilize `createRoot` over `@testing-library/react` per project conventions.
- Tests properly clear and restore mocked state to prevent test bleed.
- Branch coverage for these files improved significantly.

---
*PR created automatically by Jules for task [15030783953893277789](https://jules.google.com/task/15030783953893277789) started by @saint2706*