### PR TITLE
⚡ Bolt: [Optimization] SidebarPhaseGroup prop equality fix

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,4 @@
 - Correctly mocked `getTotalReadingTime` and `getPhase` in `Home.test.tsx` and `Lesson.test.tsx` respectively.
 - Optimized Curriculum.tsx and ContentStats.tsx to use O(1) properties (getAllLessons().length and getTotalReadingTime()) instead of recalculating during renders. Reduced layout shift risks and main thread blocking.
 - Refactored legacy Zustand procedural facades (getCompletedCount, getLastVisited, getStreakDays) in Home.tsx, Curriculum.tsx, and ProgressDashboard.tsx directly into reactive store selectors (useProgressStore) to ensure O(1) reads and prevent redundant UI synchronizations.
+>> 2026-03-27 19:24:41 UTC - Optimized SidebarPhaseGroup.tsx to avoid passing Set objects as props, resolving React.memo equality breakdown and preventing global re-renders on individual lesson completion state changes. Reconstructed the Set locally during render using O(1) strings.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -221,7 +221,6 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
               key={phase.phase}
               phase={phase}
               isActive={openPhase === phase.phase}
-              completedSet={completedSet}
               completedIdsJoined={completedIdsByPhase[phase.phase] ?? ''}
               dueCount={dueByPhase[phase.phase] || 0}
               currentPath={location.pathname}

--- a/src/components/SidebarPhaseGroup.tsx
+++ b/src/components/SidebarPhaseGroup.tsx
@@ -15,7 +15,6 @@ import { dayTokenToProgressId } from '../utils/dayToken'
 interface SidebarPhaseGroupProps {
   phase: Phase
   isActive: boolean
-  completedSet: Set<number>
   completedIdsJoined: string
   dueCount: number
   currentPath: string
@@ -26,7 +25,6 @@ interface SidebarPhaseGroupProps {
 function SidebarPhaseGroup({
   phase,
   isActive,
-  completedSet,
   completedIdsJoined,
   dueCount,
   currentPath,
@@ -37,6 +35,10 @@ function SidebarPhaseGroup({
   const lessons = getLessonsByPhase(phase.phase)
   const icon = phaseIcons[phase.phase - 1] || '📖'
   const completedCount = completedIdsJoined ? completedIdsJoined.split(',').length : 0
+
+  // Reconstruct the Set from the primitive string prop to allow O(1) lookups during render
+  // without breaking React.memo props equality checks from the parent.
+  const completedSet = new Set(completedIdsJoined ? completedIdsJoined.split(',').map(Number) : [])
 
   return (
     <div className="phase-group">

--- a/src/components/__tests__/SidebarPhaseGroup.test.tsx
+++ b/src/components/__tests__/SidebarPhaseGroup.test.tsx
@@ -41,7 +41,6 @@ describe('SidebarPhaseGroup', () => {
   const defaultProps = {
     phase: { phase: 1, title: 'Foundations', days: ['01', '02'], content: '', path: '' },
     isActive: false,
-    completedSet: new Set<number>(),
     completedIdsJoined: '',
     dueCount: 0,
     currentPath: '/',
@@ -92,12 +91,7 @@ describe('SidebarPhaseGroup', () => {
     act(() => {
       root?.render(
         <MemoryRouter>
-          <SidebarPhaseGroup
-            {...defaultProps}
-            completedSet={new Set([1])} // Day 01
-            completedIdsJoined="1"
-            dueCount={3}
-          />
+          <SidebarPhaseGroup {...defaultProps} completedIdsJoined="1" dueCount={3} />
         </MemoryRouter>,
       )
     })


### PR DESCRIPTION
### ⚡ Bolt: SidebarPhaseGroup Rendering Optimization

**Issue:**
The collapsible `SidebarPhaseGroup` component accepted a `completedSet` (a `Set<number>`) as a prop from its parent, `Sidebar`. Since `Sidebar` recreated this `Set` whenever the total progress changed (`completedLessons`), the prop reference changed, bypassing the `React.memo` equality check on `SidebarPhaseGroup`. This forced *every* phase group in the sidebar to re-render whenever a user completed or reset a single lesson across the entire curriculum.

**Solution:**
- Removed `completedSet` from `SidebarPhaseGroupProps`.
- Passed the existing `completedIdsJoined` string (which is scoped per-phase and derived via `useMemo` in the parent).
- Reconstructed the `completedSet` locally within `SidebarPhaseGroup` during its render phase, enabling O(1) lookups without breaking prop equality.

**Verification:**
- Ran `npm run lint` successfully.
- Ran unit tests `npm run test` successfully, including updated test fixtures for `SidebarPhaseGroup.test.tsx`.
- Formatted via `npm run format`.
- Logged findings in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [6048157177310055228](https://jules.google.com/task/6048157177310055228) started by @saint2706*