### PR TITLE
🎨 Picasso: [UX improvement] Enhance accessibility and polish empty states

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -22,3 +22,12 @@
 * **Observation**: Found many places (CopyButton, Sidebar streak, ProgressDashboard stats, Curriculum stats) where emojis were placed next to text strings or inside descriptive wrappers but not explicitly hidden from screen readers.
 * **Fix**: Wrapped these emojis in `<span aria-hidden="true">` to prevent screen readers from redundantly calling out "Chart showing upward trend" when the label says "Completed".
 * **Rule**: When an emoji is purely decorative and its meaning is already conveyed via text or an `aria-label`, always hide it using `aria-hidden="true"`.
+
+### Error Boundary Styling
+Learned that using domain-specific CSS classes (like `review-answer-btn`) inside global components like `ErrorBoundary` creates technical debt and unnecessary coupling. It's better to use explicit generalized button classes (`action-btn`) and avoid hard-coded inline styles for layout spacing.
+
+### Accessible Tabs
+When implementing custom Tab components, `aria-controls` on the tab triggers must point to the `id` of the `role="tabpanel"` container, and the tabpanel must be labeled by the tab trigger's `id` using `aria-labelledby`.
+
+### Accessible Spaced Repetition Buttons
+Added `aria-keyshortcuts` to the rating buttons in spaced repetition workflows to programmatically inform screen readers of available keyboard bindings (e.g., `aria-keyshortcuts="1"`).

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -47,11 +47,11 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
         <main className="main-content" role="alert" aria-live="assertive">
           <h1>Something went wrong</h1>
           <p>We hit an unexpected issue while loading this page.</p>
-          <div>
-            <button type="button" onClick={this.handleRetry}>
+          <div className="error-actions">
+            <button type="button" className="action-btn" onClick={this.handleRetry}>
               Try again
             </button>
-            <button type="button" onClick={this.handleReload}>
+            <button type="button" className="action-btn" onClick={this.handleReload}>
               Reload page
             </button>
           </div>

--- a/src/pages/CaseStudies.tsx
+++ b/src/pages/CaseStudies.tsx
@@ -88,9 +88,11 @@ export default function CaseStudies() {
       {/* Tabs */}
       <div className="cs-tabs" role="tablist" aria-label="Content type">
         <button
+          id="tab-case-studies"
           type="button"
           role="tab"
           aria-selected={activeTab === 'case-studies'}
+          aria-controls="panel-case-studies"
           className={`cs-tab ${activeTab === 'case-studies' ? 'cs-tab--active' : ''}`}
           onClick={() => {
             setActiveTab('case-studies')
@@ -100,9 +102,11 @@ export default function CaseStudies() {
           🏢 Case Studies ({caseStudies.length})
         </button>
         <button
+          id="tab-projects"
           type="button"
           role="tab"
           aria-selected={activeTab === 'projects'}
+          aria-controls="panel-projects"
           className={`cs-tab ${activeTab === 'projects' ? 'cs-tab--active' : ''}`}
           onClick={() => {
             setActiveTab('projects')
@@ -136,7 +140,13 @@ export default function CaseStudies() {
       </p>
 
       {/* Cards */}
-      <motion.div className="cs-grid" layout>
+      <motion.div
+        className="cs-grid"
+        layout
+        role="tabpanel"
+        id={activeTab === 'case-studies' ? 'panel-case-studies' : 'panel-projects'}
+        aria-labelledby={activeTab === 'case-studies' ? 'tab-case-studies' : 'tab-projects'}
+      >
         {filtered.map((item) => {
           const normDiff = normalizeDifficulty(item.difficulty)
           const diff = difficultyConfig[normDiff] ?? {

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -154,6 +154,7 @@ export default function Review() {
                     className={`review-action-btn review-${rating}`}
                     onClick={() => handleRate(rating)}
                     title={`Shortcut: ${index + 1}`}
+                    aria-keyshortcuts={`${index + 1}`}
                   >
                     {getRatingLabel(rating)}
                   </button>

--- a/src/styles/ux-features.css
+++ b/src/styles/ux-features.css
@@ -652,3 +652,27 @@
     animation: none !important;
   }
 }
+
+/* --- Error Boundary --- */
+.error-actions {
+  display: flex;
+  gap: var(--spacing-md, 1rem);
+  margin-top: var(--spacing-xl, 1.5rem);
+}
+
+.action-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+  padding: 0.6rem 1.2rem;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.action-btn:hover,
+.action-btn:focus-visible {
+  background: rgba(255, 255, 255, 0.1);
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
This PR implements UX and accessibility improvements identified by the Picasso agent.

### Details:
1. **Case Studies page:** Added accessible tab markup. The tab triggers now correctly point to their corresponding tab panel containers using `aria-controls`, and the panel is explicitly designated via `role="tabpanel"` and `aria-labelledby`.
2. **Review page:** Added `aria-keyshortcuts` attributes to the 1-4 rating buttons, giving assistive technology users visibility into keyboard shortcuts for the spaced repetition actions.
3. **Error Boundary UI:** Refined the raw, unstyled fallback buttons. Abstracted new `action-btn` and `error-actions` generic styles to `ux-features.css` to avoid hardcoded styles and unmaintainable domain coupling (e.g., re-using `review-answer-btn` improperly).

Tested with Prettier (`format`), ESLint (`lint`), and Vitest (459/459 tests passed). Playwright frontend verification also confirms correct rendering.

---
*PR created automatically by Jules for task [7483878431610571339](https://jules.google.com/task/7483878431610571339) started by @saint2706*