### PR TITLE
🧪 Testing: Increase coverage for gamificationStore

### DIFF
--- a/run-gamification-coverage.sh
+++ b/run-gamification-coverage.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+npx vitest run --coverage.enabled --coverage.include="src/stores/gamificationStore.ts" src/stores/__tests__/gamificationStore.test.ts

--- a/src/stores/__tests__/gamificationStore.test.ts
+++ b/src/stores/__tests__/gamificationStore.test.ts
@@ -1,4 +1,4 @@
-import { useGamificationStore } from '../gamificationStore'
+import { useGamificationStore, hydrateGamificationStore } from '../gamificationStore'
 import { useProgressStore } from '../progressStore'
 
 vi.mock('../../utils/confetti', () => ({
@@ -55,6 +55,82 @@ describe('gamificationStore', () => {
     expect(state.perfectQuizIds).toEqual(['quiz-day-3'])
   })
 
+  it('ignores invalid days when awarding lesson XP', () => {
+    useGamificationStore.getState().awardLessonCompletion(0)
+    useGamificationStore.getState().awardLessonCompletion(-1)
+    useGamificationStore.getState().awardLessonCompletion(1.5)
+
+    const state = useGamificationStore.getState()
+    expect(state.xpTotal).toBe(0)
+    expect(state.lessonXpAwardedDays).toHaveLength(0)
+  })
+
+  it('ignores invalid parameters when awarding exercise XP', () => {
+    useGamificationStore.getState().awardExerciseCompletion(0, 'ex-1')
+    useGamificationStore.getState().awardExerciseCompletion(1, '')
+    useGamificationStore.getState().awardExerciseCompletion(1, '   ')
+
+    const state = useGamificationStore.getState()
+    expect(state.xpTotal).toBe(0)
+    expect(state.completedExerciseIds).toHaveLength(0)
+  })
+
+  it('ignores invalid parameters when awarding perfect quiz', () => {
+    useGamificationStore.getState().awardPerfectQuiz('')
+    useGamificationStore.getState().awardPerfectQuiz('   ')
+
+    const state = useGamificationStore.getState()
+    expect(state.xpTotal).toBe(0)
+    expect(state.perfectQuizIds).toHaveLength(0)
+  })
+
+  it('calculates xpToNextMilestone correctly', () => {
+    const store = useGamificationStore.getState()
+
+    // Initial state: 0 XP, next is 50
+    let milestone = store.xpToNextMilestone()
+    expect(milestone.current).toBe(0)
+    expect(milestone.next).toBe(50)
+    expect(milestone.percent).toBe(0)
+
+    // Mid-way to 50
+    useGamificationStore.setState({ xpTotal: 25 })
+    milestone = store.xpToNextMilestone()
+    expect(milestone.percent).toBe(50)
+
+    // Reached 50, next is 150
+    useGamificationStore.setState({ xpTotal: 50 })
+    milestone = store.xpToNextMilestone()
+    expect(milestone.next).toBe(150)
+    expect(milestone.percent).toBe(0)
+
+    // Mid-way to 150
+    useGamificationStore.setState({ xpTotal: 100 })
+    milestone = store.xpToNextMilestone()
+    expect(milestone.percent).toBe(50)
+
+    // Max XP
+    useGamificationStore.setState({ xpTotal: 1000 })
+    milestone = store.xpToNextMilestone()
+    expect(milestone.next).toBeNull()
+    expect(milestone.percent).toBe(100)
+
+    // Beyond max XP
+    useGamificationStore.setState({ xpTotal: 2000 })
+    milestone = store.xpToNextMilestone()
+    expect(milestone.next).toBeNull()
+    expect(milestone.percent).toBe(100)
+  })
+
+  it('gets achievement meta', () => {
+    const meta = useGamificationStore.getState().getAchievementMeta('first-lesson')
+    expect(meta).not.toBeNull()
+    expect(meta?.id).toBe('first-lesson')
+
+    const invalid = useGamificationStore.getState().getAchievementMeta('invalid-id')
+    expect(invalid).toBeNull()
+  })
+
   it('unlocks achievements for streak, night owl, speed runner, and quiz master', () => {
     const now = new Date('2026-05-07T22:30:00')
 
@@ -89,5 +165,139 @@ describe('gamificationStore', () => {
         'quiz-master',
       ]),
     )
+  })
+
+  describe('refreshDailyChallenge', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('sets a new daily challenge if none exists for today', () => {
+      vi.setSystemTime(new Date('2026-05-01T12:00:00Z'))
+
+      // Setup some completed lessons
+      useProgressStore.setState({
+        completedLessons: [1, 2, 3],
+      })
+
+      useGamificationStore.getState().refreshDailyChallenge()
+
+      const state = useGamificationStore.getState()
+      expect(state.dailyChallenge.dateKey).toBe('2026-05-01')
+      expect(state.dailyChallenge.day).toBeGreaterThanOrEqual(1)
+      expect(state.dailyChallenge.day).toBeLessThanOrEqual(3)
+    })
+
+    it('uses lastVisitedLesson if no completed lessons', () => {
+      vi.setSystemTime(new Date('2026-05-02T12:00:00Z'))
+
+      useProgressStore.setState({
+        completedLessons: [],
+        lastVisitedLesson: 5,
+      })
+
+      useGamificationStore.getState().refreshDailyChallenge()
+
+      const state = useGamificationStore.getState()
+      expect(state.dailyChallenge.dateKey).toBe('2026-05-02')
+      expect(state.dailyChallenge.day).toBeGreaterThanOrEqual(1)
+      expect(state.dailyChallenge.day).toBeLessThanOrEqual(5)
+    })
+
+    it('uses all lessons if no completed lessons and no last visited', () => {
+      vi.setSystemTime(new Date('2026-05-03T12:00:00Z'))
+
+      useProgressStore.setState({
+        completedLessons: [],
+        lastVisitedLesson: null,
+      })
+
+      useGamificationStore.getState().refreshDailyChallenge()
+
+      const state = useGamificationStore.getState()
+      expect(state.dailyChallenge.dateKey).toBe('2026-05-03')
+      expect(state.dailyChallenge.day).toBeGreaterThanOrEqual(1)
+    })
+
+    it('does not update challenge if already set for today', () => {
+      vi.setSystemTime(new Date('2026-05-04T12:00:00Z'))
+
+      useGamificationStore.setState({
+        dailyChallenge: { day: 10, dateKey: '2026-05-04' },
+      })
+
+      useGamificationStore.getState().refreshDailyChallenge()
+
+      const state = useGamificationStore.getState()
+      expect(state.dailyChallenge.dateKey).toBe('2026-05-04')
+      expect(state.dailyChallenge.day).toBe(10) // should not change
+    })
+  })
+
+  it('hydrates gamification store', () => {
+    // Reset hasHydrated flag
+    useGamificationStore.setState({ hasHydrated: false })
+
+    // Mock rehydrate function
+    const rehydrateSpy = vi
+      .spyOn(useGamificationStore.persist, 'rehydrate')
+      .mockImplementation(() => Promise.resolve())
+
+    hydrateGamificationStore()
+    expect(rehydrateSpy).toHaveBeenCalled()
+
+    // Should not rehydrate if already hydrated
+    useGamificationStore.setState({ hasHydrated: true })
+    rehydrateSpy.mockClear()
+
+    hydrateGamificationStore()
+    expect(rehydrateSpy).not.toHaveBeenCalled()
+  })
+
+  it('unlocks milestones from exercises', () => {
+    const store = useGamificationStore.getState()
+    useGamificationStore.setState({ xpTotal: 45 })
+
+    // Will reach 50 -> unlock xp-50
+    store.awardExerciseCompletion(1, 'ex-1')
+    expect(useGamificationStore.getState().achievementsUnlocked).toContain('xp-50')
+
+    // Setup for next milestones
+    useGamificationStore.setState({ xpTotal: 145, achievementsUnlocked: [] })
+    store.awardExerciseCompletion(1, 'ex-2')
+    expect(useGamificationStore.getState().achievementsUnlocked).toContain('xp-150')
+
+    useGamificationStore.setState({ xpTotal: 295, achievementsUnlocked: [] })
+    store.awardExerciseCompletion(1, 'ex-3')
+    expect(useGamificationStore.getState().achievementsUnlocked).toContain('xp-300')
+  })
+
+  it('handles rehydration storage callback correctly', () => {
+    // Rehydration storage triggers the callback
+    const rehydrationCb = useGamificationStore.persist
+      .getOptions()
+      .onRehydrateStorage?.(useGamificationStore.getState())
+
+    if (rehydrationCb) {
+      // Simulate state rehydrated properly
+      const refreshSpy = vi.spyOn(useGamificationStore.getState(), 'refreshDailyChallenge')
+
+      // Call with no state (should do nothing)
+      rehydrationCb(undefined)
+      expect(useGamificationStore.getState().hasHydrated).toBe(true) // already true from beforeEach
+      expect(refreshSpy).not.toHaveBeenCalled()
+
+      // Reset state for actual test
+      useGamificationStore.setState({ hasHydrated: false })
+
+      // Call with state (should set hydrated and refresh daily challenge)
+      rehydrationCb(useGamificationStore.getState())
+      expect(useGamificationStore.getState().hasHydrated).toBe(true)
+      expect(refreshSpy).toHaveBeenCalled()
+    }
   })
 })


### PR DESCRIPTION
Increase the test coverage for `src/stores/gamificationStore.ts` according to the Testing 🧪 persona guidelines. The new tests verify business logic edge cases, milestone calculations, and store hydration logic that were previously uncovered. Coverage has significantly increased and all tests run smoothly.

---
*PR created automatically by Jules for task [14132739198238228765](https://jules.google.com/task/14132739198238228765) started by @saint2706*