### PR TITLE
🕵️‍♂️ Hunter: Fixed 3 errors - Replaced strict 'any' types in Test Mocks

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -86,3 +86,9 @@
 - **Fixed:** Replaced `as any` type casting with proper type assertions in `src/components/__tests__/MarkdownRenderer.test.tsx` for syntax highlighter props mock.
 - **Fixed:** Replaced `as any` type casting with proper type structure in `src/components/__tests__/ProgressBar.test.tsx` for `motion.div` mock and `root` handling.
 - **Verified:** Build, lint, and tests pass.
+
+## Session 14
+- **Fixed:** Replaced `as any` type casting with proper type signature in `src/pages/__tests__/Home.test.tsx` for mocked Zustand selector.
+- **Fixed:** Replaced `as any` type casting with proper type assertions in `src/pages/__tests__/Curriculum.test.tsx` for mocked `motion.div`, `root`, and mocked Zustand selector.
+- **Fixed:** Replaced `any` variable typings in `src/hooks/__tests__/usePyodide.test.tsx` with `ReturnType<typeof usePyodide>`, appropriate Promise structures, and strict types.
+- **Verified:** Build, lint, and tests pass.

--- a/src/hooks/__tests__/usePyodide.test.tsx
+++ b/src/hooks/__tests__/usePyodide.test.tsx
@@ -94,7 +94,7 @@ describe('usePyodide', () => {
   })
 
   it('runs python code successfully and captures output', async () => {
-    let hookResult: any
+    let hookResult: ReturnType<typeof usePyodide>
 
     function TestComponent() {
       hookResult = usePyodide()
@@ -107,17 +107,17 @@ describe('usePyodide', () => {
       }
     })
 
-    let result: any
+    let result: { output: string; error: string | null } | undefined
     await act(async () => {
-      result = await hookResult.runPython('print_hello')
+      result = await hookResult!.runPython('print_hello')
     })
 
-    expect(result.output).toBe('Hello World')
-    expect(result.error).toBeNull()
+    expect(result!.output).toBe('Hello World')
+    expect(result!.error).toBeNull()
   })
 
   it('handles python errors gracefully', async () => {
-    let hookResult: any
+    let hookResult: ReturnType<typeof usePyodide>
 
     function TestComponent() {
       hookResult = usePyodide()
@@ -130,17 +130,17 @@ describe('usePyodide', () => {
       }
     })
 
-    let result: any
+    let result: { output: string; error: string | null } | undefined
     await act(async () => {
-      result = await hookResult.runPython('raise_error')
+      result = await hookResult!.runPython('raise_error')
     })
 
-    expect(result.error).toBe('Python Error')
-    expect(result.output).toBe('')
+    expect(result!.error).toBe('Python Error')
+    expect(result!.output).toBe('')
   })
 
   it('truncates output when it exceeds the limit', async () => {
-    let hookResult: any
+    let hookResult: ReturnType<typeof usePyodide>
 
     function TestComponent() {
       hookResult = usePyodide()
@@ -155,21 +155,21 @@ describe('usePyodide', () => {
 
     // Trigger runPython
 
-    let result: any
+    let result: { output: string; error: string | null } | undefined
     await act(async () => {
-      result = await hookResult.runPython('print_large')
+      result = await hookResult!.runPython('print_large')
     })
 
     // Expect output to be truncated
     // 30000 'a' + '\n' + 30000 'b' + '\n' = 60002 chars
     // Limit is 50000 (assumed)
     // Check if output contains truncation message
-    expect(result.output).toContain('[Output truncated due to size limit]')
-    expect(result.output.length).toBeLessThan(60000)
+    expect(result!.output).toContain('[Output truncated due to size limit]')
+    expect(result!.output.length).toBeLessThan(60000)
   })
 
   it('returns the return value if no stdout', async () => {
-    let hookResult: any
+    let hookResult: ReturnType<typeof usePyodide>
 
     function TestComponent() {
       hookResult = usePyodide()
@@ -182,16 +182,16 @@ describe('usePyodide', () => {
       }
     })
 
-    let result: any
+    let result: { output: string; error: string | null } | undefined
     await act(async () => {
-      result = await hookResult.runPython('return_value')
+      result = await hookResult!.runPython('return_value')
     })
 
-    expect(result.output).toBe('Returned Value')
+    expect(result!.output).toBe('Returned Value')
   })
 
   it('handles timeout', async () => {
-    let hookResult: any
+    let hookResult: ReturnType<typeof usePyodide>
 
     function TestComponent() {
       hookResult = usePyodide()
@@ -227,13 +227,13 @@ describe('usePyodide', () => {
       )
     }
 
-    let result: any
+    let result: { output: string; error: string | null } | undefined
     await act(async () => {
       // Small timeout
-      result = await hookResult.runPython('sleep', { timeoutMs: 10 })
+      result = await hookResult!.runPython('sleep', { timeoutMs: 10 })
     })
 
-    expect(result).toEqual({
+    expect(result!).toEqual({
       output: '',
       error: 'Python execution timed out after 10ms.',
     })
@@ -253,7 +253,7 @@ describe('usePyodide', () => {
   })
 
   it('handles abort signal', async () => {
-    let hookResult: any
+    let hookResult: ReturnType<typeof usePyodide>
 
     function TestComponent() {
       hookResult = usePyodide()
@@ -282,10 +282,10 @@ describe('usePyodide', () => {
 
     const controller = new AbortController()
 
-    let resultPromise: Promise<any>
+    let resultPromise: Promise<{ output: string; error: string | null }>
 
     // Start execution
-    resultPromise = hookResult.runPython('sleep', { signal: controller.signal })
+    resultPromise = hookResult!.runPython('sleep', { signal: controller.signal })
 
     // Abort immediately
     controller.abort()

--- a/src/pages/__tests__/Curriculum.test.tsx
+++ b/src/pages/__tests__/Curriculum.test.tsx
@@ -34,7 +34,15 @@ vi.mock('../../utils/dayToken', () => ({
 
 vi.mock('motion/react', () => ({
   motion: {
-    div: ({ children, whileInView, initial, viewport, variants, transition, ...props }: any) => (
+    div: ({
+      children,
+      whileInView,
+      initial,
+      viewport,
+      variants,
+      transition,
+      ...props
+    }: Record<string, unknown> & { children?: React.ReactNode }) => (
       <div {...props}>{children}</div>
     ),
   },
@@ -45,7 +53,7 @@ vi.mock('motion/react', () => ({
 
 describe('Curriculum', () => {
   let container: HTMLDivElement | null = null
-  let root: any = null
+  let root: ReturnType<typeof createRoot> | null = null
 
   beforeEach(() => {
     container = document.createElement('div')
@@ -55,7 +63,7 @@ describe('Curriculum', () => {
 
   afterEach(() => {
     act(() => {
-      root.unmount()
+      root!.unmount()
     })
     if (container && container.parentNode) {
       container.parentNode.removeChild(container)
@@ -103,12 +111,14 @@ describe('Curriculum', () => {
       ] as unknown as ReturnType<typeof contentLoader.getLessonsByPhase>
     })
 
-    vi.mocked(useProgressStore).mockImplementation((selector: any) => {
+    vi.mocked(useProgressStore).mockImplementation(((
+      selector: (state: { completedLessons: number[] }) => unknown,
+    ) => {
       return selector({ completedLessons: [1] }) // numeric id as returned by mock
-    })
+    }) as unknown as typeof useProgressStore)
 
     act(() => {
-      root.render(
+      root!.render(
         <MemoryRouter>
           <Curriculum />
         </MemoryRouter>,

--- a/src/pages/__tests__/Home.test.tsx
+++ b/src/pages/__tests__/Home.test.tsx
@@ -40,7 +40,13 @@ vi.mock('../../components/AnimatedCounter', () => ({
 vi.mock('../../components/ProgressBar', () => ({ default: () => null }))
 
 vi.mock('../../stores/progressStore', () => {
-  const storeFn = (selector: any) =>
+  const storeFn = (
+    selector: (state: {
+      lastVisitedLesson: string | null
+      completedLessons: number[]
+      streakDays: () => number
+    }) => unknown,
+  ) =>
     selector({
       lastVisitedLesson: mockGetLastVisited(),
       completedLessons: Array.from({ length: mockGetCompletedCount() }).map((_, i) => i + 1),


### PR DESCRIPTION
Replaced `any` types with explicit strict signatures in three Vitest spec files: `Home.test.tsx`, `Curriculum.test.tsx`, and `usePyodide.test.tsx` to align with the repository's strict linting and typechecking rules. Verified via `tsc -b` and Vitest suites that the build passes cleanly.

---
*PR created automatically by Jules for task [15636973075822680844](https://jules.google.com/task/15636973075822680844) started by @saint2706*