### PR TITLE
📚 Docs: Add missing JSDoc comments to exported utility functions

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -27,3 +27,7 @@
 - **[2026-03-17] Markdown Links & Link Checker configuration**
   - Updated `mlc_config.json` configuration file to ignore more websites that return false positives (403 or 0 codes) from anti-bot mechanisms: `machinelearningmastery.com`, `docs.scipy.org`, `pgtune.leopard.in.ua`.
   - Successfully passed `markdown-link-check` script.
+- **[2026-03-18] Added missing JSDoc comments to utilities**
+  - Added full JSDoc comments (`@param`, `@returns`) to `src/utils/seoSchemas.ts` for `buildCanonicalUrl`, `buildWebSiteSchema`, and `buildCourseSchema`.
+  - Added full JSDoc comments (`@param`, `@returns`) to `src/utils/contentLoader.ts` for `getAdjacentLessons`, `getAllExercises`, `getNotebook`, and `getReadingTime`.
+  - Verified that all exported functions within `src/utils/` are fully documented via automated script check.

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -208,7 +208,12 @@ export function getLessonsByPhase(phaseNum: string | number): readonly Immutable
   return immutableLessonsByPhase[Number(phaseNum)] || []
 }
 
-/** Return previous and next lessons around the given day. */
+/**
+ * Return previous and next lessons around the given day.
+ *
+ * @param {string | number} dayNum - The day token or number of the lesson.
+ * @returns {{ prev: ImmutableLesson | null; next: ImmutableLesson | null }} An object containing the previous and next lessons.
+ */
 export function getAdjacentLessons(dayNum: string | number): {
   prev: ImmutableLesson | null
   next: ImmutableLesson | null
@@ -365,7 +370,11 @@ let immutableLessonsByPhase: Record<number, readonly ImmutableLesson[]> | null =
 let immutableExercises: readonly ImmutableExercise[] | null = null
 let immutableReviewCards: readonly ImmutableReviewCardSeed[] | null = null
 
-/** Return all parsed exercises across lessons. */
+/**
+ * Return all parsed exercises across lessons.
+ *
+ * @returns {readonly ImmutableExercise[]} A read-only array of all parsed exercises.
+ */
 export function getAllExercises(): readonly ImmutableExercise[] {
   initializeContent()
   if (!immutableExercises) {
@@ -570,12 +579,22 @@ export function getAllNotebooks(): readonly ImmutableNotebook[] {
   return immutableNotebooks
 }
 
-/** Return a notebook by phase number. */
+/**
+ * Return a notebook by phase number.
+ *
+ * @param {string | number} phaseNum - The numeric identifier of the phase.
+ * @returns {ImmutableNotebook | undefined} The corresponding notebook object or undefined if not found.
+ */
 export function getNotebook(phaseNum: string | number): ImmutableNotebook | undefined {
   return getAllNotebooks().find((n) => n.phase === Number(phaseNum))
 }
 
-/** Estimate reading time in minutes after removing markdown syntax noise. */
+/**
+ * Estimate reading time in minutes after removing markdown syntax noise.
+ *
+ * @param {string} content - The markdown content to calculate reading time for.
+ * @returns {number} The estimated reading time in minutes.
+ */
 export function getReadingTime(content: string): number {
   const stripped = content
     .replace(/```[\s\S]*?```/g, '')

--- a/src/utils/seoSchemas.ts
+++ b/src/utils/seoSchemas.ts
@@ -15,14 +15,23 @@ const SITE_NAME = 'Coding for MBA'
 const DEFAULT_DESCRIPTION =
   'A structured 108-day curriculum covering Python, Data Science, Machine Learning, Business Intelligence, and Enterprise SQL — designed for MBA professionals.'
 
-/** Build a full canonical URL from a hash path */
+/**
+ * Build a full canonical URL from a hash path.
+ *
+ * @param {string} [path] - The optional hash path.
+ * @returns {string} The full canonical URL.
+ */
 export function buildCanonicalUrl(path?: string): string {
   if (!path) return SITE_URL
   const cleanPath = path.startsWith('/') ? path : `/${path}`
   return `${SITE_URL}/#${cleanPath}`
 }
 
-/** Build the WebSite JSON-LD schema (typically for the home page) */
+/**
+ * Build the WebSite JSON-LD schema (typically for the home page).
+ *
+ * @returns {Record<string, unknown>} The WebSite JSON-LD schema.
+ */
 export function buildWebSiteSchema(): Record<string, unknown> {
   return {
     '@context': 'https://schema.org',
@@ -91,7 +100,11 @@ export function buildCollectionPageSchema(
   }
 }
 
-/** Build a Course JSON-LD schema for the curriculum */
+/**
+ * Build a Course JSON-LD schema for the curriculum.
+ *
+ * @returns {Record<string, unknown>} The Course JSON-LD schema.
+ */
 export function buildCourseSchema(): Record<string, unknown> {
   return {
     '@context': 'https://schema.org',


### PR DESCRIPTION
This PR adds missing JSDoc comments to exported functions across `src/utils/seoSchemas.ts` and `src/utils/contentLoader.ts` to ensure consistency and improve API reference documentation. 

Progress has been accurately documented in `.jules/docs-progress.md`. All format checks, typescript checks, and unit tests have been run locally and successfully passed.

---
*PR created automatically by Jules for task [15209006103436735190](https://jules.google.com/task/15209006103436735190) started by @saint2706*