### PR TITLE
fix: Resolve React unique key warning in Exercises list

### DIFF
--- a/src/components/__tests__/ExerciseCard.test.tsx
+++ b/src/components/__tests__/ExerciseCard.test.tsx
@@ -49,6 +49,7 @@ describe('ExerciseCard', () => {
   })
 
   const mockExercise = {
+    id: '1',
     day: '1',
     phase: 1,
     difficulty: 'beginner',

--- a/src/pages/Exercises.tsx
+++ b/src/pages/Exercises.tsx
@@ -221,8 +221,8 @@ export default function Exercises() {
 
       {/* Exercise Grid */}
       <motion.div className="exercises-grid" layout>
-        {filtered.map((ex, idx) => (
-          <ExerciseCard key={`${ex.day}-${idx}`} exercise={ex} />
+        {filtered.map((ex) => (
+          <ExerciseCard key={`${ex.day}-${ex.id}`} exercise={ex} />
         ))}
       </motion.div>
 

--- a/src/pages/__tests__/Exercises.test.tsx
+++ b/src/pages/__tests__/Exercises.test.tsx
@@ -44,6 +44,7 @@ describe('Exercises', () => {
   beforeEach(() => {
     vi.mocked(contentLoader.getAllExercises).mockReturnValue([
       {
+        id: '1',
         day: '1',
         title: 'Basic Math',
         phase: 1,
@@ -54,6 +55,7 @@ describe('Exercises', () => {
         starterCode: '',
       },
       {
+        id: '2',
         day: '2',
         title: 'Data Pandas',
         phase: 2,
@@ -68,7 +70,9 @@ describe('Exercises', () => {
     vi.mocked(contentLoader.getAllNotebooks).mockReturnValue([{ phase: 1, cells: [] } as any])
 
     vi.mocked(useQuizStore).mockImplementation((selector: any) =>
-      selector({ getLowScoringTopics: () => ['pandas'] }),
+      selector({
+        getLowScoringTopics: () => [{ quizId: 'q1', topic: 'pandas', accuracy: 50, incorrect: 2 }],
+      }),
     )
   })
 

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -237,6 +237,7 @@ export function getAdjacentLessons(dayNum: string | number): {
 
 /** Exercise parsed from lesson markdown. */
 export interface Exercise {
+  id: string
   day: DayToken
   lessonTitle: string
   phase: number
@@ -258,21 +259,6 @@ export interface ReviewCardSeed {
   answer: string
 }
 
-/** Parse exercise sections from a lesson markdown body. */
-function extractExercisesFromLesson(lesson: Lesson): Exercise[] {
-  return extractExercises(lesson.content).map((ex) => ({
-    day: lesson.day,
-    phase: lesson.phase,
-    difficulty: lesson.difficulty || 'beginner',
-    lessonTitle: lesson.title,
-    title: ex.title,
-    goal: ex.goal,
-    starterCode: ex.starterCode,
-    expectedOutput: ex.expectedOutput,
-    tags: ex.tags.length > 0 ? ex.tags : (lesson.tags ?? []),
-  }))
-}
-
 function normalizeIdPart(value: string): string {
   return value
     .toLowerCase()
@@ -285,6 +271,23 @@ function getLessonIdPrefix(lesson: Lesson): string {
   const segments = lesson.path.split('/')
   const lessonDir = segments[segments.length - 2] || `day-${lesson.day}`
   return `p${lesson.phase}-d${lesson.day}-${normalizeIdPart(lessonDir)}`
+}
+
+/** Parse exercise sections from a lesson markdown body. */
+function extractExercisesFromLesson(lesson: Lesson): Exercise[] {
+  const lessonIdPrefix = getLessonIdPrefix(lesson)
+  return extractExercises(lesson.content).map((ex, index) => ({
+    id: `${lessonIdPrefix}-exercise-${index + 1}-${normalizeIdPart(ex.title)}`,
+    day: lesson.day,
+    phase: lesson.phase,
+    difficulty: lesson.difficulty || 'beginner',
+    lessonTitle: lesson.title,
+    title: ex.title,
+    goal: ex.goal,
+    starterCode: ex.starterCode,
+    expectedOutput: ex.expectedOutput,
+    tags: ex.tags.length > 0 ? ex.tags : (lesson.tags ?? []),
+  }))
 }
 
 function extractHeadingsFromLessonContent(content: string): string[] {


### PR DESCRIPTION
Resolves a React unique key warning when rendering the list of Exercises.

The previous implementation relied on the array index for React `key`s when rendering `ExerciseCard` components, leading to potential rendering issues and a React warning in strict mode.

Changes:
- Added a deterministic `id` string property (derived from the `slug` or title) to the `Exercise` interface.
- Modified the map function in `Exercises.tsx` to use this new `id` field.
- Updated relevant test mocks to maintain type safety and test coverage.

---
*PR created automatically by Jules for task [14789836966859749682](https://jules.google.com/task/14789836966859749682) started by @saint2706*