### PR TITLE
🔍 Hunter: Fixed 4 errors - Removed `as any` type casting in tests

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -57,3 +57,10 @@
 - **Fixed:** Replaced `as any` cast on mock imports and `TouchEvent` in `src/components/__tests__/SearchPalette.test.tsx`, `src/components/__tests__/Sidebar.test.tsx`, `src/components/__tests__/AnimatedCounter.test.tsx`, and `src/hooks/__tests__/useSwipe.test.tsx`.
 - **Fixed:** Used `Object.defineProperty` on the mocked `window` objects in `src/components/__tests__/BackToTop.test.tsx` instead of `as any`.
 - **Verified:** Build, lint, and tests pass.
+
+## Session 10
+- **Fixed:** Removed leftover `as any` type casting in `src/utils/__tests__/searchIndex.perf.test.ts` by using `as unknown as typeof window.requestIdleCallback`.
+- **Fixed:** Removed leftover `as any` type casting in `src/utils/__tests__/confetti.test.ts` by using `as unknown as { window?: Window }`.
+- **Fixed:** Removed leftover `as any` type casting in `src/utils/__tests__/seoSchemas.test.ts` by using `as Record<string, unknown>[]` and `as Record<string, unknown>`.
+- **Fixed:** Removed leftover `as any` type casting in `src/utils/__tests__/searchIndex.test.ts` by using `as unknown as typeof window.requestIdleCallback`.
+- **Verified:** Build, lint, and tests pass.

--- a/src/utils/__tests__/confetti.test.ts
+++ b/src/utils/__tests__/confetti.test.ts
@@ -56,7 +56,7 @@ describe('confetti', () => {
     })
 
     it('should not throw and not call if window is undefined', () => {
-      delete (global as any).window
+      delete (global as unknown as { window?: Window }).window
 
       confettiModule.triggerSparkle()
       expect(confetti).not.toHaveBeenCalled()
@@ -123,7 +123,7 @@ describe('confetti', () => {
     })
 
     it('should not start interval if window is undefined', () => {
-      delete (global as any).window
+      delete (global as unknown as { window?: Window }).window
 
       confettiModule.triggerCurriculumFireworks()
       expect(confetti).not.toHaveBeenCalled()

--- a/src/utils/__tests__/searchIndex.perf.test.ts
+++ b/src/utils/__tests__/searchIndex.perf.test.ts
@@ -22,7 +22,7 @@ describe('searchIndex first-search performance', () => {
       window.requestIdleCallback = vi.fn((cb) => {
         const id = setTimeout(cb, 1)
         return Number(id)
-      }) as any
+      }) as unknown as typeof window.requestIdleCallback
     }
   })
 

--- a/src/utils/__tests__/searchIndex.test.ts
+++ b/src/utils/__tests__/searchIndex.test.ts
@@ -37,7 +37,7 @@ beforeEach(async () => {
     window.requestIdleCallback = vi.fn((cb) => {
       const id = setTimeout(cb, 1)
       return Number(id)
-    }) as any
+    }) as unknown as typeof window.requestIdleCallback
   }
 
   const mod = await import('../searchIndex')

--- a/src/utils/__tests__/seoSchemas.test.ts
+++ b/src/utils/__tests__/seoSchemas.test.ts
@@ -78,7 +78,7 @@ describe('seoSchemas', () => {
       expect(schema.url).toBe(`${SITE_URL}/#/curriculum`)
       expect(schema.numberOfItems).toBe(2)
 
-      const elements = schema.itemListElement as any[]
+      const elements = schema.itemListElement as Record<string, unknown>[]
       expect(elements).toHaveLength(2)
 
       expect(elements[0]).toMatchObject({
@@ -117,7 +117,7 @@ describe('seoSchemas', () => {
       expect(schema.description).toBe('My Collection')
       expect(schema.url).toBe(`${SITE_URL}/#/collection`)
 
-      const hasPart = schema.hasPart as any[]
+      const hasPart = schema.hasPart as Record<string, unknown>[]
       expect(hasPart).toHaveLength(2)
 
       expect(hasPart[0]).toMatchObject({
@@ -148,14 +148,14 @@ describe('seoSchemas', () => {
       expect(schema.url).toBe(`${SITE_URL}/`)
       expect(schema.numberOfCredits).toBe(140)
 
-      const provider = schema.provider as any
+      const provider = schema.provider as Record<string, unknown>
       expect(provider['@type']).toBe('Organization')
       expect(provider.name).toBe('Coding for MBA')
 
       expect(schema.teaches).toBeInstanceOf(Array)
       expect((schema.teaches as string[]).includes('Python Programming')).toBe(true)
 
-      const instance = schema.hasCourseInstance as any
+      const instance = schema.hasCourseInstance as Record<string, unknown>
       expect(instance['@type']).toBe('CourseInstance')
       expect(instance.courseMode).toBe('Online')
     })
@@ -177,11 +177,11 @@ describe('seoSchemas', () => {
       expect(schema.educationalLevel).toBe('Professional')
       expect(schema.learningResourceType).toBe('Lesson')
 
-      const isPartOf = schema.isPartOf as any
+      const isPartOf = schema.isPartOf as Record<string, unknown>
       expect(isPartOf['@type']).toBe('Course')
       expect(isPartOf.name).toBe('Coding for MBA — 140-Day Technical Curriculum')
 
-      const about = schema.about as any
+      const about = schema.about as Record<string, unknown>
       expect(about['@type']).toBe('Thing')
       expect(about.name).toBe('Phase 2 - Day 5')
     })


### PR DESCRIPTION
As an autonomous bug hunter, I addressed several type safety issues in the test suite by removing the use of `as any` casting. 

**Changes Made:**
1.  **`src/utils/__tests__/searchIndex.perf.test.ts`**: Replaced `as any` with `as unknown as typeof window.requestIdleCallback` when mocking `window.requestIdleCallback`.
2.  **`src/utils/__tests__/confetti.test.ts`**: Replaced `delete (global as any).window` with `delete (global as unknown as { window?: Window }).window` to ensure type-safe global object property deletion.
3.  **`src/utils/__tests__/seoSchemas.test.ts`**: Replaced `as any[]` and `as any` with `as Record<string, unknown>[]` and `as Record<string, unknown>` for evaluating schema properties without compilation errors.
4.  **`src/utils/__tests__/searchIndex.test.ts`**: Replaced `as any` with `as unknown as typeof window.requestIdleCallback` when mocking `window.requestIdleCallback`.
5.  **`.jules/hunter-progress.md`**: Logged the fixed issues under "Session 10".

**Verification:**
-   `npm run lint` completes without errors.
-   `npm run build` succeeds.
-   `npm run test` passes successfully for all modified files.

---
*PR created automatically by Jules for task [6512590331145087295](https://jules.google.com/task/6512590331145087295) started by @saint2706*