### PR TITLE
📚 Docs: Add missing JSDoc comments to Zustand stores

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -40,3 +40,11 @@
   - Added missing typed JSDoc comments and `@returns` tags to `src/components/CopyButton.tsx`, `src/components/ExerciseWidget.tsx`, `src/components/MarkdownRenderer.tsx`, and `src/components/Sidebar.tsx`.
   - Added missing typed JSDoc comments and `@returns` tags to `src/utils/prism.ts` and `src/utils/curriculumConfig.ts`.
   - All modified components and utilities now meet documentation standards.
+
+- **[2026-03-24] JSDoc Improvements in Stores**
+  - Added missing typed JSDoc comments to `src/stores/gamificationStore.ts` for `useGamificationStore` and `ACHIEVEMENTS`.
+  - Added missing typed JSDoc comments to `src/stores/quizStore.ts` for `useQuizStore`.
+  - Added missing typed JSDoc comments to `src/stores/progressStore.ts` for `useProgressStore`.
+  - Added missing typed JSDoc comments to `src/stores/learningAnalyticsStore.ts` for `useLearningAnalyticsStore`.
+  - Added missing typed JSDoc comments to `src/stores/userPreferencesStore.ts` for `useUserPreferencesStore`.
+  - Verified no missing JSDoc comments in `src/stores/` using automated script.

--- a/src/stores/gamificationStore.ts
+++ b/src/stores/gamificationStore.ts
@@ -38,6 +38,9 @@ export type AchievementMeta = {
   icon: string
 }
 
+/**
+ * A static list of all available achievements in the gamification system.
+ */
 export const ACHIEVEMENTS: AchievementMeta[] = [
   {
     id: 'first-lesson',
@@ -184,6 +187,11 @@ function maybeCelebrateAchievement(id: AchievementId): void {
   toastSuccess(`${meta.icon} Badge unlocked: ${meta.label}`)
 }
 
+/**
+ * Hook for accessing the gamification store state.
+ *
+ * @returns {GamificationStore} The state of the gamification store.
+ */
 export const useGamificationStore = create<GamificationStore>()(
   persist(
     (set, get) => ({

--- a/src/stores/learningAnalyticsStore.ts
+++ b/src/stores/learningAnalyticsStore.ts
@@ -177,6 +177,11 @@ export function formatDuration(ms: number): string {
   return `${hours}h ${minutes}m`
 }
 
+/**
+ * Hook for accessing the learning analytics store state.
+ *
+ * @returns {LearningAnalyticsStore} The state of the learning analytics store.
+ */
 export const useLearningAnalyticsStore = create<LearningAnalyticsStore>()(
   persist(
     (set, get) => ({

--- a/src/stores/progressStore.ts
+++ b/src/stores/progressStore.ts
@@ -173,6 +173,11 @@ function normalizePersistedState(
   }
 }
 
+/**
+ * Hook for accessing the progress store state.
+ *
+ * @returns {ProgressStore} The state of the progress store.
+ */
 export const useProgressStore = create<ProgressStore>()(
   persist(
     (set, get) => ({

--- a/src/stores/quizStore.ts
+++ b/src/stores/quizStore.ts
@@ -119,6 +119,11 @@ function normalizeAttempts(value: unknown): QuizAttempt[] {
     .slice(-MAX_ATTEMPTS)
 }
 
+/**
+ * Hook for accessing the quiz store state.
+ *
+ * @returns {QuizStore} The state of the quiz store.
+ */
 export const useQuizStore = create<QuizStore>()(
   persist(
     (set, get) => ({

--- a/src/stores/userPreferencesStore.ts
+++ b/src/stores/userPreferencesStore.ts
@@ -97,6 +97,11 @@ function getLegacyPalette(): ColorPalette {
   return legacyTheme === 'light' ? 'light-steel' : 'gradient-blues'
 }
 
+/**
+ * Hook for accessing the user preferences store state.
+ *
+ * @returns {UserPreferencesStore} The state of the user preferences store.
+ */
 export const useUserPreferencesStore = create<UserPreferencesStore>()(
   persist(
     (set) => ({


### PR DESCRIPTION
This PR implements the requested `Docs` persona task by adding missing JSDoc documentation to the exported variables and functions in the `src/stores/` directory.

### Key Changes
1. **Added JSDocs** to all Zustand custom hooks (`use*Store`) indicating their purpose and return types.
2. **Added JSDocs** to the exported `ACHIEVEMENTS` array in the gamification store.
3. **Updated the documentation log** at `.jules/docs-progress.md` with the new entry for today's work.
4. Validated the changes to ensure all unit tests (`npm test`) and type checks (`npm run lint`) pass seamlessly.

---
*PR created automatically by Jules for task [7629646844874995263](https://jules.google.com/task/7629646844874995263) started by @saint2706*