### PR TITLE
⚡ Bolt: Optimize phase loops and components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,5 @@
 - Removed unnecessary optimization of `lessonMetrics.reduce` in `ContentStats.tsx` because `readingTime` is already pre-calculated in the array, making the global cache lookup an invalid regression.
 - Correctly mocked `getTotalReadingTime` and `getPhase` in `Home.test.tsx` and `Lesson.test.tsx` respectively.
 - Optimized Curriculum.tsx and ContentStats.tsx to use O(1) properties (getAllLessons().length and getTotalReadingTime()) instead of recalculating during renders. Reduced layout shift risks and main thread blocking.
+- Refactored `resolveChallengeCandidates` in `gamificationStore.ts` to map over `getAllLessons()` instead of using an O(N) `getAllPhases().flatMap` iteration.
+- Wrapped `phases.map()` in `ProgressDashboard.tsx` and `Home.tsx` into `useMemo` hooks returning `phaseProgressData` and `phaseCardsData` respectively, preventing O(N*M) calculation cycles (like `completedSet.has()`) from firing on every component re-render.

--- a/src/pages/Exercises.tsx
+++ b/src/pages/Exercises.tsx
@@ -221,8 +221,8 @@ export default function Exercises() {
 
       {/* Exercise Grid */}
       <motion.div className="exercises-grid" layout>
-        {filtered.map((ex, idx) => (
-          <ExerciseCard key={`${ex.day}-${idx}`} exercise={ex} />
+        {filtered.map((ex) => (
+          <ExerciseCard key={`${ex.day}-${ex.title}`} exercise={ex} />
         ))}
       </motion.div>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -89,6 +89,20 @@ export default function Home() {
     refreshDailyChallenge()
   }, [refreshDailyChallenge])
 
+  // ⚡ Bolt: Memoize phase computation for the grid to avoid O(N*M) calculation on every render
+  const phaseCardsData = useMemo(() => {
+    return phases.map((phase) => {
+      const lessons = getLessonsByPhase(phase.phase)
+      const diff = difficultyConfig[phase.difficulty || 'beginner'] || difficultyConfig.beginner!
+      const icon = phaseIcons[phase.phase - 1] || '📖'
+      const hours = Math.round((phase.totalDuration || 0) / 60)
+      const completedInPhase = lessons.filter((l) =>
+        completedSet.has(dayTokenToProgressId(l.day)),
+      )
+      return { phase, diff, icon, hours, completedInPhase, totalLessons: lessons.length }
+    })
+  }, [phases, completedSet])
+
   useEffect(() => {
     const calculateTotalHours = () => {
       // ⚡ Bolt: Use O(1) cached value instead of O(N) recalculation via reduce with expensive regex parsing
@@ -334,16 +348,7 @@ export default function Home() {
         </div>
 
         <div className="phases-grid">
-          {phases.map((phase) => {
-            const lessons = getLessonsByPhase(phase.phase)
-            const diff =
-              difficultyConfig[phase.difficulty || 'beginner'] || difficultyConfig.beginner!
-            const icon = phaseIcons[phase.phase - 1] || '📖'
-            const hours = Math.round((phase.totalDuration || 0) / 60)
-            const completedInPhase = lessons.filter((l) =>
-              completedSet.has(dayTokenToProgressId(l.day)),
-            )
-
+          {phaseCardsData.map(({ phase, diff, icon, hours, completedInPhase, totalLessons }) => {
             return (
               <Link
                 to={`/phase/${phase.phase}`}
@@ -364,12 +369,12 @@ export default function Home() {
                   >
                     {diff.label}
                   </span>
-                  <span className="meta-pill">📅 {lessons.length} Days</span>
+                  <span className="meta-pill">📅 {totalLessons} Days</span>
                   {hours > 0 && <span className="meta-pill">⏱ {hours}h</span>}
                 </div>
                 {completedInPhase.length > 0 && (
                   <div className="phase-card-progress">
-                    <ProgressBar completed={completedInPhase.length} total={lessons.length} />
+                    <ProgressBar completed={completedInPhase.length} total={totalLessons} />
                   </div>
                 )}
               </Link>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -96,9 +96,7 @@ export default function Home() {
       const diff = difficultyConfig[phase.difficulty || 'beginner'] || difficultyConfig.beginner!
       const icon = phaseIcons[phase.phase - 1] || '📖'
       const hours = Math.round((phase.totalDuration || 0) / 60)
-      const completedInPhase = lessons.filter((l) =>
-        completedSet.has(dayTokenToProgressId(l.day)),
-      )
+      const completedInPhase = lessons.filter((l) => completedSet.has(dayTokenToProgressId(l.day)))
       return { phase, diff, icon, hours, completedInPhase, totalLessons: lessons.length }
     })
   }, [phases, completedSet])

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -101,9 +101,7 @@ export default function ProgressDashboard() {
   const phaseProgressData = useMemo(() => {
     return phases.map((phase) => {
       const lessons = getLessonsByPhase(phase.phase)
-      const completedInPhase = lessons.filter((l) =>
-        completedSet.has(dayTokenToProgressId(l.day)),
-      )
+      const completedInPhase = lessons.filter((l) => completedSet.has(dayTokenToProgressId(l.day)))
       const icon = phaseIcons[phase.phase - 1] || '📖'
       const diff = difficultyConfig[phase.difficulty || 'beginner'] || difficultyConfig.beginner!
 

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -97,6 +97,20 @@ export default function ProgressDashboard() {
 
   const challengeLesson = getLesson(dailyChallenge.day)
 
+  // ⚡ Bolt: Memoize phase arrays so O(N*M) calculation doesn't happen on every render (e.g. from typing/toggling)
+  const phaseProgressData = useMemo(() => {
+    return phases.map((phase) => {
+      const lessons = getLessonsByPhase(phase.phase)
+      const completedInPhase = lessons.filter((l) =>
+        completedSet.has(dayTokenToProgressId(l.day)),
+      )
+      const icon = phaseIcons[phase.phase - 1] || '📖'
+      const diff = difficultyConfig[phase.difficulty || 'beginner'] || difficultyConfig.beginner!
+
+      return { phase, lessons, completedInPhase, icon, diff }
+    })
+  }, [phases, completedSet])
+
   useEffect(() => {
     refreshDailyChallenge()
   }, [refreshDailyChallenge])
@@ -523,9 +537,10 @@ export default function ProgressDashboard() {
       </div>
 
       <div className="progress-heatmap">
-        {phases.map((phase) => {
-          const lessons = getLessonsByPhase(phase.phase)
-          const icon = phaseIcons[phase.phase - 1] || '📖'
+        {phaseProgressData.map(({ phase, lessons, icon, completedInPhase }) => {
+          // Pre-compute completed set for O(1) inside loop
+          const completedDayTokens = new Set(completedInPhase.map((l) => l.day))
+
           return (
             <div className="heatmap-phase" key={phase.phase}>
               <div className="heatmap-phase-label">
@@ -533,7 +548,7 @@ export default function ProgressDashboard() {
               </div>
               <div className="heatmap-cells">
                 {lessons.map((lesson) => {
-                  const done = completedSet.has(dayTokenToProgressId(lesson.day))
+                  const done = completedDayTokens.has(lesson.day)
                   return (
                     <Link
                       to={`/lesson/${lesson.day}`}
@@ -559,15 +574,7 @@ export default function ProgressDashboard() {
       </div>
 
       <div className="progress-phases-list">
-        {phases.map((phase) => {
-          const lessons = getLessonsByPhase(phase.phase)
-          const completedInPhase = lessons.filter((l) =>
-            completedSet.has(dayTokenToProgressId(l.day)),
-          )
-          const icon = phaseIcons[phase.phase - 1] || '📖'
-          const diff =
-            difficultyConfig[phase.difficulty || 'beginner'] || difficultyConfig.beginner!
-
+        {phaseProgressData.map(({ phase, lessons, completedInPhase, icon, diff }) => {
           return (
             <Link to={`/phase/${phase.phase}`} className="progress-phase-row" key={phase.phase}>
               <div className="progress-phase-info">

--- a/src/stores/gamificationStore.ts
+++ b/src/stores/gamificationStore.ts
@@ -13,7 +13,7 @@
 
 import { create } from 'zustand'
 import { StateStorage, createJSONStorage, persist } from 'zustand/middleware'
-import { getAllPhases, getLessonsByPhase } from '../utils/contentLoader'
+import { getAllLessons } from '../utils/contentLoader'
 import { useProgressStore } from './progressStore'
 import { triggerSparkle } from '../utils/confetti'
 import { toastSuccess } from '../utils/toast'
@@ -169,11 +169,10 @@ function resolveChallengeCandidates(): number[] {
     return Array.from({ length: lastVisited }, (_, i) => i + 1)
   }
 
-  return getAllPhases().flatMap((phase) =>
-    getLessonsByPhase(phase.phase)
-      .map((lesson) => dayTokenToProgressId(lesson.day))
-      .filter((day) => Number.isInteger(day) && day > 0),
-  )
+  // ⚡ Bolt: Use getAllLessons() directly instead of O(N*M) nested mapping over phases
+  return getAllLessons()
+    .map((lesson) => dayTokenToProgressId(lesson.day))
+    .filter((day) => Number.isInteger(day) && day > 0)
 }
 
 function maybeCelebrateAchievement(id: AchievementId): void {


### PR DESCRIPTION
This change implements performance optimizations specifically targeting frontend render cycles where `getLessonsByPhase` was being recalculated continuously during layout renders, and replaces an `O(N)` nested phase map structure with a cleaner flat map structure in `gamificationStore`.

---
*PR created automatically by Jules for task [12859232043047124396](https://jules.google.com/task/12859232043047124396) started by @saint2706*