### PR TITLE
🔍 Hunter: Fixed 5 errors - Removed leftover `as any` casts in test files

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -52,3 +52,8 @@
 - **Fixed:** Removed `as any` type casts from mock module and return array in `src/components/__tests__/SidebarPhaseGroup.test.tsx` by properly typing mock and adding missing properties.
 - **Fixed:** Replaced `as any` cast on mocked `IntersectionObserver` with `as unknown as typeof IntersectionObserver` in `src/components/__tests__/TableOfContents.test.tsx`.
 - **Verified:** Build, lint, and tests pass.
+
+## Session 9
+- **Fixed:** Replaced `as any` cast on mock imports and `TouchEvent` in `src/components/__tests__/SearchPalette.test.tsx`, `src/components/__tests__/Sidebar.test.tsx`, `src/components/__tests__/AnimatedCounter.test.tsx`, and `src/hooks/__tests__/useSwipe.test.tsx`.
+- **Fixed:** Used `Object.defineProperty` on the mocked `window` objects in `src/components/__tests__/BackToTop.test.tsx` instead of `as any`.
+- **Verified:** Build, lint, and tests pass.

--- a/src/components/__tests__/AnimatedCounter.test.tsx
+++ b/src/components/__tests__/AnimatedCounter.test.tsx
@@ -60,7 +60,7 @@ describe('AnimatedCounter', () => {
 
     vi.mocked(motionReact.animate).mockImplementation((_from, _to, options: any) => {
       updateCallback = options.onUpdate
-      return { stop: vi.fn() } as any
+      return { stop: vi.fn() } as unknown as ReturnType<typeof motionReact.animate>
     })
 
     act(() => {

--- a/src/components/__tests__/BackToTop.test.tsx
+++ b/src/components/__tests__/BackToTop.test.tsx
@@ -43,7 +43,7 @@ describe('BackToTop', () => {
 
     // Simulate scroll and wait for requestAnimationFrame to execute
     await act(async () => {
-      ;(window as any).scrollY = 500
+      Object.defineProperty(window, 'scrollY', { value: 500, configurable: true })
       window.dispatchEvent(new Event('scroll'))
       await new Promise((resolve) => requestAnimationFrame(resolve))
     })
@@ -61,7 +61,7 @@ describe('BackToTop', () => {
 
     // Scroll down to make it visible
     await act(async () => {
-      ;(window as any).scrollY = 500
+      Object.defineProperty(window, 'scrollY', { value: 500, configurable: true })
       window.dispatchEvent(new Event('scroll'))
       await new Promise((resolve) => requestAnimationFrame(resolve))
     })

--- a/src/components/__tests__/SearchPalette.test.tsx
+++ b/src/components/__tests__/SearchPalette.test.tsx
@@ -18,7 +18,9 @@ vi.mock('../../utils/searchIndex', async () => {
 })
 
 vi.mock('../../utils/contentLoader', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/contentLoader')>('../../utils/contentLoader')
+  const actual = await vi.importActual<typeof import('../../utils/contentLoader')>(
+    '../../utils/contentLoader',
+  )
   return {
     ...actual,
     difficultyConfig: {

--- a/src/components/__tests__/SearchPalette.test.tsx
+++ b/src/components/__tests__/SearchPalette.test.tsx
@@ -9,7 +9,7 @@ import * as searchIndex from '../../utils/searchIndex'
 vi.mock('../../utils/searchIndex', async () => {
   const actual = await vi.importActual('../../utils/searchIndex')
   return {
-    ...(actual as any),
+    ...(actual as typeof searchIndex),
     getSearchSnippet: vi.fn((content) => 'Snippet of ' + content),
     getSearchIndexStatus: vi.fn(() => ({ isReady: true, processedCount: 10, totalCount: 10 })),
     search: vi.fn(),
@@ -18,9 +18,9 @@ vi.mock('../../utils/searchIndex', async () => {
 })
 
 vi.mock('../../utils/contentLoader', async () => {
-  const actual = await vi.importActual('../../utils/contentLoader')
+  const actual = await vi.importActual<typeof import('../../utils/contentLoader')>('../../utils/contentLoader')
   return {
-    ...(actual as any),
+    ...actual,
     difficultyConfig: {
       beginner: { label: 'Beginner', color: '#000', bg: '#fff' },
     },
@@ -35,9 +35,9 @@ vi.mock('../../hooks/useDebounce', () => ({
 
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom')
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
   return {
-    ...(actual as any),
+    ...actual,
     useNavigate: () => mockNavigate,
   }
 })
@@ -95,7 +95,7 @@ describe('SearchPalette', () => {
           tags: ['test'],
         },
       },
-    ] as any)
+    ] as unknown as ReturnType<typeof searchIndex.search>)
 
     act(() => {
       root?.render(

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -8,7 +8,9 @@ import * as reviewTracker from '../../utils/reviewTracker'
 
 // Mock dependencies
 vi.mock('../../utils/contentLoader', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/contentLoader')>('../../utils/contentLoader')
+  const actual = await vi.importActual<typeof import('../../utils/contentLoader')>(
+    '../../utils/contentLoader',
+  )
   return {
     ...actual,
     getAllPhases: vi.fn(),

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -8,9 +8,9 @@ import * as reviewTracker from '../../utils/reviewTracker'
 
 // Mock dependencies
 vi.mock('../../utils/contentLoader', async () => {
-  const actual = await vi.importActual('../../utils/contentLoader')
+  const actual = await vi.importActual<typeof import('../../utils/contentLoader')>('../../utils/contentLoader')
   return {
-    ...(actual as any),
+    ...actual,
     getAllPhases: vi.fn(),
     getLessonsByPhase: vi.fn(),
     phaseIcons: ['A', 'B'],
@@ -39,11 +39,11 @@ describe('Sidebar', () => {
 
     vi.mocked(contentLoader.getAllPhases).mockReturnValue([
       { phase: 1, title: 'Phase 1', days: ['01', '02'] },
-    ] as any)
+    ] as unknown as ReturnType<typeof contentLoader.getAllPhases>)
     vi.mocked(contentLoader.getLessonsByPhase).mockReturnValue([
       { day: '01', title: 'Lesson 1', phase: 1 },
       { day: '02', title: 'Lesson 2', phase: 1 },
-    ] as any)
+    ] as unknown as ReturnType<typeof contentLoader.getLessonsByPhase>)
     vi.mocked(reviewTracker.getReviewDueCountByPhase).mockReturnValue({})
   })
 
@@ -112,7 +112,7 @@ describe('Sidebar', () => {
 
     vi.mocked(reviewTracker.getReviewDueCountByPhase).mockReturnValue({
       1: 5,
-    } as any)
+    } as unknown as Record<number, number>)
 
     act(() => {
       root?.render(

--- a/src/hooks/__tests__/useSwipe.test.tsx
+++ b/src/hooks/__tests__/useSwipe.test.tsx
@@ -56,7 +56,7 @@ describe('useSwipe', () => {
 
     const eventOptions = type === 'touchstart' ? { touches: [touch] } : { changedTouches: [touch] }
 
-    const event = new TouchEvent(type, eventOptions as any)
+    const event = new TouchEvent(type, eventOptions as unknown as TouchEventInit)
     element.dispatchEvent(event)
   }
 


### PR DESCRIPTION
🔍 Hunter: Fixed 5 errors - Removed leftover `as any` casts in test files

Replaced all instances of `as any` casts in mock imports and window variables with strongly typed options or `Object.defineProperty`. Updated `.jules/hunter-progress.md` with progress tracking for the new session. Build and test passes.

---
*PR created automatically by Jules for task [8030792521401064876](https://jules.google.com/task/8030792521401064876) started by @saint2706*