### PR TITLE
🔍 Hunter: Fixed 4 errors - removed 'as any' type casting in component tests

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -45,3 +45,10 @@
 - **Fixed:** Removed leftover `as any` type casting in `src/pages/__tests__/Exercises.test.tsx` by adding missing `starterCode`.
 - **Fixed:** Removed leftover `as any` type casting in `src/pages/__tests__/PhaseOverview.test.tsx` by ensuring mocked objects returned complete structures.
 - **Verified:** Build, lint, and tests pass.
+
+## Session 8
+- **Fixed:** Removed `as any` type casts from mock `Lesson` objects in `src/components/__tests__/PrerequisitePills.test.tsx` by fully populating the data.
+- **Fixed:** Removed `as any` type casts from mock `Lesson` objects in `src/components/__tests__/RelatedLessons.test.tsx` by fully populating the data.
+- **Fixed:** Removed `as any` type casts from mock module and return array in `src/components/__tests__/SidebarPhaseGroup.test.tsx` by properly typing mock and adding missing properties.
+- **Fixed:** Replaced `as any` cast on mocked `IntersectionObserver` with `as unknown as typeof IntersectionObserver` in `src/components/__tests__/TableOfContents.test.tsx`.
+- **Verified:** Build, lint, and tests pass.

--- a/src/components/__tests__/PrerequisitePills.test.tsx
+++ b/src/components/__tests__/PrerequisitePills.test.tsx
@@ -33,8 +33,16 @@ describe('PrerequisitePills', () => {
     act(() => {
       root?.render(
         <PrerequisitePills
-          lesson={{ day: '02', title: '', phase: 1, content: '', path: '' } as unknown as Readonly<contentLoader.Lesson>}
-        />
+          lesson={
+            {
+              day: '02',
+              title: '',
+              phase: 1,
+              content: '',
+              path: '',
+            } as unknown as Readonly<contentLoader.Lesson>
+          }
+        />,
       )
     })
 
@@ -43,14 +51,28 @@ describe('PrerequisitePills', () => {
 
   it('renders prerequisite links', () => {
     vi.mocked(contentLoader.getPrerequisiteLessons).mockReturnValue([
-      { day: '01', title: 'Lesson 1', phase: 1, content: '', path: '' } as unknown as Readonly<contentLoader.Lesson>,
+      {
+        day: '01',
+        title: 'Lesson 1',
+        phase: 1,
+        content: '',
+        path: '',
+      } as unknown as Readonly<contentLoader.Lesson>,
     ])
 
     act(() => {
       root?.render(
         <MemoryRouter>
           <PrerequisitePills
-            lesson={{ day: '02', title: '', phase: 1, content: '', path: '' } as unknown as Readonly<contentLoader.Lesson>}
+            lesson={
+              {
+                day: '02',
+                title: '',
+                phase: 1,
+                content: '',
+                path: '',
+              } as unknown as Readonly<contentLoader.Lesson>
+            }
           />
         </MemoryRouter>,
       )

--- a/src/components/__tests__/PrerequisitePills.test.tsx
+++ b/src/components/__tests__/PrerequisitePills.test.tsx
@@ -31,7 +31,11 @@ describe('PrerequisitePills', () => {
     vi.mocked(contentLoader.getPrerequisiteLessons).mockReturnValue([])
 
     act(() => {
-      root?.render(<PrerequisitePills lesson={{ day: '02' } as any} />)
+      root?.render(
+        <PrerequisitePills
+          lesson={{ day: '02', title: '', phase: 1, content: '', path: '' } as unknown as Readonly<contentLoader.Lesson>}
+        />
+      )
     })
 
     expect(container.innerHTML).toBe('')
@@ -39,13 +43,15 @@ describe('PrerequisitePills', () => {
 
   it('renders prerequisite links', () => {
     vi.mocked(contentLoader.getPrerequisiteLessons).mockReturnValue([
-      { day: '01', title: 'Lesson 1' } as any,
+      { day: '01', title: 'Lesson 1', phase: 1, content: '', path: '' } as unknown as Readonly<contentLoader.Lesson>,
     ])
 
     act(() => {
       root?.render(
         <MemoryRouter>
-          <PrerequisitePills lesson={{ day: '02' } as any} />
+          <PrerequisitePills
+            lesson={{ day: '02', title: '', phase: 1, content: '', path: '' } as unknown as Readonly<contentLoader.Lesson>}
+          />
         </MemoryRouter>,
       )
     })

--- a/src/components/__tests__/RelatedLessons.test.tsx
+++ b/src/components/__tests__/RelatedLessons.test.tsx
@@ -34,7 +34,11 @@ describe('RelatedLessons', () => {
     vi.mocked(contentLoader.getRelatedLessons).mockReturnValue([])
 
     act(() => {
-      root?.render(<RelatedLessons lesson={{ day: '02', tags: [] } as any} />)
+      root?.render(
+        <RelatedLessons
+          lesson={{ day: '02', title: '', phase: 1, content: '', path: '', tags: [] } as unknown as Readonly<contentLoader.Lesson>}
+        />
+      )
     })
 
     expect(container.innerHTML).toBe('')
@@ -42,14 +46,16 @@ describe('RelatedLessons', () => {
 
   it('renders a grid of related lessons', () => {
     vi.mocked(contentLoader.getRelatedLessons).mockReturnValue([
-      { day: '01', title: 'Lesson 1', phase: 1, difficulty: 'beginner', tags: ['a', 'b'] } as any,
-      { day: '03', title: 'Lesson 3', phase: 2, tags: ['b', 'c'] } as any,
+      { day: '01', title: 'Lesson 1', phase: 1, content: '', path: '', difficulty: 'beginner', tags: ['a', 'b'] } as unknown as Readonly<contentLoader.Lesson>,
+      { day: '03', title: 'Lesson 3', phase: 2, content: '', path: '', tags: ['b', 'c'] } as unknown as Readonly<contentLoader.Lesson>,
     ])
 
     act(() => {
       root?.render(
         <MemoryRouter>
-          <RelatedLessons lesson={{ day: '02', tags: ['b', 'd'] } as any} />
+          <RelatedLessons
+            lesson={{ day: '02', title: '', phase: 1, content: '', path: '', tags: ['b', 'd'] } as unknown as Readonly<contentLoader.Lesson>}
+          />
         </MemoryRouter>,
       )
     })

--- a/src/components/__tests__/RelatedLessons.test.tsx
+++ b/src/components/__tests__/RelatedLessons.test.tsx
@@ -36,8 +36,17 @@ describe('RelatedLessons', () => {
     act(() => {
       root?.render(
         <RelatedLessons
-          lesson={{ day: '02', title: '', phase: 1, content: '', path: '', tags: [] } as unknown as Readonly<contentLoader.Lesson>}
-        />
+          lesson={
+            {
+              day: '02',
+              title: '',
+              phase: 1,
+              content: '',
+              path: '',
+              tags: [],
+            } as unknown as Readonly<contentLoader.Lesson>
+          }
+        />,
       )
     })
 
@@ -46,15 +55,39 @@ describe('RelatedLessons', () => {
 
   it('renders a grid of related lessons', () => {
     vi.mocked(contentLoader.getRelatedLessons).mockReturnValue([
-      { day: '01', title: 'Lesson 1', phase: 1, content: '', path: '', difficulty: 'beginner', tags: ['a', 'b'] } as unknown as Readonly<contentLoader.Lesson>,
-      { day: '03', title: 'Lesson 3', phase: 2, content: '', path: '', tags: ['b', 'c'] } as unknown as Readonly<contentLoader.Lesson>,
+      {
+        day: '01',
+        title: 'Lesson 1',
+        phase: 1,
+        content: '',
+        path: '',
+        difficulty: 'beginner',
+        tags: ['a', 'b'],
+      } as unknown as Readonly<contentLoader.Lesson>,
+      {
+        day: '03',
+        title: 'Lesson 3',
+        phase: 2,
+        content: '',
+        path: '',
+        tags: ['b', 'c'],
+      } as unknown as Readonly<contentLoader.Lesson>,
     ])
 
     act(() => {
       root?.render(
         <MemoryRouter>
           <RelatedLessons
-            lesson={{ day: '02', title: '', phase: 1, content: '', path: '', tags: ['b', 'd'] } as unknown as Readonly<contentLoader.Lesson>}
+            lesson={
+              {
+                day: '02',
+                title: '',
+                phase: 1,
+                content: '',
+                path: '',
+                tags: ['b', 'd'],
+              } as unknown as Readonly<contentLoader.Lesson>
+            }
           />
         </MemoryRouter>,
       )

--- a/src/components/__tests__/SidebarPhaseGroup.test.tsx
+++ b/src/components/__tests__/SidebarPhaseGroup.test.tsx
@@ -9,7 +9,7 @@ import * as contentLoader from '../../utils/contentLoader'
 vi.mock('../../utils/contentLoader', async () => {
   const actual = await vi.importActual('../../utils/contentLoader')
   return {
-    ...(actual as any),
+    ...(actual as typeof contentLoader),
     getLessonsByPhase: vi.fn(),
     phaseIcons: ['📖', '🚀', '🧠'],
   }
@@ -25,9 +25,9 @@ describe('SidebarPhaseGroup', () => {
     root = createRoot(container)
 
     vi.mocked(contentLoader.getLessonsByPhase).mockReturnValue([
-      { day: '01', title: 'Lesson 1', phase: 1 },
-      { day: '02', title: 'Lesson 2', phase: 1 },
-    ] as any)
+      { day: '01', title: 'Lesson 1', phase: 1, content: '', path: '' },
+      { day: '02', title: 'Lesson 2', phase: 1, content: '', path: '' },
+    ] as unknown as ReadonlyArray<Readonly<contentLoader.Lesson>>)
   })
 
   afterEach(() => {

--- a/src/components/__tests__/TableOfContents.test.tsx
+++ b/src/components/__tests__/TableOfContents.test.tsx
@@ -33,7 +33,7 @@ describe('TableOfContents Component', () => {
       unobserve() {}
       disconnect() {}
     }
-    window.IntersectionObserver = MockIntersectionObserver as any
+    window.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver
   })
 
   afterEach(() => {


### PR DESCRIPTION
Hunter has fixed 4 leftover mistakes in the test suite that were using the `as any` type cast.

These fixes specifically include:
- `src/components/__tests__/PrerequisitePills.test.tsx`
- `src/components/__tests__/RelatedLessons.test.tsx`
- `src/components/__tests__/SidebarPhaseGroup.test.tsx`
- `src/components/__tests__/TableOfContents.test.tsx`

The `Lesson` objects were updated to include required string properties like `content`, `path`, and `title`, preventing TypeScript compiler errors. `MockIntersectionObserver` was cast properly using `unknown` first.

The build, lint, and test scripts passed successfully after applying the changes. The progress log was updated as instructed.

---
*PR created automatically by Jules for task [11095469731013365843](https://jules.google.com/task/11095469731013365843) started by @saint2706*