### PR TITLE
feat(ui): add Reading Comfort theme and toggle for lesson reading mode

### DIFF
--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -79,6 +79,7 @@ export default function Lesson() {
   const lesson = getLesson(dayNum!)
   const { prev, next } = getAdjacentLessons(dayNum!)
   const readingModePreference = useUserPreferencesStore((state) => state.readingMode)
+  const readingComfortTheme = useUserPreferencesStore((state) => state.readingComfortTheme)
   const setReadingModePreference = useUserPreferencesStore((state) => state.setReadingMode)
   const [readingMode, setReadingMode] = useState(readingModePreference)
   const [nearBottom, setNearBottom] = useState(false)
@@ -258,7 +259,7 @@ export default function Lesson() {
 
   return (
     <div
-      className={`page-container lesson-with-toc lesson-reading-surface ${readingMode ? 'reading-mode' : ''}`}
+      className={`page-container lesson-with-toc ${readingMode && readingComfortTheme ? 'lesson-reading-surface' : ''} ${readingMode ? 'reading-mode' : ''}`}
       ref={swipeRef}
     >
       <SEOHead

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -108,6 +108,7 @@ export default function ProgressDashboard() {
     codeLanguage,
     density,
     readingMode,
+    readingComfortTheme,
     customCursorEnabled,
     setPalette,
     setSidebarDefaultOpen,
@@ -115,6 +116,7 @@ export default function ProgressDashboard() {
     setCodeLanguage,
     setDensity,
     setReadingMode,
+    setReadingComfortTheme,
     setCustomCursorEnabled,
   } = useUserPreferencesStore()
 
@@ -472,6 +474,26 @@ export default function ProgressDashboard() {
             </span>
             <small id="reading-mode-help">
               Focus on lesson text with reduced interface chrome.
+            </small>
+          </label>
+
+          <label
+            className="preferences-field preferences-toggle"
+            htmlFor="reading-comfort-theme-default"
+          >
+            Reading comfort theme
+            <span className="preferences-toggle-row">
+              <input
+                id="reading-comfort-theme-default"
+                type="checkbox"
+                checked={readingComfortTheme}
+                onChange={(event) => setReadingComfortTheme(event.target.checked)}
+                aria-describedby="reading-comfort-theme-help"
+              />
+              Apply the softer reading palette in reading mode
+            </span>
+            <small id="reading-comfort-theme-help">
+              Keeps your selected palette for the rest of the app.
             </small>
           </label>
 

--- a/src/stores/__tests__/userPreferencesStore.test.ts
+++ b/src/stores/__tests__/userPreferencesStore.test.ts
@@ -11,6 +11,9 @@ describe('userPreferencesStore', () => {
       fontSize: 'md',
       codeLanguage: 'python',
       density: 'comfortable',
+      readingMode: false,
+      readingComfortTheme: true,
+      customCursorEnabled: false,
     })
   })
 
@@ -22,6 +25,9 @@ describe('userPreferencesStore', () => {
     expect(state.fontSize).toBe('md')
     expect(state.codeLanguage).toBe('python')
     expect(state.density).toBe('comfortable')
+    expect(state.readingMode).toBe(false)
+    expect(state.readingComfortTheme).toBe(true)
+    expect(state.customCursorEnabled).toBe(false)
   })
 
   it('updates each preference via actions', () => {
@@ -32,6 +38,9 @@ describe('userPreferencesStore', () => {
     store.setFontSize('lg')
     store.setCodeLanguage('sql')
     store.setDensity('compact')
+    store.setReadingMode(true)
+    store.setReadingComfortTheme(false)
+    store.setCustomCursorEnabled(true)
 
     const updated = useUserPreferencesStore.getState()
 
@@ -41,6 +50,9 @@ describe('userPreferencesStore', () => {
       fontSize: 'lg',
       codeLanguage: 'sql',
       density: 'compact',
+      readingMode: true,
+      readingComfortTheme: false,
+      customCursorEnabled: true,
     })
   })
 
@@ -84,6 +96,7 @@ describe('userPreferencesStore', () => {
     expect(state.density).toBe('comfortable')
     // For boolean, it might default to false if not boolean
     expect(state.sidebarDefaultOpen).toBe(false)
+    expect(state.readingComfortTheme).toBe(true)
   })
 
   it('migrates from legacy theme field to palette', async () => {

--- a/src/stores/userPreferencesStore.ts
+++ b/src/stores/userPreferencesStore.ts
@@ -33,6 +33,7 @@ export type UserPreferencesStore = {
   codeLanguage: CodeLanguagePreference
   density: DensityPreference
   readingMode: boolean
+  readingComfortTheme: boolean
   customCursorEnabled: boolean
   setPalette: (palette: ColorPalette) => void
   setSidebarDefaultOpen: (open: boolean) => void
@@ -40,6 +41,7 @@ export type UserPreferencesStore = {
   setCodeLanguage: (language: CodeLanguagePreference) => void
   setDensity: (density: DensityPreference) => void
   setReadingMode: (readingMode: boolean) => void
+  setReadingComfortTheme: (readingComfortTheme: boolean) => void
   setCustomCursorEnabled: (customCursorEnabled: boolean) => void
 }
 
@@ -111,6 +113,7 @@ export const useUserPreferencesStore = create<UserPreferencesStore>()(
       codeLanguage: 'python',
       density: 'comfortable',
       readingMode: false,
+      readingComfortTheme: true,
       customCursorEnabled: false,
       setPalette: (palette) => set({ palette }),
       setSidebarDefaultOpen: (sidebarDefaultOpen) => set({ sidebarDefaultOpen }),
@@ -118,11 +121,12 @@ export const useUserPreferencesStore = create<UserPreferencesStore>()(
       setCodeLanguage: (codeLanguage) => set({ codeLanguage }),
       setDensity: (density) => set({ density }),
       setReadingMode: (readingMode) => set({ readingMode }),
+      setReadingComfortTheme: (readingComfortTheme) => set({ readingComfortTheme }),
       setCustomCursorEnabled: (customCursorEnabled) => set({ customCursorEnabled }),
     }),
     {
       name: STORAGE_KEY,
-      version: 4,
+      version: 5,
       storage: createJSONStorage(() => safeStorage),
       partialize: (state) => ({
         palette: state.palette,
@@ -131,6 +135,7 @@ export const useUserPreferencesStore = create<UserPreferencesStore>()(
         codeLanguage: state.codeLanguage,
         density: state.density,
         readingMode: state.readingMode,
+        readingComfortTheme: state.readingComfortTheme,
         customCursorEnabled: state.customCursorEnabled,
       }),
       migrate: (persistedState) => {
@@ -150,6 +155,8 @@ export const useUserPreferencesStore = create<UserPreferencesStore>()(
           codeLanguage: normalizeCodeLanguage(raw.codeLanguage),
           density: normalizeDensity(raw.density),
           readingMode: typeof raw.readingMode === 'boolean' ? raw.readingMode : false,
+          readingComfortTheme:
+            typeof raw.readingComfortTheme === 'boolean' ? raw.readingComfortTheme : true,
           customCursorEnabled:
             typeof raw.customCursorEnabled === 'boolean' ? raw.customCursorEnabled : false,
         }
@@ -176,3 +183,9 @@ export const selectSidebarDefaultOpen = (state: UserPreferencesStore) => state.s
  * @returns {boolean} Whether reading mode is enabled.
  */
 export const selectReadingMode = (state: UserPreferencesStore) => state.readingMode
+/**
+ * Selector for the reading comfort theme preference.
+ * @param {UserPreferencesStore} state - The user preferences state.
+ * @returns {boolean} Whether the reading comfort theme is enabled.
+ */
+export const selectReadingComfortTheme = (state: UserPreferencesStore) => state.readingComfortTheme

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -161,26 +161,24 @@ img {
 }
 
 .lesson-reading-surface {
-  --bg-primary: var(--reading-bg-primary);
-  --bg-surface: var(--reading-bg-surface);
-  --bg-card: color-mix(in srgb, var(--reading-bg-surface) 94%, #1f2d49 6%);
-  --bg-card-hover: color-mix(in srgb, var(--reading-bg-surface) 90%, #243452 10%);
-  --bg-code: var(--reading-bg-code);
-  --border-subtle: var(--reading-border-subtle);
-  --border-card: var(--reading-border-card);
-  --border-active: var(--reading-border-active);
-  --accent-glow: var(--reading-accent-glow);
-  --gradient-card: linear-gradient(
-    145deg,
-    rgba(67, 97, 238, 0.03) 0%,
-    rgba(63, 55, 201, 0.02) 100%
-  );
+  --bg-primary: var(--reading-theme-bg-primary);
+  --bg-surface: var(--reading-theme-bg-surface);
+  --bg-card: var(--reading-theme-bg-card);
+  --bg-card-hover: var(--reading-theme-bg-card-hover);
+  --bg-code: var(--reading-theme-bg-code);
+  --accent-primary: var(--reading-theme-accent-primary);
+  --accent-secondary: var(--reading-theme-accent-secondary);
+  --accent-tertiary: var(--reading-theme-accent-tertiary);
+  --border-subtle: var(--reading-theme-border-subtle);
+  --border-card: var(--reading-theme-border-card);
+  --border-active: var(--reading-theme-border-active);
+  --accent-glow: var(--reading-theme-accent-glow);
+  --gradient-card: none;
   --gradient-glow: none;
   --shadow-card: 0 3px 18px rgba(0, 0, 0, 0.22);
   --shadow-glow: none;
 }
 
 .lesson-reading-surface.page-container {
-  background:
-    radial-gradient(circle at 18% -18%, rgba(67, 97, 238, 0.06), transparent 45%), transparent;
+  background: var(--bg-primary);
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -51,14 +51,19 @@
     transparent 40%
   );
 
-  /* Calm reading surface */
-  --reading-bg-primary: #090918;
-  --reading-bg-surface: #0f0f24;
-  --reading-bg-code: #12122a;
-  --reading-border-subtle: rgba(150, 160, 210, 0.1);
-  --reading-border-card: rgba(150, 160, 210, 0.14);
-  --reading-border-active: rgba(94, 96, 206, 0.26);
-  --reading-accent-glow: rgba(94, 96, 206, 0.1);
+  /* Reading-first palette (low-chroma, softer contrast) */
+  --reading-theme-bg-primary: color-mix(in srgb, var(--bg-primary) 90%, #121826 10%);
+  --reading-theme-bg-surface: color-mix(in srgb, var(--bg-surface) 92%, #141b2d 8%);
+  --reading-theme-bg-card: color-mix(in srgb, var(--bg-card) 94%, #1a2338 6%);
+  --reading-theme-bg-card-hover: color-mix(in srgb, var(--bg-card-hover) 95%, #202a44 5%);
+  --reading-theme-bg-code: color-mix(in srgb, var(--bg-code) 94%, #151d30 6%);
+  --reading-theme-accent-primary: color-mix(in srgb, var(--accent-primary) 58%, #a9b8d4 42%);
+  --reading-theme-accent-secondary: color-mix(in srgb, var(--accent-secondary) 52%, #9ca9c8 48%);
+  --reading-theme-accent-tertiary: color-mix(in srgb, var(--accent-tertiary) 56%, #a7bdd5 44%);
+  --reading-theme-border-subtle: color-mix(in srgb, var(--border-subtle) 85%, #7f8aa0 15%);
+  --reading-theme-border-card: color-mix(in srgb, var(--border-card) 85%, #7f8aa0 15%);
+  --reading-theme-border-active: color-mix(in srgb, var(--border-active) 72%, #95a2bf 28%);
+  --reading-theme-accent-glow: color-mix(in srgb, var(--accent-glow) 45%, transparent);
 
   /* Shadows */
   --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
### Motivation
- Provide a low-chroma, reading-first color surface for long-form lesson reading to reduce visual noise and improve comfort. 
- Allow users to opt into the reading-specific palette independently from their global color `palette` setting so palette choice remains consistent elsewhere in the app. 
- Remove decorative gradients on lesson pages when the reading surface is active to keep focus on text content.

### Description
- Added a persisted `readingComfortTheme` preference to `useUserPreferencesStore` including type, setter, selector, default value, and migration support (store version bumped to `5`) in `src/stores/userPreferencesStore.ts`.
- Exposed a new toggle in the Preferences panel at `src/pages/ProgressDashboard.tsx` wired to the new `readingComfortTheme` setter so users can persist the choice independently from `palette`.
- Applied the reading surface conditionally in `src/pages/Lesson.tsx` so the `.lesson-reading-surface` class is added only when `readingMode` is enabled and `readingComfortTheme` is true.
- Introduced a reading-first variable set in `src/styles/variables.css` (softer background mixes, lower-chroma accents, gentler borders) and updated `.lesson-reading-surface` in `src/styles/base.css` to consume those variables and to remove decorative radial gradients and card gradients.
- Updated `src/stores/__tests__/userPreferencesStore.test.ts` to include the new preference in defaults, action updates, persistence and migration assertions.

### Testing
- Ran dependency install with `npm install` which completed successfully.
- Ran `npm run format:check` (initially failed due to formatting), then fixed formatting with `npm run format` and rechecked successfully.
- Ran typecheck/lint via `npm run lint` (which runs `tsc -b`) and it passed.
- Ran the test suite with `npm run test -- --reporter=verbose` and all tests passed (`459` tests passed in this run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc2715947c8330b9ad6e66bb0507b9)