### PR TITLE
📚 Docs: Fix markdown link checker false positives for keras and google ML crash course

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -31,3 +31,7 @@
   - Added full JSDoc comments (`@param`, `@returns`) to `src/utils/seoSchemas.ts` for `buildCanonicalUrl`, `buildWebSiteSchema`, and `buildCourseSchema`.
   - Added full JSDoc comments (`@param`, `@returns`) to `src/utils/contentLoader.ts` for `getAdjacentLessons`, `getAllExercises`, `getNotebook`, and `getReadingTime`.
   - Verified that all exported functions within `src/utils/` are fully documented via automated script check.
+
+- **[2026-03-20] Markdown Links & Link Checker configuration**
+  - Updated `mlc_config.json` configuration file to ignore `keras.io` and `developers.google.com/machine-learning/crash-course` which return false positives (403 or 0 codes) from anti-bot mechanisms.
+  - Successfully passed `markdown-link-check` script.

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -23,6 +23,8 @@
     {"pattern": "^https://docs\\.scipy\\.org/"},
     {"pattern": "^https://pgtune\\.leopard\\.in\\.ua/"},
     {"pattern": "^https://python\\.langchain\\.com/"},
-    {"pattern": "^https://docs\\.trychroma\\.com/"}
+    {"pattern": "^https://docs\\.trychroma\\.com/"},
+    {"pattern": "^https://keras\\.io/"},
+    {"pattern": "^https://developers\\.google\\.com/machine-learning/crash-course"}
   ]
 }


### PR DESCRIPTION
This PR updates the `mlc_config.json` configuration file used by the automated `markdown-link-check` script.

The URLs `https://keras.io/api/layers/` and `https://developers.google.com/machine-learning/crash-course` were consistently failing with a Status 0 error during link checks because these domains employ anti-bot/DDoS protections (like Cloudflare) that block programmatic requests, even though the links are valid.

These domains have been added to the `ignorePatterns` array to prevent false-positive CI failures.

Also updated `.jules/docs-progress.md` to track this progress.

---
*PR created automatically by Jules for task [6205217872141395865](https://jules.google.com/task/6205217872141395865) started by @saint2706*