### PR TITLE
🧘 Buddha: [SEO] Semantic HTML Hierarchy Refactoring

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -105,3 +105,7 @@ This scroll records the harmonization of the `Coding-For-MBA` codebase for human
 ## 🧘 Buddha: Added Product Schema & Updated llms.txt [SEO][GEO]
 - Added `buildProductSchema` JSON-LD to `src/pages/Home.tsx` and `src/pages/Curriculum.tsx` to enrich structured data for search engines.
 - Ran `node scripts/generate-llms-txt.js` to ensure the `llms.txt` manifest includes the latest content, ensuring GEO compatibility.
+
+## 🧘 Buddha: Semantic HTML Hierarchy Refactoring [SEO][GEO]
+- Fixed semantic heading hierarchy in `src/components/ExerciseWidget.tsx`, `src/components/MasteryCheck.tsx`, and `src/components/ExerciseCard.tsx` by changing `<h4>` to `<h3>` to prevent skipped heading levels.
+- Regenerated `llms.txt` using `node scripts/generate-llms-txt.js` to ensure latest context is available for AI crawlers.

--- a/src/components/ExerciseCard.tsx
+++ b/src/components/ExerciseCard.tsx
@@ -32,7 +32,7 @@ function ExerciseCard({ exercise }: ExerciseCardProps) {
           {diff.label}
         </span>
       </div>
-      <h4 className="exercise-card__title">{exercise.title}</h4>
+      <h3 className="exercise-card__title">{exercise.title}</h3>
       {exercise.goal && <p className="exercise-card__goal">{exercise.goal}</p>}
       <div className="exercise-card__footer">
         <Link to={`/lesson/${exercise.day}`} className="exercise-card__link">

--- a/src/components/ExerciseWidget.tsx
+++ b/src/components/ExerciseWidget.tsx
@@ -190,7 +190,7 @@ export default function ExerciseWidget({
         <span className="exercise-widget__icon" aria-hidden="true">
           🧪
         </span>
-        <h4 className="exercise-widget__title">{title}</h4>
+        <h3 className="exercise-widget__title">{title}</h3>
       </div>
 
       {goal && (

--- a/src/components/MasteryCheck.tsx
+++ b/src/components/MasteryCheck.tsx
@@ -37,7 +37,7 @@ export default function MasteryCheck({
     <div className={`mastery-check ${revealed ? 'mastery-check--revealed' : ''}`}>
       <div className="mastery-check__header">
         <span className="mastery-check__badge">Q{questionNumber}</span>
-        <h4 className="mastery-check__title">{title}</h4>
+        <h3 className="mastery-check__title">{title}</h3>
       </div>
 
       <div className="mastery-check__question">


### PR DESCRIPTION
Fixed heading hierarchy by replacing `<h4>` with `<h3>` where appropriate in `ExerciseCard`, `ExerciseWidget`, and `MasteryCheck` components. This prevents skipped heading levels for better semantic HTML. Validated test suite and build correctly.

---
*PR created automatically by Jules for task [664776182925656763](https://jules.google.com/task/664776182925656763) started by @saint2706*