### PR TITLE
⚡ Bolt: [PERF] Optimize React re-renders in Dashboard and Sidebar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,9 +7,9 @@
 
 import { useState, useMemo, useEffect, useRef } from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import { getAllPhases } from '../utils/contentLoader'
+import { getAllPhases, getLessonsByPhase } from '../utils/contentLoader'
 import { getReviewDueCountByPhase, getReviewStreak } from '../utils/reviewTracker'
-import { normalizeDayToken } from '../utils/dayToken'
+import { normalizeDayToken, dayTokenToProgressId } from '../utils/dayToken'
 import { useProgressStore } from '../stores/progressStore'
 import SidebarPhaseGroup from './SidebarPhaseGroup'
 
@@ -64,6 +64,18 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
   // Reactive progress tracking
   const completedLessons = useProgressStore((state) => state.completedLessons)
   const completedSet = useMemo(() => new Set(completedLessons), [completedLessons])
+
+  const completedIdsByPhase = useMemo(() => {
+    const idsByPhase: Record<number, string> = {}
+    for (const phase of phases) {
+      const lessons = getLessonsByPhase(phase.phase)
+      idsByPhase[phase.phase] = lessons
+        .map((l) => dayTokenToProgressId(l.day))
+        .filter((id) => completedSet.has(id))
+        .join(',')
+    }
+    return idsByPhase
+  }, [phases, completedSet])
 
   // Determines currently open phase: manual toggle takes precedence over auto-derived.
   const openPhase = manualOpen !== null ? manualOpen : derivedOpenPhase
@@ -210,6 +222,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
               phase={phase}
               isActive={openPhase === phase.phase}
               completedSet={completedSet}
+              completedIdsJoined={completedIdsByPhase[phase.phase] ?? ''}
               dueCount={dueByPhase[phase.phase] || 0}
               currentPath={location.pathname}
               onToggle={togglePhase}

--- a/src/components/SidebarPhaseGroup.tsx
+++ b/src/components/SidebarPhaseGroup.tsx
@@ -16,6 +16,7 @@ interface SidebarPhaseGroupProps {
   phase: Phase
   isActive: boolean
   completedSet: Set<number>
+  completedIdsJoined: string
   dueCount: number
   currentPath: string
   onToggle: (phaseNum: number) => void
@@ -26,6 +27,7 @@ function SidebarPhaseGroup({
   phase,
   isActive,
   completedSet,
+  completedIdsJoined,
   dueCount,
   currentPath,
   onToggle,
@@ -34,7 +36,7 @@ function SidebarPhaseGroup({
   const prefersReducedMotion = useReducedMotion()
   const lessons = getLessonsByPhase(phase.phase)
   const icon = phaseIcons[phase.phase - 1] || '📖'
-  const completedCount = lessons.filter((l) => completedSet.has(dayTokenToProgressId(l.day))).length
+  const completedCount = completedIdsJoined ? completedIdsJoined.split(',').length : 0
 
   return (
     <div className="phase-group">
@@ -168,14 +170,8 @@ function propsAreEqual(
   }
 
   // Check if completion status of ANY lesson IN THIS PHASE changed
-  if (prevProps.completedSet !== nextProps.completedSet) {
-    const lessons = getLessonsByPhase(nextProps.phase.phase)
-    for (const lesson of lessons) {
-      const id = dayTokenToProgressId(lesson.day)
-      if (prevProps.completedSet.has(id) !== nextProps.completedSet.has(id)) {
-        return false
-      }
-    }
+  if (prevProps.completedIdsJoined !== nextProps.completedIdsJoined) {
+    return false
   }
 
   return true

--- a/src/components/__tests__/SidebarPhaseGroup.test.tsx
+++ b/src/components/__tests__/SidebarPhaseGroup.test.tsx
@@ -42,6 +42,7 @@ describe('SidebarPhaseGroup', () => {
     phase: { phase: 1, title: 'Foundations', days: ['01', '02'], content: '', path: '' },
     isActive: false,
     completedSet: new Set<number>(),
+    completedIdsJoined: '',
     dueCount: 0,
     currentPath: '/',
     onToggle: vi.fn(),
@@ -94,6 +95,7 @@ describe('SidebarPhaseGroup', () => {
           <SidebarPhaseGroup
             {...defaultProps}
             completedSet={new Set([1])} // Day 01
+            completedIdsJoined="1"
             dueCount={3}
           />
         </MemoryRouter>,

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -33,7 +33,7 @@ import {
   difficultyConfig,
   getPhase,
   getLessonsByPhase,
-  getAllLessons,
+  getCurriculumMetadata,
 } from '../utils/contentLoader'
 import { setLastVisited } from '../utils/progressTracker'
 import MarkdownRenderer, {
@@ -174,7 +174,7 @@ export default function Lesson() {
         }
       }
 
-      const totalLessonCount = getAllLessons().length
+      const totalLessonCount = getCurriculumMetadata().totalDays
       if (afterCompleted.length === totalLessonCount) {
         triggerCurriculumFireworks()
         toastSuccess('🎓 Curriculum complete! Incredible work.')

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -587,18 +587,14 @@ export default function ProgressDashboard() {
         <p>Each cell represents a lesson. Completed lessons are highlighted.</p>
       </div>
 
-      <div className="progress-heatmap">
-        {renderedHeatmapPhases}
-      </div>
+      <div className="progress-heatmap">{renderedHeatmapPhases}</div>
 
       {/* Per-Phase Progress */}
       <div className="section-header" style={{ marginTop: '2.5rem', marginBottom: '1rem' }}>
         <h2>Progress by Phase</h2>
       </div>
 
-      <div className="progress-phases-list">
-        {renderedProgressPhases}
-      </div>
+      <div className="progress-phases-list">{renderedProgressPhases}</div>
 
       {/* Clear progress */}
       <div style={{ marginTop: '3rem', textAlign: 'center' }}>

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -119,6 +119,72 @@ export default function ProgressDashboard() {
     setCustomCursorEnabled,
   } = useUserPreferencesStore()
 
+  const renderedHeatmapPhases = useMemo(
+    () =>
+      phases.map((phase) => {
+        const lessons = getLessonsByPhase(phase.phase)
+        const icon = phaseIcons[phase.phase - 1] || '📖'
+        return (
+          <div className="heatmap-phase" key={phase.phase}>
+            <div className="heatmap-phase-label">
+              <span>{icon}</span> P{phase.phase}
+            </div>
+            <div className="heatmap-cells">
+              {lessons.map((lesson) => {
+                const done = completedSet.has(dayTokenToProgressId(lesson.day))
+                return (
+                  <Link
+                    to={`/lesson/${lesson.day}`}
+                    className={`heatmap-cell ${done ? 'done' : ''}`}
+                    key={lesson.day}
+                    title={`Day ${lesson.day}: ${lesson.title}${done ? ' ✓' : ''}`}
+                  >
+                    <span className="sr-only">
+                      Day {lesson.day}: {lesson.title} {done ? '(completed)' : '(not completed)'}
+                    </span>
+                  </Link>
+                )
+              })}
+            </div>
+          </div>
+        )
+      }),
+    [phases, completedSet],
+  )
+
+  const renderedProgressPhases = useMemo(
+    () =>
+      phases.map((phase) => {
+        const lessons = getLessonsByPhase(phase.phase)
+        const completedInPhase = lessons.filter((l) =>
+          completedSet.has(dayTokenToProgressId(l.day)),
+        )
+        const icon = phaseIcons[phase.phase - 1] || '📖'
+        const diff = difficultyConfig[phase.difficulty || 'beginner'] || difficultyConfig.beginner!
+
+        return (
+          <Link to={`/phase/${phase.phase}`} className="progress-phase-row" key={phase.phase}>
+            <div className="progress-phase-info">
+              <span className="progress-phase-icon">{icon}</span>
+              <div>
+                <span className="progress-phase-name">
+                  Phase {phase.phase}: {phase.title}
+                </span>
+                <span
+                  className="difficulty-badge"
+                  style={{ color: diff.color, background: diff.bg, marginLeft: '0.5rem' }}
+                >
+                  {diff.label}
+                </span>
+              </div>
+            </div>
+            <ProgressBar completed={completedInPhase.length} total={lessons.length} />
+          </Link>
+        )
+      }),
+    [phases, completedSet],
+  )
+
   return (
     <div className="page-container">
       <SEOHead
@@ -522,34 +588,7 @@ export default function ProgressDashboard() {
       </div>
 
       <div className="progress-heatmap">
-        {phases.map((phase) => {
-          const lessons = getLessonsByPhase(phase.phase)
-          const icon = phaseIcons[phase.phase - 1] || '📖'
-          return (
-            <div className="heatmap-phase" key={phase.phase}>
-              <div className="heatmap-phase-label">
-                <span>{icon}</span> P{phase.phase}
-              </div>
-              <div className="heatmap-cells">
-                {lessons.map((lesson) => {
-                  const done = completedSet.has(dayTokenToProgressId(lesson.day))
-                  return (
-                    <Link
-                      to={`/lesson/${lesson.day}`}
-                      className={`heatmap-cell ${done ? 'done' : ''}`}
-                      key={lesson.day}
-                      title={`Day ${lesson.day}: ${lesson.title}${done ? ' ✓' : ''}`}
-                    >
-                      <span className="sr-only">
-                        Day {lesson.day}: {lesson.title} {done ? '(completed)' : '(not completed)'}
-                      </span>
-                    </Link>
-                  )
-                })}
-              </div>
-            </div>
-          )
-        })}
+        {renderedHeatmapPhases}
       </div>
 
       {/* Per-Phase Progress */}
@@ -558,35 +597,7 @@ export default function ProgressDashboard() {
       </div>
 
       <div className="progress-phases-list">
-        {phases.map((phase) => {
-          const lessons = getLessonsByPhase(phase.phase)
-          const completedInPhase = lessons.filter((l) =>
-            completedSet.has(dayTokenToProgressId(l.day)),
-          )
-          const icon = phaseIcons[phase.phase - 1] || '📖'
-          const diff =
-            difficultyConfig[phase.difficulty || 'beginner'] || difficultyConfig.beginner!
-
-          return (
-            <Link to={`/phase/${phase.phase}`} className="progress-phase-row" key={phase.phase}>
-              <div className="progress-phase-info">
-                <span className="progress-phase-icon">{icon}</span>
-                <div>
-                  <span className="progress-phase-name">
-                    Phase {phase.phase}: {phase.title}
-                  </span>
-                  <span
-                    className="difficulty-badge"
-                    style={{ color: diff.color, background: diff.bg, marginLeft: '0.5rem' }}
-                  >
-                    {diff.label}
-                  </span>
-                </div>
-              </div>
-              <ProgressBar completed={completedInPhase.length} total={lessons.length} />
-            </Link>
-          )
-        })}
+        {renderedProgressPhases}
       </div>
 
       {/* Clear progress */}

--- a/src/pages/__tests__/Lesson.test.tsx
+++ b/src/pages/__tests__/Lesson.test.tsx
@@ -35,6 +35,7 @@ vi.mock('../../utils/contentLoader', () => ({
   getAllPhases: () => [{ phase: 1 }, { phase: 2 }],
   getPhase: (phaseNum: number) => [{ phase: 1 }, { phase: 2 }].find((p) => p.phase === phaseNum),
   getLessonsByPhase: (phase: number) => (phase === 1 ? [{ day: '1B' }] : [{ day: '2' }]),
+  getCurriculumMetadata: () => ({ totalDays: 2, totalPhases: 2, totalLevels: 1 }),
   getAllLessons: () => [{ day: '1B' }, { day: '2' }],
   difficultyConfig: {
     beginner: { label: 'Beginner', color: '#000', bg: '#fff' },


### PR DESCRIPTION
Implemented performance improvements targeting excessive re-renders during navigation and dashboard interactions.

- Eliminated unmemoized array operations (`map().filter().join()`) inside `Sidebar.tsx`'s render phase.
- Replaced iterative completion checks inside `SidebarPhaseGroup` with a simple primitive prop check (`completedIdsJoined`).
- Extracted and safely hoisted `useMemo` loops inside `ProgressDashboard.tsx` to stop P*N re-calculations of the Heatmap and Phase list when local UI state changes.
- Utilized cached `getCurriculumMetadata` over `getAllLessons().length`.

---
*PR created automatically by Jules for task [12903769950562557137](https://jules.google.com/task/12903769950562557137) started by @saint2706*