### PR TITLE
🔍 Hunter: Fixed 6 errors - replaced leftover `as any` casting in tests

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -64,3 +64,12 @@
 - **Fixed:** Removed leftover `as any` type casting in `src/utils/__tests__/seoSchemas.test.ts` by using `as Record<string, unknown>[]` and `as Record<string, unknown>`.
 - **Fixed:** Removed leftover `as any` type casting in `src/utils/__tests__/searchIndex.test.ts` by using `as unknown as typeof window.requestIdleCallback`.
 - **Verified:** Build, lint, and tests pass.
+
+## Session 11
+- **Fixed:** Removed `as any` type casting in `src/pages/__tests__/SearchResults.test.tsx` by providing all necessary fields for the mocked `searchIndex.search` results.
+- **Fixed:** Removed `as any` type casting in `src/pages/__tests__/Curriculum.test.tsx` by using `as unknown as contentLoader.Lesson`.
+- **Fixed:** Removed `as any` type casting in `src/pages/__tests__/NotebookViewer.test.tsx` by using `as unknown as contentLoader.Phase` and `as unknown as contentLoader.Notebook`.
+- **Fixed:** Removed `as any` type casting in `src/pages/__tests__/Exercises.test.tsx` by using `as unknown as contentLoader.Exercise[]` and `as unknown as contentLoader.Notebook`.
+- **Fixed:** Removed `as any` type casting in `src/pages/__tests__/CaseStudies.test.tsx` by using `as unknown as contentLoader.CaseStudy[]` and `as unknown as contentLoader.Project[]`.
+- **Fixed:** Removed `as any` type casting in `src/pages/__tests__/ProgressDashboard.test.tsx` by using proper `as unknown as Type` casts for `Phase[]`, `Lesson[]`, and `typeof useUserPreferencesStore`.
+- **Verified:** Build, lint, and tests pass.

--- a/src/pages/__tests__/CaseStudies.test.tsx
+++ b/src/pages/__tests__/CaseStudies.test.tsx
@@ -50,7 +50,7 @@ describe('CaseStudies', () => {
         estimatedTime: '2 hours',
         content: 'Content 2',
       },
-    ] as any)
+    ] as unknown as contentLoader.CaseStudy[])
 
     vi.mocked(contentLoader.getAllProjects).mockReturnValue([
       {
@@ -61,7 +61,7 @@ describe('CaseStudies', () => {
         estimatedTime: '3 hours',
         content: 'Content 3',
       },
-    ] as any)
+    ] as unknown as contentLoader.Project[])
   })
 
   afterEach(() => {

--- a/src/pages/__tests__/Curriculum.test.tsx
+++ b/src/pages/__tests__/Curriculum.test.tsx
@@ -66,8 +66,8 @@ describe('Curriculum', () => {
 
   it('renders the curriculum page correctly with phases and lessons', () => {
     vi.mocked(contentLoader.getAllLessons).mockReturnValue([
-      { day: '1', title: 'Intro', phase: 1, content: '', path: '' } as any,
-      { day: '2', title: 'Advanced', phase: 2, content: '', path: '' } as any,
+      { day: '1', title: 'Intro', phase: 1, content: '', path: '' } as unknown as contentLoader.Lesson,
+      { day: '2', title: 'Advanced', phase: 2, content: '', path: '' } as unknown as contentLoader.Lesson,
     ])
 
     vi.mocked(contentLoader.getAllPhases).mockReturnValue([

--- a/src/pages/__tests__/Curriculum.test.tsx
+++ b/src/pages/__tests__/Curriculum.test.tsx
@@ -66,8 +66,20 @@ describe('Curriculum', () => {
 
   it('renders the curriculum page correctly with phases and lessons', () => {
     vi.mocked(contentLoader.getAllLessons).mockReturnValue([
-      { day: '1', title: 'Intro', phase: 1, content: '', path: '' } as unknown as contentLoader.Lesson,
-      { day: '2', title: 'Advanced', phase: 2, content: '', path: '' } as unknown as contentLoader.Lesson,
+      {
+        day: '1',
+        title: 'Intro',
+        phase: 1,
+        content: '',
+        path: '',
+      } as unknown as contentLoader.Lesson,
+      {
+        day: '2',
+        title: 'Advanced',
+        phase: 2,
+        content: '',
+        path: '',
+      } as unknown as contentLoader.Lesson,
     ])
 
     vi.mocked(contentLoader.getAllPhases).mockReturnValue([

--- a/src/pages/__tests__/Exercises.test.tsx
+++ b/src/pages/__tests__/Exercises.test.tsx
@@ -63,9 +63,9 @@ describe('Exercises', () => {
         tags: ['data', 'pandas'],
         starterCode: '',
       },
-    ] as any)
+    ] as unknown as contentLoader.Exercise[])
 
-    vi.mocked(contentLoader.getAllNotebooks).mockReturnValue([{ phase: 1, cells: [] } as any])
+    vi.mocked(contentLoader.getAllNotebooks).mockReturnValue([{ phase: 1, cells: [] } as unknown as contentLoader.Notebook])
 
     vi.mocked(useQuizStore).mockImplementation((selector: any) =>
       selector({ getLowScoringTopics: () => ['pandas'] }),

--- a/src/pages/__tests__/Exercises.test.tsx
+++ b/src/pages/__tests__/Exercises.test.tsx
@@ -65,7 +65,9 @@ describe('Exercises', () => {
       },
     ] as unknown as contentLoader.Exercise[])
 
-    vi.mocked(contentLoader.getAllNotebooks).mockReturnValue([{ phase: 1, cells: [] } as unknown as contentLoader.Notebook])
+    vi.mocked(contentLoader.getAllNotebooks).mockReturnValue([
+      { phase: 1, cells: [] } as unknown as contentLoader.Notebook,
+    ])
 
     vi.mocked(useQuizStore).mockImplementation((selector: any) =>
       selector({ getLowScoringTopics: () => ['pandas'] }),

--- a/src/pages/__tests__/NotebookViewer.test.tsx
+++ b/src/pages/__tests__/NotebookViewer.test.tsx
@@ -35,7 +35,7 @@ describe('NotebookViewer', () => {
   beforeEach(() => {
     vi.mocked(contentLoader.getPhase).mockReturnValue({
       title: 'Phase 1 Title',
-    } as any)
+    } as unknown as contentLoader.Phase)
   })
 
   afterEach(() => {
@@ -58,7 +58,7 @@ describe('NotebookViewer', () => {
   })
 
   it('renders empty state when notebook has no cells', () => {
-    vi.mocked(contentLoader.getNotebook).mockReturnValue({ cells: [] } as any)
+    vi.mocked(contentLoader.getNotebook).mockReturnValue({ cells: [] } as unknown as contentLoader.Notebook)
 
     render(
       <MemoryRouter initialEntries={['/solutions/1']}>
@@ -91,7 +91,7 @@ describe('NotebookViewer', () => {
           outputs: [{ output_type: 'error', ename: 'NameError', evalue: 'name is not defined' }],
         },
       ],
-    } as any)
+    } as unknown as contentLoader.Notebook)
 
     render(
       <MemoryRouter initialEntries={['/solutions/1']}>
@@ -126,7 +126,7 @@ describe('NotebookViewer', () => {
           ],
         },
       ],
-    } as any)
+    } as unknown as contentLoader.Notebook)
 
     render(
       <MemoryRouter initialEntries={['/solutions/1']}>
@@ -157,7 +157,7 @@ describe('NotebookViewer', () => {
           ],
         },
       ],
-    } as any)
+    } as unknown as contentLoader.Notebook)
 
     render(
       <MemoryRouter initialEntries={['/solutions/1']}>

--- a/src/pages/__tests__/NotebookViewer.test.tsx
+++ b/src/pages/__tests__/NotebookViewer.test.tsx
@@ -58,7 +58,9 @@ describe('NotebookViewer', () => {
   })
 
   it('renders empty state when notebook has no cells', () => {
-    vi.mocked(contentLoader.getNotebook).mockReturnValue({ cells: [] } as unknown as contentLoader.Notebook)
+    vi.mocked(contentLoader.getNotebook).mockReturnValue({
+      cells: [],
+    } as unknown as contentLoader.Notebook)
 
     render(
       <MemoryRouter initialEntries={['/solutions/1']}>

--- a/src/pages/__tests__/ProgressDashboard.test.tsx
+++ b/src/pages/__tests__/ProgressDashboard.test.tsx
@@ -83,7 +83,10 @@ describe('ProgressDashboard', () => {
     vi.mocked(contentLoader.getLessonsByPhase).mockReturnValue([
       { day: '1', title: 'Lesson 1' },
     ] as unknown as contentLoader.Lesson[])
-    vi.mocked(contentLoader.getLesson).mockReturnValue({ day: '1', title: 'Lesson 1' } as unknown as contentLoader.Lesson)
+    vi.mocked(contentLoader.getLesson).mockReturnValue({
+      day: '1',
+      title: 'Lesson 1',
+    } as unknown as contentLoader.Lesson)
 
     // Progress store mock
     vi.mocked(useProgressStore).mockImplementation((selector: any) => {

--- a/src/pages/__tests__/ProgressDashboard.test.tsx
+++ b/src/pages/__tests__/ProgressDashboard.test.tsx
@@ -75,15 +75,15 @@ describe('ProgressDashboard', () => {
   beforeEach(() => {
     vi.mocked(contentLoader.getAllPhases).mockReturnValue([
       { phase: 1, title: 'Phase 1', difficulty: 'beginner' },
-    ] as any)
+    ] as unknown as contentLoader.Phase[])
     vi.mocked(contentLoader.getAllLessons).mockReturnValue([
       { day: '1', title: 'Lesson 1' },
       { day: '2', title: 'Lesson 2' },
-    ] as any)
+    ] as unknown as contentLoader.Lesson[])
     vi.mocked(contentLoader.getLessonsByPhase).mockReturnValue([
       { day: '1', title: 'Lesson 1' },
-    ] as any)
-    vi.mocked(contentLoader.getLesson).mockReturnValue({ day: '1', title: 'Lesson 1' } as any)
+    ] as unknown as contentLoader.Lesson[])
+    vi.mocked(contentLoader.getLesson).mockReturnValue({ day: '1', title: 'Lesson 1' } as unknown as contentLoader.Lesson)
 
     // Progress store mock
     vi.mocked(useProgressStore).mockImplementation((selector: any) => {
@@ -148,7 +148,7 @@ describe('ProgressDashboard', () => {
       setReadingMode: vi.fn(),
       setReadingComfortTheme: vi.fn(),
       setCustomCursorEnabled: vi.fn(),
-    } as any)
+    } as unknown as typeof useUserPreferencesStore)
   })
 
   afterEach(() => {

--- a/src/pages/__tests__/SearchResults.test.tsx
+++ b/src/pages/__tests__/SearchResults.test.tsx
@@ -83,14 +83,23 @@ describe('SearchResults', () => {
           title: 'Python Basics',
           difficulty: 'beginner',
           phase: 1,
+          content: 'Raw markdown content',
+          path: '/phase-01/day-01',
           plainContent: 'Content about python',
+          dayText: 'Day 1',
+          phaseText: 'Phase 1',
+          titleLower: 'python basics',
+          conceptsLower: 'loops',
+          tagsLower: 'programming',
+          phaseTextLower: 'phase 1',
+          dayTextLower: 'day 1',
+          plainContentLower: 'content about python',
           concepts: ['loops'],
           tags: ['programming'],
         },
         score: 1,
-        matches: [],
       },
-    ] as any)
+    ])
     vi.mocked(searchIndex.extractMatchedTerms).mockReturnValue(['python'])
 
     render(


### PR DESCRIPTION
🔍 Hunter: Fixed 6 errors - replaced leftover `as any` casting in tests

Removed `as any` type casting in test files by providing necessary fields or using `as unknown as Type`:
- `src/pages/__tests__/SearchResults.test.tsx`
- `src/pages/__tests__/Curriculum.test.tsx`
- `src/pages/__tests__/NotebookViewer.test.tsx`
- `src/pages/__tests__/Exercises.test.tsx`
- `src/pages/__tests__/CaseStudies.test.tsx`
- `src/pages/__tests__/ProgressDashboard.test.tsx`

Updated `.jules/hunter-progress.md` with Session 11.
Build now passes ✅.

---
*PR created automatically by Jules for task [5335248480390291799](https://jules.google.com/task/5335248480390291799) started by @saint2706*