### PR TITLE
feat(styles): add motion tokens and reading-mode motion safeguards

### DIFF
--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -40,7 +40,7 @@ export default function BackToTop() {
    * Smoothly scrolls the window back to the top of the page.
    */
   const scrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' })
+    window.scrollTo({ top: 0, behavior: prefersReducedMotion ? 'auto' : 'smooth' })
   }
 
   return (

--- a/src/components/ExerciseCard.tsx
+++ b/src/components/ExerciseCard.tsx
@@ -7,7 +7,7 @@
 
 import { memo } from 'react'
 import { Link } from 'react-router-dom'
-import { motion } from 'motion/react'
+import { motion, useReducedMotion } from 'motion/react'
 import { difficultyConfig, phaseIcons, type Exercise } from '../utils/contentLoader'
 
 interface ExerciseCardProps {
@@ -17,12 +17,15 @@ interface ExerciseCardProps {
 function ExerciseCard({ exercise }: ExerciseCardProps) {
   const diff = difficultyConfig[exercise.difficulty] || difficultyConfig.beginner!
   const icon = phaseIcons[exercise.phase - 1] || '📖'
+  const prefersReducedMotion = useReducedMotion()
 
   return (
     <motion.div
       className="exercise-card"
       layout
-      transition={{ type: 'spring', stiffness: 220, damping: 24 }}
+      transition={
+        prefersReducedMotion ? { duration: 0 } : { type: 'spring', stiffness: 220, damping: 24 }
+      }
     >
       <div className="exercise-card__header">
         <span className="exercise-card__phase">

--- a/src/components/__tests__/ExerciseCard.test.tsx
+++ b/src/components/__tests__/ExerciseCard.test.tsx
@@ -6,6 +6,7 @@ import ExerciseCard from '../ExerciseCard'
 
 // Mock motion to avoid animation issues
 vi.mock('motion/react', () => ({
+  useReducedMotion: () => false,
   motion: {
     div: ({ children, className, ...props }: any) => {
       const {

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -13,11 +13,11 @@
 }
 
 .animate-in {
-  animation: fadeInUp 0.5s ease-out forwards;
+  animation: fadeInUp var(--motion-duration-active-card-entrance) ease-out forwards;
 }
 
 .phase-card {
-  animation: fadeInUp 0.4s ease-out backwards;
+  animation: fadeInUp var(--motion-duration-active-standard) ease-out backwards;
 }
 
 .phase-card:nth-child(1) {
@@ -62,9 +62,15 @@
   *,
   *::before,
   *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+
+  .animate-in,
+  .phase-card {
+    animation: none !important;
+  }
+
+  .phase-card {
+    animation-delay: 0s !important;
   }
 }

--- a/src/styles/interactive.css
+++ b/src/styles/interactive.css
@@ -22,7 +22,7 @@
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: all var(--motion-duration-active-fast) var(--motion-easing-standard);
 }
 
 .python-runner__btn:hover:not(:disabled) {
@@ -155,7 +155,7 @@
   border: 1px solid var(--border-subtle);
   border-radius: 4px;
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: all var(--motion-duration-active-fast) var(--motion-easing-standard);
 }
 
 .code-playground__btn:hover {
@@ -329,7 +329,7 @@
   border: 1px solid rgba(167, 139, 250, 0.15);
   border-radius: 4px;
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: all var(--motion-duration-active-fast) var(--motion-easing-standard);
 }
 
 .exercise-widget__solution-btn:hover {
@@ -348,7 +348,7 @@
   border-radius: var(--radius-md);
   overflow: hidden;
   background: rgba(245, 158, 11, 0.02);
-  transition: border-color var(--transition-base);
+  transition: border-color var(--motion-duration-active-standard) var(--motion-easing-standard);
 }
 
 .mastery-check--revealed {
@@ -416,7 +416,7 @@
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: all var(--motion-duration-active-fast) var(--motion-easing-standard);
 }
 
 .mastery-check__check-btn:hover {
@@ -433,7 +433,7 @@
 
 .mastery-check__answer {
   border-top: 1px solid rgba(34, 197, 94, 0.1);
-  animation: fadeSlideIn 0.2s ease-out;
+  animation: fadeSlideIn var(--motion-duration-active-fast) ease-out;
 }
 
 .mastery-check__answer-label {
@@ -469,7 +469,7 @@
   border: 1px solid rgba(34, 197, 94, 0.2);
   border-radius: 4px;
   cursor: pointer;
-  transition: all var(--transition-fast);
+  transition: all var(--motion-duration-active-fast) var(--motion-easing-standard);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -481,7 +481,7 @@
 
 .code-block-inline-playground {
   border-top: 1px solid var(--border-subtle);
-  animation: fadeSlideIn 0.2s ease-out;
+  animation: fadeSlideIn var(--motion-duration-active-fast) ease-out;
 }
 
 .code-block-inline-playground .code-playground {
@@ -509,5 +509,21 @@
     flex-direction: column;
     gap: 0.3rem;
     align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mastery-check__answer,
+  .code-block-inline-playground {
+    animation: none !important;
+  }
+
+  .python-runner__btn,
+  .code-playground__btn,
+  .exercise-widget__solution-btn,
+  .mastery-check,
+  .mastery-check__check-btn,
+  .code-block-try-btn {
+    transition: none !important;
   }
 }

--- a/src/styles/ux-features.css
+++ b/src/styles/ux-features.css
@@ -20,7 +20,7 @@
     transparent 72%
   );
   transform: translateX(-130%);
-  animation: skeletonShimmer 1.4s infinite;
+  animation: skeletonShimmer var(--motion-duration-active-skeleton) infinite;
 }
 
 .skeleton-text {
@@ -67,6 +67,16 @@
   .skeleton::after {
     animation: none !important;
   }
+
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none !important;
+  }
+
+  .stats-bar-fill,
+  .stats-phase-card {
+    transition: none !important;
+  }
 }
 
 /* ---------- Glassmorphism Utility ---------- */
@@ -101,6 +111,13 @@
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-primary) 24%, transparent);
   }
 
+  .reading-mode a:hover,
+  .reading-mode button:hover,
+  .reading-mode .interactive:hover {
+    box-shadow: none;
+    transform: none;
+  }
+
   a:focus-visible,
   button:focus-visible,
   .interactive:focus-visible {
@@ -129,7 +146,7 @@
 .scroll-progress-bar {
   height: 100%;
   background: var(--accent-primary);
-  transition: width 50ms linear;
+  transition: width var(--motion-duration-active-fast) linear;
   border-radius: 0 2px 2px 0;
 }
 
@@ -161,7 +178,8 @@
   font-size: 0.65rem;
   color: var(--text-muted);
   text-decoration: none;
-  transition: var(--transition-fast);
+  transition-duration: var(--motion-duration-active-fast);
+  transition-timing-function: var(--motion-easing-standard);
   flex: 1;
 }
 
@@ -188,11 +206,11 @@
 
 /* ---------- Page Transitions (View Transitions API) ---------- */
 ::view-transition-old(root) {
-  animation: fade-out 200ms ease-out;
+  animation: fade-out var(--motion-duration-active-view-transition) ease-out;
 }
 
 ::view-transition-new(root) {
-  animation: fade-in 200ms ease-in;
+  animation: fade-in var(--motion-duration-active-view-transition) ease-in;
 }
 
 @keyframes fade-out {
@@ -319,7 +337,7 @@
 .stats-bar-fill {
   height: 100%;
   border-radius: var(--radius-sm);
-  transition: width 600ms ease-out;
+  transition: width var(--motion-duration-active-slow) ease-out;
 }
 
 .stats-bar-beginner {
@@ -359,7 +377,8 @@
   border-radius: var(--radius-md);
   padding: 1rem;
   text-decoration: none;
-  transition: var(--transition-fast);
+  transition-duration: var(--motion-duration-active-fast);
+  transition-timing-function: var(--motion-easing-standard);
 }
 
 .stats-phase-card:hover {
@@ -583,9 +602,9 @@
   opacity: 0;
   transition:
     border-color var(--transition-fast),
-    width var(--transition-fast),
-    height var(--transition-fast),
-    opacity var(--transition-fast);
+    width var(--motion-duration-active-fast),
+    height var(--motion-duration-active-fast),
+    opacity var(--motion-duration-active-fast);
 }
 
 .custom-cursor-active .custom-cursor-dot,

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -86,10 +86,27 @@
   --radius-lg: 16px;
   --radius-xl: 24px;
 
-  /* Transitions */
-  --transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);
-  --transition-base: 250ms cubic-bezier(0.4, 0, 0.2, 1);
-  --transition-slow: 400ms cubic-bezier(0.4, 0, 0.2, 1);
+  /* Motion */
+  --motion-duration-instant: 0ms;
+  --motion-duration-fast: 150ms;
+  --motion-duration-standard: 250ms;
+  --motion-duration-slow: 400ms;
+  --motion-duration-skeleton: 1400ms;
+  --motion-duration-view-transition: 200ms;
+  --motion-duration-card-entrance: 500ms;
+  --motion-easing-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --motion-easing-emphasized: cubic-bezier(0.22, 1, 0.36, 1);
+  --motion-duration-active-fast: var(--motion-duration-fast);
+  --motion-duration-active-standard: var(--motion-duration-standard);
+  --motion-duration-active-slow: var(--motion-duration-slow);
+  --motion-duration-active-skeleton: var(--motion-duration-skeleton);
+  --motion-duration-active-view-transition: var(--motion-duration-view-transition);
+  --motion-duration-active-card-entrance: var(--motion-duration-card-entrance);
+
+  /* Backward-compatible transition aliases */
+  --transition-fast: var(--motion-duration-fast) var(--motion-easing-standard);
+  --transition-base: var(--motion-duration-standard) var(--motion-easing-standard);
+  --transition-slow: var(--motion-duration-slow) var(--motion-easing-standard);
 
   /* Typography */
   --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -415,4 +432,15 @@
   --reading-accent-glow: rgba(73, 80, 87, 0.06);
   --text-on-accent: #ffffff;
   --text-on-brand: #0d1117;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --motion-duration-active-fast: var(--motion-duration-instant);
+    --motion-duration-active-standard: var(--motion-duration-instant);
+    --motion-duration-active-slow: var(--motion-duration-instant);
+    --motion-duration-active-skeleton: var(--motion-duration-instant);
+    --motion-duration-active-view-transition: var(--motion-duration-instant);
+    --motion-duration-active-card-entrance: var(--motion-duration-instant);
+  }
 }


### PR DESCRIPTION
### Motivation

- Centralize motion timings so animations/transitions can be tuned globally and respect `prefers-reduced-motion` without chasing scattered values. 
- Reduce distracting hover glow and motion when users are in a focused reading mode by scoping hover effects.
- Ensure interactive React components and view transitions honor user reduced-motion preferences (not just skeletons). 

### Description

- Added motion design tokens and backward-compatible transition aliases in `src/styles/variables.css` (`--motion-duration-*`, `--motion-easing-*`, and active aliases that collapse under `prefers-reduced-motion`).
- Replaced hard-coded durations/usages with motion tokens across UX styles: `src/styles/ux-features.css`, `src/styles/animations.css`, and `src/styles/interactive.css`, and disabled view-transition/stats transitions for reduced-motion users.
- Scoped hover glow suppression for reading mode with `.reading-mode a:hover`, `.reading-mode button:hover`, and `.reading-mode .interactive:hover` while keeping `:focus-visible` outlines intact (Lesson page already toggles `reading-mode`).
- Updated React components to respect reduced-motion: `ExerciseCard` now uses `useReducedMotion` to disable layout spring when preferred, and `BackToTop` uses reduced-motion-aware scrolling; updated the related unit test mock to provide `useReducedMotion`.

### Testing

- Ran `npm install` to ensure deps were present and `prettier`/husky hooks run (succeeded).
- Ran `npm run format:check` and `npm run format` to normalize styles; format checks passed after formatting.
- Ran type checks (`npm run lint` → `tsc -b`) and unit tests (`npm run test` → `vitest run`), and all automated tests passed locally (`459` tests, all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc488e520083309c36a1b41154aac1)