### PR TITLE
🧘 Buddha: [GEO] Add FAQ schema to Mastery Check component

### DIFF
--- a/src/components/MasteryCheck.tsx
+++ b/src/components/MasteryCheck.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useId } from 'react'
 import CodePlayground from './CodePlayground'
+import { buildFAQSchema } from '../utils/seoSchemas'
 
 interface MasteryCheckProps {
   questionNumber: number
@@ -32,9 +33,16 @@ export default function MasteryCheck({
 
   // Check if the answer contains Python code (look for code blocks)
   const hasRunnableCode = codeSnippet && codeSnippet.trim().length > 0
+  const faqSchema = buildFAQSchema([{ question: title, answer: answer }])
 
   return (
     <div className={`mastery-check ${revealed ? 'mastery-check--revealed' : ''}`}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(faqSchema).replace(/</g, '\\u003c'),
+        }}
+      />
       <div className="mastery-check__header">
         <span className="mastery-check__badge">Q{questionNumber}</span>
         <h3 className="mastery-check__title">{title}</h3>


### PR DESCRIPTION
Adds `FAQPage` schema to the `MasteryCheck` component to expose Q&A sections directly in the DOM via JSON-LD for better AI discoverability and Generative Engine Optimization (GEO).

---
*PR created automatically by Jules for task [15208669919943118937](https://jules.google.com/task/15208669919943118937) started by @saint2706*