### PR TITLE
🕵️‍♂️ Hunter: Fixed 2 errors - Removed as unknown type casts

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -73,3 +73,8 @@
 - **Fixed:** Removed `as any` type casting in `src/pages/__tests__/CaseStudies.test.tsx` by using `as unknown as contentLoader.CaseStudy[]` and `as unknown as contentLoader.Project[]`.
 - **Fixed:** Removed `as any` type casting in `src/pages/__tests__/ProgressDashboard.test.tsx` by using proper `as unknown as Type` casts for `Phase[]`, `Lesson[]`, and `typeof useUserPreferencesStore`.
 - **Verified:** Build, lint, and tests pass.
+
+## Session 12
+- **Fixed:** Replaced `as unknown as Lesson` cast with `as Lesson` and default fallback initializations in `src/utils/contentLoader.ts`.
+- **Fixed:** Replaced `as unknown[]` cast with `as string[]` type assertion in `src/components/ConceptGraph.tsx`.
+- **Verified:** Build, lint, and tests pass.

--- a/src/components/ConceptGraph.tsx
+++ b/src/components/ConceptGraph.tsx
@@ -123,7 +123,8 @@ export default function ConceptGraph({ search = '', highlightPhase = null }: Con
     const edges: GraphEdge[] = []
     const edgeSet = new Set<string>()
     for (const l of lessons) {
-      const prereqs = ((l.prerequisites as unknown[]) || [])
+      const prerequisites = (l.prerequisites || []) as string[]
+      const prereqs = prerequisites
         .map((entry) => dayTokenFromReference(entry))
         .filter((entry): entry is string => Boolean(entry))
       for (const p of prereqs) {

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -105,13 +105,15 @@ function initializeContent() {
         : undefined
 
       return {
+        title: frontmatter.title || 'Untitled',
+        phase: frontmatter.phase || 0,
         ...frontmatter,
         day,
         daySortKey: parsedDay?.sortKey || day,
         prerequisites,
         content,
         path,
-      } as unknown as Lesson
+      } as Lesson
     })
     .sort((a, b) => compareDayTokens(a.day, b.day))
 


### PR DESCRIPTION
Fixed 2 type casting issues where `as unknown as Type` was used instead of native type assertions by providing default fallbacks for required parameters.
Updated `src/utils/contentLoader.ts` and `src/components/ConceptGraph.tsx`. Verified the build passes cleanly.

---
*PR created automatically by Jules for task [5999076426211139960](https://jules.google.com/task/5999076426211139960) started by @saint2706*