### PR TITLE
⚡ Bolt: Optimize content statistics and metadata recalculations

### DIFF
--- a/src/pages/ContentStats.tsx
+++ b/src/pages/ContentStats.tsx
@@ -9,9 +9,8 @@
  * - Display key totals (Total Lessons, Total Exercises, Total Reading Time).
  */
 
-import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
-import { getAllLessons, getAllPhases, phaseIcons, getReadingTime } from '../utils/contentLoader'
+import { phaseIcons, getContentStats } from '../utils/contentLoader'
 import SEOHead from '../components/SEOHead'
 import AnimatedCounter from '../components/AnimatedCounter'
 
@@ -25,84 +24,12 @@ import AnimatedCounter from '../components/AnimatedCounter'
  * - Tag cloud visualization of most common tags
  * - Top concepts list showing frequently covered topics
  *
- * All statistics are computed dynamically from lesson content.
+ * All statistics are computed statically once via contentLoader.
  *
  * @returns The rendered content statistics page
  */
 export default function ContentStats() {
-  const stats = useMemo(() => {
-    const lessons = getAllLessons()
-    const phases = getAllPhases()
-
-    const getWordCount = (markdown: string) => {
-      const plainText = markdown.replace(/```[\s\S]*?```/g, '').replace(/[#*_>`()!-]/g, '')
-      return plainText.split(/\s+/).filter(Boolean).length
-    }
-
-    const lessonMetrics = lessons.map((l) => ({
-      phase: l.phase,
-      difficulty: (l.difficulty as string) || 'unknown',
-      tags: ((l.tags as string[]) || []).map((t) => t.trim()).filter(Boolean),
-      concepts: ((l.concepts as string[]) || []).map((c) => c.trim()).filter(Boolean),
-      wordCount: getWordCount(l.content),
-      readingTime: getReadingTime(l.content),
-    }))
-
-    // Total word count
-    const totalWords = lessonMetrics.reduce((sum, l) => sum + l.wordCount, 0)
-    const totalReadingMins = lessonMetrics.reduce((sum, l) => sum + l.readingTime, 0)
-
-    // Difficulty breakdown
-    const difficultyMap: Record<string, number> = {}
-    for (const l of lessonMetrics) {
-      difficultyMap[l.difficulty] = (difficultyMap[l.difficulty] || 0) + 1
-    }
-
-    // Tag cloud
-    const tagMap: Record<string, number> = {}
-    for (const l of lessonMetrics) {
-      for (const t of l.tags) {
-        tagMap[t] = (tagMap[t] || 0) + 1
-      }
-    }
-    const tagCloud = Object.entries(tagMap)
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 40)
-
-    // Phase stats
-    const phaseStats = phases.map((p) => {
-      const phaseLessons = lessonMetrics.filter((l) => l.phase === p.phase)
-      return {
-        phase: p.phase,
-        title: p.title,
-        lessonCount: phaseLessons.length,
-        totalWords: phaseLessons.reduce((sum, l) => sum + l.wordCount, 0),
-        totalReadingTime: phaseLessons.reduce((sum, l) => sum + l.readingTime, 0),
-      }
-    })
-
-    // Concept stats
-    const conceptMap: Record<string, number> = {}
-    for (const l of lessonMetrics) {
-      for (const c of l.concepts) {
-        conceptMap[c] = (conceptMap[c] || 0) + 1
-      }
-    }
-    const topConcepts = Object.entries(conceptMap)
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 20)
-
-    return {
-      lessonCount: lessons.length,
-      phaseCount: phases.length,
-      totalWords,
-      totalReadingMins,
-      difficultyMap,
-      tagCloud,
-      phaseStats,
-      topConcepts,
-    }
-  }, [])
+  const stats = getContentStats()
 
   const maxTagCount = stats.tagCloud[0]?.[1] || 1
 

--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -16,10 +16,10 @@ import SEOHead from '../components/SEOHead'
 import { buildItemListSchema, buildProductSchema } from '../utils/seoSchemas'
 import {
   getAllPhases,
-  getAllLessons,
   getLessonsByPhase,
   difficultyConfig,
   phaseIcons,
+  getCurriculumMetadata,
 } from '../utils/contentLoader'
 import { dayTokenToProgressId } from '../utils/dayToken'
 import Breadcrumb from '../components/Breadcrumb'
@@ -71,7 +71,7 @@ export default function Curriculum() {
     })
   }, [phases, completedSet])
 
-  const totalLessons = useMemo(() => getAllLessons().length, [])
+  const { totalDays: totalLessons } = getCurriculumMetadata()
   const completedCount = completedLessons.length
   const overallPct = useMemo(
     () => (totalLessons > 0 ? Math.round((completedCount / totalLessons) * 100) : 0),

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -17,12 +17,12 @@ import SEOHead from '../components/SEOHead'
 import { buildWebSiteSchema, buildCourseSchema, buildProductSchema } from '../utils/seoSchemas'
 import {
   getAllPhases,
-  getAllLessons,
   getTotalReadingTime,
   getLessonsByPhase,
   getLesson,
   difficultyConfig,
   phaseIcons,
+  getCurriculumMetadata,
 } from '../utils/contentLoader'
 import { useProgressStore } from '../stores/progressStore'
 import { dayTokenToProgressId } from '../utils/dayToken'
@@ -43,18 +43,7 @@ import { useGamificationStore } from '../stores/gamificationStore'
  */
 export default function Home() {
   const phases = getAllPhases()
-  const stats = useMemo(() => {
-    const allLessons = getAllLessons()
-    const allPhases = getAllPhases()
-    const totalDays = allLessons.length
-    const totalPhases = allPhases.length
-
-    // Calculate unique difficulty levels
-    const uniqueLevels = new Set(allLessons.map((l) => l.difficulty || 'beginner'))
-    const totalLevels = uniqueLevels.size
-
-    return { totalDays, totalPhases, totalLevels }
-  }, [])
+  const stats = getCurriculumMetadata()
   const [totalHours, setTotalHours] = useState<number | null>(null)
   const lastVisitedDay = useProgressStore((state) => state.lastVisitedLesson)
   const lastVisitedLesson = lastVisitedDay ? (getLesson(lastVisitedDay) ?? null) : null
@@ -76,7 +65,7 @@ export default function Home() {
     : 0
   const completedCount = completedLessons.length
   const streakDays = useProgressStore((state) => state.streakDays())
-  const totalLessons = useMemo(() => getAllLessons().length, [])
+  const totalLessons = stats.totalDays
   const prefersReducedMotion = useReducedMotion()
   const { scrollYProgress } = useScroll()
   const heroY = useTransform(scrollYProgress, [0, 0.35], [0, prefersReducedMotion ? 0 : -50])

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -17,9 +17,9 @@ import {
   getAllPhases,
   getLessonsByPhase,
   getLesson,
-  getAllLessons,
   phaseIcons,
   difficultyConfig,
+  getCurriculumMetadata,
 } from '../utils/contentLoader'
 import { dayTokenToProgressId } from '../utils/dayToken'
 import ProgressBar from '../components/ProgressBar'
@@ -45,11 +45,11 @@ import { useProgressStore } from '../stores/progressStore'
  */
 export default function ProgressDashboard() {
   const phases = getAllPhases()
+  const { totalDays: totalLessons } = getCurriculumMetadata()
 
   const completedLessons = useProgressStore((state) => state.completedLessons)
   const completedSet = useMemo(() => new Set(completedLessons), [completedLessons])
 
-  const totalLessons = useMemo(() => getAllLessons().length, [])
   const overallPct =
     totalLessons > 0 ? Math.round((completedLessons.length / totalLessons) * 100) : 0
 

--- a/src/pages/__tests__/ContentStats.test.tsx
+++ b/src/pages/__tests__/ContentStats.test.tsx
@@ -19,9 +19,7 @@ vi.mock('../../components/AnimatedCounter', () => ({
 }))
 
 vi.mock('../../utils/contentLoader', () => ({
-  getAllLessons: vi.fn(),
-  getAllPhases: vi.fn(),
-  getReadingTime: vi.fn(),
+  getContentStats: vi.fn(),
   phaseIcons: ['📊', '🐍'],
 }))
 
@@ -47,43 +45,31 @@ describe('ContentStats', () => {
   })
 
   it('renders content statistics correctly', () => {
-    vi.mocked(contentLoader.getAllPhases).mockReturnValue([
-      {
-        phase: 1,
-        title: 'Python Foundations',
-        description: 'desc',
-        days: ['1', '2'],
-        objectives: [] as string[],
-        content: '',
-        path: '',
-      },
-    ])
-
-    vi.mocked(contentLoader.getAllLessons).mockReturnValue([
-      {
-        day: '1',
-        title: 'Intro',
-        phase: 1,
-        difficulty: 'beginner',
-        tags: ['python', 'basics'],
-        concepts: ['variables', 'types'],
-        content: 'This is a test lesson with some words.', // 8 words
-        path: '',
-      },
-      {
-        day: '2',
-        title: 'Advanced',
-        phase: 1,
-        difficulty: 'advanced',
-        tags: ['python', 'data'],
-        concepts: ['variables', 'loops'],
-        content: 'Another lesson with more words here.', // 6 words
-        path: '',
-      },
-    ])
-
-    vi.mocked(contentLoader.getReadingTime).mockImplementation((content) => {
-      return content.length > 30 ? 5 : 2
+    vi.mocked(contentLoader.getContentStats).mockReturnValue({
+      lessonCount: 2,
+      phaseCount: 1,
+      totalWords: 14,
+      totalReadingMins: 7,
+      difficultyMap: { beginner: 1, advanced: 1 },
+      tagCloud: [
+        ['python', 2],
+        ['basics', 1],
+        ['data', 1],
+      ],
+      phaseStats: [
+        {
+          phase: 1,
+          title: 'Python Foundations',
+          lessonCount: 2,
+          totalWords: 14,
+          totalReadingTime: 7,
+        },
+      ],
+      topConcepts: [
+        ['variables', 2],
+        ['types', 1],
+        ['loops', 1],
+      ],
     })
 
     act(() => {

--- a/src/pages/__tests__/Curriculum.test.tsx
+++ b/src/pages/__tests__/Curriculum.test.tsx
@@ -12,7 +12,7 @@ vi.mock('../../components/SEOHead', () => ({
 
 vi.mock('../../utils/contentLoader', () => ({
   getAllPhases: vi.fn(),
-  getAllLessons: vi.fn(() => []),
+  getCurriculumMetadata: vi.fn(() => ({ totalDays: 0, totalPhases: 0, totalLevels: 0 })),
   getLessonsByPhase: vi.fn(),
   difficultyConfig: {
     beginner: { label: 'Beginner', color: '#000', bg: '#fff' },
@@ -65,22 +65,11 @@ describe('Curriculum', () => {
   })
 
   it('renders the curriculum page correctly with phases and lessons', () => {
-    vi.mocked(contentLoader.getAllLessons).mockReturnValue([
-      {
-        day: '1',
-        title: 'Intro',
-        phase: 1,
-        content: '',
-        path: '',
-      } as unknown as contentLoader.Lesson,
-      {
-        day: '2',
-        title: 'Advanced',
-        phase: 2,
-        content: '',
-        path: '',
-      } as unknown as contentLoader.Lesson,
-    ])
+    vi.mocked(contentLoader.getCurriculumMetadata).mockReturnValue({
+      totalDays: 2,
+      totalPhases: 2,
+      totalLevels: 2,
+    })
 
     vi.mocked(contentLoader.getAllPhases).mockReturnValue([
       {

--- a/src/pages/__tests__/Home.test.tsx
+++ b/src/pages/__tests__/Home.test.tsx
@@ -54,7 +54,7 @@ vi.mock('../../stores/progressStore', () => {
 })
 
 vi.mock('../../utils/contentLoader', () => ({
-  getAllLessons: () => [{ day: 12, phase: 2, difficulty: 'beginner', content: 'hello world' }],
+  getCurriculumMetadata: () => ({ totalDays: 1, totalPhases: 1, totalLevels: 1 }),
   getReadingTime: () => 5,
   getTotalReadingTime: () => 5,
   getAllPhases: () => [

--- a/src/pages/__tests__/ProgressDashboard.test.tsx
+++ b/src/pages/__tests__/ProgressDashboard.test.tsx
@@ -42,7 +42,7 @@ vi.mock('../../utils/contentLoader', () => ({
   getAllPhases: vi.fn(),
   getLessonsByPhase: vi.fn(),
   getLesson: vi.fn(),
-  getAllLessons: vi.fn(),
+  getCurriculumMetadata: vi.fn(() => ({ totalDays: 0, totalPhases: 0, totalLevels: 0 })),
   phaseIcons: ['📊'],
   difficultyConfig: {
     beginner: { label: 'Beginner', color: '#000', bg: '#fff' },
@@ -76,10 +76,11 @@ describe('ProgressDashboard', () => {
     vi.mocked(contentLoader.getAllPhases).mockReturnValue([
       { phase: 1, title: 'Phase 1', difficulty: 'beginner' },
     ] as unknown as contentLoader.Phase[])
-    vi.mocked(contentLoader.getAllLessons).mockReturnValue([
-      { day: '1', title: 'Lesson 1' },
-      { day: '2', title: 'Lesson 2' },
-    ] as unknown as contentLoader.Lesson[])
+    vi.mocked(contentLoader.getCurriculumMetadata).mockReturnValue({
+      totalDays: 2,
+      totalPhases: 1,
+      totalLevels: 1,
+    })
     vi.mocked(contentLoader.getLessonsByPhase).mockReturnValue([
       { day: '1', title: 'Lesson 1' },
     ] as unknown as contentLoader.Lesson[])

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -588,6 +588,135 @@ export function getTotalReadingTime(): number {
   return totalReadingTimeCache
 }
 
+let curriculumMetadataCache: {
+  totalDays: number
+  totalPhases: number
+  totalLevels: number
+} | null = null
+
+/**
+ * Retrieves cached curriculum metadata.
+ *
+ * @returns {{ totalDays: number; totalPhases: number; totalLevels: number }} The total number of days, phases, and difficulty levels.
+ */
+export function getCurriculumMetadata(): {
+  totalDays: number
+  totalPhases: number
+  totalLevels: number
+} {
+  if (curriculumMetadataCache === null) {
+    const allLessons = getAllLessons()
+    const allPhases = getAllPhases()
+    const totalDays = allLessons.length
+    const totalPhases = allPhases.length
+
+    // Calculate unique difficulty levels
+    const uniqueLevels = new Set(allLessons.map((l) => l.difficulty || 'beginner'))
+    const totalLevels = uniqueLevels.size
+
+    curriculumMetadataCache = { totalDays, totalPhases, totalLevels }
+  }
+  return curriculumMetadataCache
+}
+
+let contentStatsCache: {
+  lessonCount: number
+  phaseCount: number
+  totalWords: number
+  totalReadingMins: number
+  difficultyMap: Record<string, number>
+  tagCloud: [string, number][]
+  phaseStats: {
+    phase: number
+    title: string
+    lessonCount: number
+    totalWords: number
+    totalReadingTime: number
+  }[]
+  topConcepts: [string, number][]
+} | null = null
+
+/**
+ * Retrieves comprehensive content statistics for the curriculum.
+ * The statistics are computed once and cached to avoid O(N) recalculations on render.
+ */
+export function getContentStats() {
+  if (contentStatsCache === null) {
+    const lessons = getAllLessons()
+    const phases = getAllPhases()
+
+    const getWordCount = (markdown: string) => {
+      const plainText = markdown.replace(/```[\s\S]*?```/g, '').replace(/[#*_>`()!-]/g, '')
+      return plainText.split(/\s+/).filter(Boolean).length
+    }
+
+    const lessonMetrics = lessons.map((l) => ({
+      phase: l.phase,
+      difficulty: (l.difficulty as string) || 'unknown',
+      tags: ((l.tags as string[]) || []).map((t) => t.trim()).filter(Boolean),
+      concepts: ((l.concepts as string[]) || []).map((c) => c.trim()).filter(Boolean),
+      wordCount: getWordCount(l.content),
+      readingTime: getReadingTime(l.content),
+    }))
+
+    // Total word count
+    const totalWords = lessonMetrics.reduce((sum, l) => sum + l.wordCount, 0)
+    const totalReadingMins = lessonMetrics.reduce((sum, l) => sum + l.readingTime, 0)
+
+    // Difficulty breakdown
+    const difficultyMap: Record<string, number> = {}
+    for (const l of lessonMetrics) {
+      difficultyMap[l.difficulty] = (difficultyMap[l.difficulty] || 0) + 1
+    }
+
+    // Tag cloud
+    const tagMap: Record<string, number> = {}
+    for (const l of lessonMetrics) {
+      for (const t of l.tags) {
+        tagMap[t] = (tagMap[t] || 0) + 1
+      }
+    }
+    const tagCloud = Object.entries(tagMap)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 40)
+
+    // Phase stats
+    const phaseStats = phases.map((p) => {
+      const phaseLessons = lessonMetrics.filter((l) => l.phase === p.phase)
+      return {
+        phase: p.phase,
+        title: p.title,
+        lessonCount: phaseLessons.length,
+        totalWords: phaseLessons.reduce((sum, l) => sum + l.wordCount, 0),
+        totalReadingTime: phaseLessons.reduce((sum, l) => sum + l.readingTime, 0),
+      }
+    })
+
+    // Concept stats
+    const conceptMap: Record<string, number> = {}
+    for (const l of lessonMetrics) {
+      for (const c of l.concepts) {
+        conceptMap[c] = (conceptMap[c] || 0) + 1
+      }
+    }
+    const topConcepts = Object.entries(conceptMap)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 20)
+
+    contentStatsCache = {
+      lessonCount: lessons.length,
+      phaseCount: phases.length,
+      totalWords,
+      totalReadingMins,
+      difficultyMap,
+      tagCloud,
+      phaseStats,
+      topConcepts,
+    }
+  }
+  return contentStatsCache
+}
+
 /**
  * Retrieves all valid parsed Jupyter notebooks available in the project.
  * Uses lazy loading to delay instantiation until the first request.


### PR DESCRIPTION
⚡ Bolt: Optimize content statistics and metadata recalculations

Replaced O(N) repetitive array processing tasks in `ContentStats`, `Home`, `ProgressDashboard`, and `Curriculum` with statically-cached O(1) module-level helper methods inside `contentLoader.ts`. This prevents excessive markdown parsing and recalculations whenever these components mount, avoiding unnecessary CPU cycles in the browser.

Specifically:
- Replaced inline heavy `getWordCount` & `getReadingTime` mapping in `ContentStats.tsx` with a single exported, cached `getContentStats()` function from `contentLoader.ts`.
- Added a `getCurriculumMetadata()` function to safely cache `totalDays`, `totalPhases`, and `totalLevels` since the content is statically defined. Added integrations to UI views using these parameters.

---
*PR created automatically by Jules for task [5456289748097400620](https://jules.google.com/task/5456289748097400620) started by @saint2706*