### PR TITLE
🔍 Hunter: Fixed 5 errors - Replaced `any` typings in test files

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -78,3 +78,11 @@
 - **Fixed:** Replaced `as unknown as Lesson` cast with `as Lesson` and default fallback initializations in `src/utils/contentLoader.ts`.
 - **Fixed:** Replaced `as unknown[]` cast with `as string[]` type assertion in `src/components/ConceptGraph.tsx`.
 - **Verified:** Build, lint, and tests pass.
+
+## Session 13
+- **Fixed:** Replaced `as any` type casting with proper `Record<string, unknown>` and `unknown` types in `src/components/__tests__/ExerciseWidget.test.tsx` to improve type safety and fix strict type errors.
+- **Fixed:** Replaced `as any` type casting with proper type structure in `src/components/__tests__/ExerciseCard.test.tsx` for `motion.div` mock.
+- **Fixed:** Replaced `as any` type casting with proper type structure in `src/components/__tests__/AnimatedCounter.test.tsx` for `motion.animate` mock options.
+- **Fixed:** Replaced `as any` type casting with proper type assertions in `src/components/__tests__/MarkdownRenderer.test.tsx` for syntax highlighter props mock.
+- **Fixed:** Replaced `as any` type casting with proper type structure in `src/components/__tests__/ProgressBar.test.tsx` for `motion.div` mock and `root` handling.
+- **Verified:** Build, lint, and tests pass.

--- a/src/components/__tests__/AnimatedCounter.test.tsx
+++ b/src/components/__tests__/AnimatedCounter.test.tsx
@@ -58,8 +58,10 @@ describe('AnimatedCounter', () => {
 
     let updateCallback: (val: number) => void = () => {}
 
-    vi.mocked(motionReact.animate).mockImplementation((_from, _to, options: any) => {
-      updateCallback = options.onUpdate
+    vi.mocked(motionReact.animate).mockImplementation((_from, _to, options: unknown) => {
+      if (options && typeof (options as { onUpdate?: unknown }).onUpdate === 'function') {
+        updateCallback = (options as { onUpdate: (val: number) => void }).onUpdate
+      }
       return { stop: vi.fn() } as unknown as ReturnType<typeof motionReact.animate>
     })
 

--- a/src/components/__tests__/ExerciseCard.test.tsx
+++ b/src/components/__tests__/ExerciseCard.test.tsx
@@ -8,7 +8,11 @@ import ExerciseCard from '../ExerciseCard'
 vi.mock('motion/react', () => ({
   useReducedMotion: () => false,
   motion: {
-    div: ({ children, className, ...props }: any) => {
+    div: ({
+      children,
+      className,
+      ...props
+    }: Record<string, unknown> & { children?: React.ReactNode; className?: string }) => {
       const {
         layout: _layout,
         whileHover: _whileHover,
@@ -32,7 +36,7 @@ vi.mock('motion/react', () => ({
 
 describe('ExerciseCard', () => {
   let container: HTMLDivElement | null = null
-  let root: any = null
+  let root: ReturnType<typeof createRoot> | null = null
 
   beforeEach(() => {
     container = document.createElement('div')
@@ -42,7 +46,7 @@ describe('ExerciseCard', () => {
 
   afterEach(() => {
     act(() => {
-      root.unmount()
+      root?.unmount()
     })
     container?.remove()
     container = null
@@ -63,7 +67,7 @@ describe('ExerciseCard', () => {
 
   const renderCard = (exercise = mockExercise) => {
     act(() => {
-      root.render(
+      root?.render(
         <MemoryRouter>
           <ExerciseCard exercise={exercise} />
         </MemoryRouter>,

--- a/src/components/__tests__/ExerciseWidget.test.tsx
+++ b/src/components/__tests__/ExerciseWidget.test.tsx
@@ -20,11 +20,11 @@ vi.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({
 
 // Mock CodePlayground to capture props
 
-let capturedCodePlaygroundProps: any
+let capturedCodePlaygroundProps: Record<string, unknown> | null = null
 const mockSetCode = vi.fn()
 
 vi.mock('../CodePlayground', () => ({
-  default: React.forwardRef((props: any, ref: any) => {
+  default: React.forwardRef((props: Record<string, unknown>, ref: React.ForwardedRef<unknown>) => {
     capturedCodePlaygroundProps = props
     React.useImperativeHandle(ref, () => ({
       setCode: mockSetCode,
@@ -66,7 +66,7 @@ vi.mock('../../stores/quizStore', () => ({
   useQuizStore: Object.assign(
     // Hook implementation
 
-    (selector: any) => {
+    (selector: (state: Record<string, unknown>) => unknown) => {
       // Mock state for selector
       const state = {
         getQuizStats: mockGetQuizStats,
@@ -111,7 +111,7 @@ describe('ExerciseWidget', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
-    capturedCodePlaygroundProps = undefined
+    capturedCodePlaygroundProps = null
     vi.clearAllMocks()
   })
 
@@ -164,7 +164,11 @@ describe('ExerciseWidget', () => {
     }
 
     await act(async () => {
-      capturedCodePlaygroundProps.onSubmissionEvaluated(result)
+      ;(
+        capturedCodePlaygroundProps as unknown as {
+          onSubmissionEvaluated: (res: typeof result) => void
+        }
+      )?.onSubmissionEvaluated(result)
     })
 
     expect(mockRecordAttempt).toHaveBeenCalledWith(
@@ -188,7 +192,9 @@ describe('ExerciseWidget', () => {
     })
 
     await act(async () => {
-      capturedCodePlaygroundProps.onExpectedOutputMatched()
+      ;(
+        capturedCodePlaygroundProps as unknown as { onExpectedOutputMatched: () => void }
+      )?.onExpectedOutputMatched()
     })
 
     expect(mockAwardExerciseCompletion).toHaveBeenCalled()

--- a/src/components/__tests__/MarkdownRenderer.test.tsx
+++ b/src/components/__tests__/MarkdownRenderer.test.tsx
@@ -4,17 +4,23 @@ import { createRoot, Root } from 'react-dom/client'
 import MarkdownRenderer from '../MarkdownRenderer'
 
 const syntaxHighlighterMock = vi.fn(
-  ({ children, wrapLongLines, codeTagProps, customStyle }: any) => (
-    <div
-      className="syntax-highlighter"
-      data-wrap-long-lines={String(Boolean(wrapLongLines))}
-      data-white-space={codeTagProps?.style?.whiteSpace ?? ''}
-      data-overflow-wrap={codeTagProps?.style?.overflowWrap ?? ''}
-      data-overflow-x={customStyle?.overflowX ?? ''}
-    >
-      {children}
-    </div>
-  ),
+  ({ children, wrapLongLines, codeTagProps, customStyle }: Record<string, unknown>) => {
+    const safeCodeTagProps = codeTagProps as
+      | { style?: { whiteSpace?: string; overflowWrap?: string } }
+      | undefined
+    const safeCustomStyle = customStyle as { overflowX?: string } | undefined
+    return (
+      <div
+        className="syntax-highlighter"
+        data-wrap-long-lines={String(Boolean(wrapLongLines))}
+        data-white-space={safeCodeTagProps?.style?.whiteSpace ?? ''}
+        data-overflow-wrap={safeCodeTagProps?.style?.overflowWrap ?? ''}
+        data-overflow-x={safeCustomStyle?.overflowX ?? ''}
+      >
+        {children as React.ReactNode}
+      </div>
+    )
+  },
 )
 
 // Mock Child Components
@@ -25,23 +31,23 @@ vi.mock('../CodePlayground', () => ({
 }))
 
 vi.mock('../ExerciseWidget', () => ({
-  default: (props: any) => (
-    <div data-testid="exercise-widget" data-title={props.title}>
-      {props.goal}
+  default: (props: Record<string, unknown>) => (
+    <div data-testid="exercise-widget" data-title={props.title as string}>
+      {props.goal as React.ReactNode}
     </div>
   ),
 }))
 
 vi.mock('../MasteryCheck', () => ({
-  default: (props: any) => (
-    <div data-testid="mastery-check" data-title={props.title}>
-      {props.questionText}
+  default: (props: Record<string, unknown>) => (
+    <div data-testid="mastery-check" data-title={props.title as string}>
+      {props.questionText as React.ReactNode}
     </div>
   ),
 }))
 
 vi.mock('../../utils/prism', () => ({
-  default: (props: any) => syntaxHighlighterMock(props),
+  default: (props: Record<string, unknown>) => syntaxHighlighterMock(props),
 }))
 
 vi.mock('react-syntax-highlighter/dist/esm/styles/prism', () => ({
@@ -115,12 +121,19 @@ describe('MarkdownRenderer', () => {
       root.render(<MarkdownRenderer content={content} />)
     })
 
-    const [highlighterProps] = syntaxHighlighterMock.mock.calls.at(-1) ?? []
+    const [highlighterPropsRaw] = syntaxHighlighterMock.mock.calls.at(-1) ?? []
+    const highlighterProps = highlighterPropsRaw as
+      | {
+          wrapLongLines?: boolean
+          codeTagProps?: { style?: { whiteSpace?: string; overflowWrap?: string } }
+          customStyle?: { overflowX?: string }
+        }
+      | undefined
     expect(highlighterProps).toBeTruthy()
-    expect(highlighterProps.wrapLongLines).toBe(true)
-    expect(highlighterProps.codeTagProps?.style?.whiteSpace).toBe('pre-wrap')
-    expect(highlighterProps.codeTagProps?.style?.overflowWrap).toBe('anywhere')
-    expect(highlighterProps.customStyle?.overflowX).toBe('hidden')
+    expect(highlighterProps?.wrapLongLines).toBe(true)
+    expect(highlighterProps?.codeTagProps?.style?.whiteSpace).toBe('pre-wrap')
+    expect(highlighterProps?.codeTagProps?.style?.overflowWrap).toBe('anywhere')
+    expect(highlighterProps?.customStyle?.overflowX).toBe('hidden')
   })
 
   it('renders "Try It" button for Python code blocks', () => {

--- a/src/components/__tests__/ProgressBar.test.tsx
+++ b/src/components/__tests__/ProgressBar.test.tsx
@@ -6,7 +6,11 @@ import ProgressBar from '../ProgressBar'
 // Mock motion to avoid animation issues in tests
 vi.mock('motion/react', () => ({
   motion: {
-    div: ({ children, className, ...props }: any) => {
+    div: ({
+      children,
+      className,
+      ...props
+    }: Record<string, unknown> & { children?: React.ReactNode; className?: string }) => {
       const { initial: _initial, animate: _animate, transition: _transition, ...safeProps } = props
       void _initial
       void _animate
@@ -24,7 +28,7 @@ vi.mock('motion/react', () => ({
 
 describe('ProgressBar', () => {
   let container: HTMLDivElement | null = null
-  let root: any = null
+  let root: ReturnType<typeof createRoot> | null = null
 
   beforeEach(() => {
     container = document.createElement('div')
@@ -34,7 +38,7 @@ describe('ProgressBar', () => {
 
   afterEach(() => {
     act(() => {
-      root.unmount()
+      root?.unmount()
     })
     container?.remove()
     container = null
@@ -42,7 +46,7 @@ describe('ProgressBar', () => {
 
   it('renders correctly with given progress', () => {
     act(() => {
-      root.render(<ProgressBar completed={5} total={10} />)
+      root?.render(<ProgressBar completed={5} total={10} />)
     })
 
     const progressBar = container?.querySelector('[role="progressbar"]')
@@ -57,7 +61,7 @@ describe('ProgressBar', () => {
 
   it('renders correctly with 0 total', () => {
     act(() => {
-      root.render(<ProgressBar completed={0} total={0} />)
+      root?.render(<ProgressBar completed={0} total={0} />)
     })
 
     const progressBar = container?.querySelector('[role="progressbar"]')
@@ -67,14 +71,14 @@ describe('ProgressBar', () => {
 
   it('renders correctly with singular lesson label', () => {
     act(() => {
-      root.render(<ProgressBar completed={1} total={1} />)
+      root?.render(<ProgressBar completed={1} total={1} />)
     })
     expect(container?.textContent).toContain('1/1 lesson')
   })
 
   it('hides label when showLabel is false', () => {
     act(() => {
-      root.render(<ProgressBar completed={5} total={10} showLabel={false} />)
+      root?.render(<ProgressBar completed={5} total={10} showLabel={false} />)
     })
 
     expect(container?.textContent).not.toContain('lessons')
@@ -82,13 +86,13 @@ describe('ProgressBar', () => {
 
   it('calculates percentage correctly', () => {
     act(() => {
-      root.render(<ProgressBar completed={1} total={3} />)
+      root?.render(<ProgressBar completed={5} total={3} />)
     })
     const progressBar = container?.querySelector('[role="progressbar"]')
     expect(progressBar?.getAttribute('aria-valuenow')).toBe('33')
 
     act(() => {
-      root.render(<ProgressBar completed={2} total={3} />)
+      root?.render(<ProgressBar completed={2} total={3} />)
     })
     expect(progressBar?.getAttribute('aria-valuenow')).toBe('67')
   })

--- a/src/components/__tests__/ProgressBar.test.tsx
+++ b/src/components/__tests__/ProgressBar.test.tsx
@@ -86,7 +86,7 @@ describe('ProgressBar', () => {
 
   it('calculates percentage correctly', () => {
     act(() => {
-      root?.render(<ProgressBar completed={5} total={3} />)
+      root?.render(<ProgressBar completed={1} total={3} />)
     })
     const progressBar = container?.querySelector('[role="progressbar"]')
     expect(progressBar?.getAttribute('aria-valuenow')).toBe('33')


### PR DESCRIPTION
This PR addresses the issue of loose `any` typings present across several component test files (`ExerciseWidget.test.tsx`, `ExerciseCard.test.tsx`, `AnimatedCounter.test.tsx`, `MarkdownRenderer.test.tsx`, and `ProgressBar.test.tsx`). 

By using `Record<string, unknown>`, actual types, or `unknown` where appropriate, we increase type safety and minimize the potential for missed compilation errors or broken lint pipelines. Build and unit tests pass successfully.

---
*PR created automatically by Jules for task [1341246157366952892](https://jules.google.com/task/1341246157366952892) started by @saint2706*