### PR TITLE
🎨 Picasso: [UX improvement] Add ARIA attributes for collapsible regions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,7 @@ export default function App() {
         <Suspense fallback={null}>
           <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
         </Suspense>
-        <Navbar onToggleSidebar={() => setSidebarOpen((prev) => !prev)} />
+        <Navbar sidebarOpen={sidebarOpen} onToggleSidebar={() => setSidebarOpen((prev) => !prev)} />
         <main className="main-content" id="main-content" tabIndex={-1}>
           <Suspense fallback={<PageSkeleton />}>
             <Routes location={location}>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -18,9 +18,10 @@ import { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'
 
 interface NavbarProps {
   onToggleSidebar: () => void
+  sidebarOpen: boolean
 }
 
-export default function Navbar({ onToggleSidebar }: NavbarProps) {
+export default function Navbar({ onToggleSidebar, sidebarOpen }: NavbarProps) {
   const location = useLocation()
   const navigate = useNavigate()
   const [query, setQuery] = useState('')
@@ -76,6 +77,8 @@ export default function Navbar({ onToggleSidebar }: NavbarProps) {
           onClick={onToggleSidebar}
           aria-label="Toggle sidebar menu"
           title="Toggle sidebar"
+          aria-expanded={sidebarOpen}
+          aria-controls="app-sidebar"
         >
           <svg
             viewBox="0 0 24 24"

--- a/src/components/SearchPalette.tsx
+++ b/src/components/SearchPalette.tsx
@@ -185,6 +185,7 @@ export default function SearchPalette({ isOpen, onClose }: SearchPaletteProps) {
             onKeyDown={handleKeyDown}
             aria-label="Search"
             aria-autocomplete="list"
+            aria-expanded={results.length > 0}
             aria-controls="search-results"
             aria-activedescendant={results.length > 0 ? `search-result-${activeIndex}` : undefined}
           />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -102,6 +102,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
         aria-hidden="true"
       />
       <aside
+        id="app-sidebar"
         className={`sidebar ${isOpen ? 'open' : ''}`}
         role="navigation"
         aria-label="Lesson navigation"

--- a/src/components/__tests__/Navbar.test.tsx
+++ b/src/components/__tests__/Navbar.test.tsx
@@ -32,7 +32,7 @@ describe('Navbar', () => {
     await act(async () => {
       root.render(
         <MemoryRouter initialEntries={['/']}>
-          <Navbar onToggleSidebar={() => {}} />
+          <Navbar sidebarOpen={false} onToggleSidebar={() => {}} />
         </MemoryRouter>,
       )
     })
@@ -47,7 +47,7 @@ describe('Navbar', () => {
     await act(async () => {
       root.render(
         <MemoryRouter initialEntries={['/']}>
-          <Navbar onToggleSidebar={() => {}} />
+          <Navbar sidebarOpen={false} onToggleSidebar={() => {}} />
         </MemoryRouter>,
       )
     })


### PR DESCRIPTION
🎨 Picasso: [UX improvement] Add ARIA attributes for collapsible regions

Added `aria-expanded` and `aria-controls` to the sidebar toggle button and search palette input to improve accessibility for screen readers, mapped to their respective open states.

- Added `sidebarOpen` prop to `Navbar`
- Added `id="app-sidebar"` to `Sidebar` aside element
- Mapped `aria-expanded` and `aria-controls` in `Navbar` hamburger button
- Mapped `aria-expanded` and `aria-controls` in `SearchPalette` input
- Updated `Navbar.test.tsx` to handle `sidebarOpen` prop

---
*PR created automatically by Jules for task [16022180978792958856](https://jules.google.com/task/16022180978792958856) started by @saint2706*