### PR TITLE
📚 Docs: Update mlc_config.json to ignore false positive dead links

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -23,3 +23,7 @@
   - Created a Python script `/home/jules/self_created_tools/check_jsdoc4.py` to identify missing JSDoc comments for exported functions and arrow functions across `src/stores/`.
 - Updated README.md and CONTRIBUTING.md to reflect the new 140-day curriculum (incorporating Phases 10-12).
 - Updated TSDoc tags for exported functions in `src/utils/codeSecurity.ts` and `src/utils/confetti.ts` for better clarity and API completeness.
+
+- **[2026-03-17] Markdown Links & Link Checker configuration**
+  - Updated `mlc_config.json` configuration file to ignore more websites that return false positives (403 or 0 codes) from anti-bot mechanisms: `machinelearningmastery.com`, `docs.scipy.org`, `pgtune.leopard.in.ua`.
+  - Successfully passed `markdown-link-check` script.

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -18,6 +18,9 @@
     {"pattern": "^https://jsonplaceholder\\.typicode\\.com/"},
     {"pattern": "^https://feature-engine\\.readthedocs\\.io/"},
     {"pattern": "^https://joblib\\.readthedocs\\.io/"},
-    {"pattern": "^https://reddit\\.com/r/localllama"}
+    {"pattern": "^https://reddit\\.com/r/localllama"},
+    {"pattern": "^https://machinelearningmastery\\.com/"},
+    {"pattern": "^https://docs\\.scipy\\.org/"},
+    {"pattern": "^https://pgtune\\.leopard\\.in\\.ua/"}
   ]
 }


### PR DESCRIPTION
This PR resolves issues with the `markdown-link-check` script failing due to Cloudflare anti-bot mechanisms and other firewall protections returning a 403 or 0 status on valid URLs. The domains have been added to the `mlc_config.json` ignore patterns so the build passes successfully.

---
*PR created automatically by Jules for task [7692940478126898601](https://jules.google.com/task/7692940478126898601) started by @saint2706*