### PR TITLE
🎨 Picasso: [UX improvement] Add accessibility attributes to Sidebar close button

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -22,3 +22,10 @@
 * **Observation**: Found many places (CopyButton, Sidebar streak, ProgressDashboard stats, Curriculum stats) where emojis were placed next to text strings or inside descriptive wrappers but not explicitly hidden from screen readers.
 * **Fix**: Wrapped these emojis in `<span aria-hidden="true">` to prevent screen readers from redundantly calling out "Chart showing upward trend" when the label says "Completed".
 * **Rule**: When an emoji is purely decorative and its meaning is already conveyed via text or an `aria-label`, always hide it using `aria-hidden="true"`.
+
+### Sidebar Close Button Accessibility
+**Date:** $(date +%Y-%m-%d)
+**Goal:** Enhance keyboard and screen reader accessibility for the sidebar close button.
+**Changes Made:**
+- Added `aria-expanded={isOpen}` and `aria-controls="app-sidebar"` to the close button in `src/components/Sidebar.tsx`.
+**Learning:** To maintain strict screen reader accessibility for collapsible UI regions (like sidebars or menus), always apply `aria-expanded={isOpen}` and `aria-controls="target-id"` to their respective toggle or close buttons.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -125,6 +125,8 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
             className="sidebar-close"
             onClick={onClose}
             aria-label="Close sidebar"
+            aria-expanded={isOpen}
+            aria-controls="app-sidebar"
           >
             <svg
               width="20"


### PR DESCRIPTION
🎨 **Picasso: [UX improvement]**

**What was changed:**
- Added `aria-expanded={isOpen}` and `aria-controls="app-sidebar"` to the close button in `src/components/Sidebar.tsx`.

**Why it was changed:**
- To improve accessibility and provide necessary semantic context to assistive technologies (screen readers) about the relationship between the close button and the sidebar container, and the current expanded state of the sidebar.

**Verification:**
- Ran `npm run test` to ensure existing tests pass without regressions.
- Ran `npm run lint` and `npm run format:check` to ensure code quality rules are upheld.
- Passed code review and documented the pattern in `.jules/picasso.md`.

---
*PR created automatically by Jules for task [3523564327353898191](https://jules.google.com/task/3523564327353898191) started by @saint2706*