### PR TITLE
🎨 Picasso: Add aria-hidden tags to decorative emojis

### DIFF
--- a/src/components/CodePlayground.tsx
+++ b/src/components/CodePlayground.tsx
@@ -242,7 +242,15 @@ const CodePlayground = forwardRef<CodePlaygroundHandle, CodePlaygroundProps>(
               }
               title={isConfirmingReset ? 'Click again to confirm reset' : 'Reset code to original'}
             >
-              {isConfirmingReset ? '⚠️ Confirm?' : '↺ Reset'}
+              {isConfirmingReset ? (
+                <>
+                  <span aria-hidden="true">⚠️</span> Confirm?
+                </>
+              ) : (
+                <>
+                  <span aria-hidden="true">↺</span> Reset
+                </>
+              )}
             </button>
           </div>
         </div>

--- a/src/components/ExerciseWidget.tsx
+++ b/src/components/ExerciseWidget.tsx
@@ -250,11 +250,19 @@ export default function ExerciseWidget({
             aria-expanded={showSolution}
             aria-controls={solutionId}
           >
-            {showSolution
-              ? '🔽 Hide Solution'
-              : hasSubmitted
-                ? '💡 Show Solution (Review Mode)'
-                : '💡 Show Solution'}
+            {showSolution ? (
+              <>
+                <span aria-hidden="true">🔽</span> Hide Solution
+              </>
+            ) : hasSubmitted ? (
+              <>
+                <span aria-hidden="true">💡</span> Show Solution (Review Mode)
+              </>
+            ) : (
+              <>
+                <span aria-hidden="true">💡</span> Show Solution
+              </>
+            )}
           </button>
           <AnimatePresence initial={false}>
             {showSolution && (
@@ -304,7 +312,15 @@ export default function ExerciseWidget({
                             : {}),
                         }}
                       >
-                        {isConfirmingSolution ? '⚠️ Confirm?' : '🚀 Try Solution'}
+                        {isConfirmingSolution ? (
+                          <>
+                            <span aria-hidden="true">⚠️</span> Confirm?
+                          </>
+                        ) : (
+                          <>
+                            <span aria-hidden="true">🚀</span> Try Solution
+                          </>
+                        )}
                       </button>
                       <CopyButton text={solution} className="code-block-copy" showEmoji={true} />
                     </div>

--- a/src/components/MasteryCheck.tsx
+++ b/src/components/MasteryCheck.tsx
@@ -65,7 +65,15 @@ export default function MasteryCheck({
         aria-expanded={revealed}
         {...(revealed && { 'aria-controls': answerId })}
       >
-        {revealed ? '🔽 Hide Answer' : '✅ Check Answer'}
+        {revealed ? (
+          <>
+            <span aria-hidden="true">🔽</span> Hide Answer
+          </>
+        ) : (
+          <>
+            <span aria-hidden="true">✅</span> Check Answer
+          </>
+        )}
       </button>
 
       {revealed && (


### PR DESCRIPTION
This PR introduces small accessibility (a11y) improvements to interactive elements across the application, guided by the Picasso persona priorities.

**Discovery & Motivation**
During an accessibility audit, it was found that several text-bearing action buttons contained decorative emojis (e.g., 🔄, 💡, ✅, ⚠️). Without proper ARIA tagging, screen readers natively read the names of these emojis out loud (e.g., "Warning sign Confirm?"). This creates redundant auditory clutter and slightly degrades the UX for users relying on assistive technologies.

**Implementation Details**
* Wrapped decorative emojis inside text buttons with `<span aria-hidden="true">`.
* Modified components:
  * `src/components/ExerciseWidget.tsx`
  * `src/components/CodePlayground.tsx`
  * `src/components/MasteryCheck.tsx`
* Touched zero layout, styling, or structural logic logic— purely semantic enhancements.
* The changes total fewer than 50 lines.

**Verification**
* Ran `npm run format` and `npm run lint` (zero warnings/errors).
* Executed test suite (`npm run test`), all 515 tests pass.
* Used Playwright to take a full-page snapshot of the application with the modified components; confirmed zero visual regressions or layout shifts.
* Learned and documented findings in `.jules/picasso.md` (to be pushed or kept in internal memory if not existing).

---
*PR created automatically by Jules for task [6656920478866717979](https://jules.google.com/task/6656920478866717979) started by @saint2706*