### PR TITLE
🧪 Testing: [Increase overall test coverage for utilities and components]

### DIFF
--- a/src/components/__tests__/CopyButton.test.tsx
+++ b/src/components/__tests__/CopyButton.test.tsx
@@ -160,4 +160,13 @@ describe('CopyButton', () => {
     expect(consoleSpy).toHaveBeenCalledWith('Failed to copy text to clipboard', expect.any(Error))
     consoleSpy.mockRestore()
   })
+
+  it('renders emoji when showEmoji is true', () => {
+    act(() => {
+      root?.render(<CopyButton text="some code" showEmoji />)
+    })
+
+    const button = container.querySelector('button')
+    expect(button?.textContent).toContain('📋 Copy')
+  })
 })

--- a/src/utils/__tests__/dayToken.test.ts
+++ b/src/utils/__tests__/dayToken.test.ts
@@ -4,9 +4,24 @@ import {
   dayTokenFromReference,
   dayTokenToProgressId,
   normalizeDayToken,
+  parseDayToken,
+  extractDayToken,
 } from '../dayToken'
 
 describe('dayToken utilities', () => {
+  it('normalizes invalid day tokens deterministically', () => {
+    expect(normalizeDayToken(null as any)).toBe('')
+    expect(normalizeDayToken(undefined as any)).toBe('')
+    expect(normalizeDayToken('')).toBe('')
+    expect(normalizeDayToken('invalid')).toBe('INVALID')
+  })
+
+  it('compares invalid day tokens deterministically', () => {
+    expect(compareDayTokens('invalidA', 'invalidA')).toBe(0)
+    expect(compareDayTokens('invalidA', 'invalidB')).toBe(-1)
+    expect(compareDayTokens('invalidB', 'invalidA')).toBe(1)
+  })
+
   it('normalizes and sorts alphanumeric day tokens deterministically', () => {
     const tokens = ['36C', '36', '36b', '37', '35']
     const sorted = [...tokens].sort(compareDayTokens)
@@ -34,5 +49,43 @@ describe('dayToken utilities', () => {
     expect(dayTokenToProgressId('36')).toBe(36)
     expect(dayTokenToProgressId('36B')).toBeGreaterThan(dayTokenToProgressId('36A'))
     expect(dayTokenToProgressId('36C')).toBeGreaterThan(dayTokenToProgressId('36B'))
+  })
+
+  it('parses day tokens correctly', () => {
+    expect(parseDayToken('36B')).toEqual({
+      token: '36B',
+      number: 36,
+      suffix: 'B',
+      sortKey: '00036:B',
+    })
+    expect(parseDayToken('invalid')).toBeNull()
+  })
+
+  it('extracts day tokens correctly', () => {
+    expect(extractDayToken('36B')).toBe('36B')
+    expect(extractDayToken(36)).toBe('36')
+    expect(extractDayToken(null)).toBeNull()
+    expect(extractDayToken('invalid')).toBeNull()
+  })
+
+  it('dayTokenFromPath returns null for invalid paths', () => {
+    expect(dayTokenFromPath('/some/random/path')).toBeNull()
+  })
+
+  it('dayTokenFromReference returns null for invalid references', () => {
+    expect(dayTokenFromReference('invalid reference')).toBeNull()
+    expect(dayTokenFromReference(null)).toBeNull()
+    expect(dayTokenFromReference({})).toBeNull()
+  })
+
+  it('dayTokenToProgressId handles invalid tokens and cache', () => {
+    expect(dayTokenToProgressId('invalid')).toBeNaN()
+    expect(dayTokenToProgressId('invalid')).toBeNaN() // check cache
+
+    expect(dayTokenToProgressId('36B')).toBe(360002)
+    expect(dayTokenToProgressId('36B')).toBe(360002) // check cache
+
+    expect(dayTokenToProgressId('36')).toBe(36)
+    expect(dayTokenToProgressId('36')).toBe(36) // check cache
   })
 })

--- a/src/utils/__tests__/slug.test.ts
+++ b/src/utils/__tests__/slug.test.ts
@@ -27,4 +27,21 @@ describe('slug utilities', () => {
     expect(slugger.slug('Profit Growth ROI')).toBe('profit-growth-roi-1')
     expect(slugger.slug('PROFIT growth roi')).toBe('profit-growth-roi-2')
   })
+
+  it('handles empty strings and default fallback', () => {
+    const slugger = createSlugger()
+    expect(slugger.slug('')).toBe('section')
+    expect(slugger.slug('')).toBe('section-1')
+  })
+
+  it('handles empty React nodes', () => {
+    expect(extractTextFromReactNode(null)).toBe('')
+    expect(extractTextFromReactNode(true)).toBe('')
+    expect(extractTextFromReactNode(false)).toBe('')
+    expect(extractTextFromReactNode(createElement('div', {}))).toBe('')
+  })
+
+  it('handles arbitrary objects gracefully', () => {
+    expect(extractTextFromReactNode({} as any)).toBe('')
+  })
 })


### PR DESCRIPTION
Increases overall codebase test coverage for the utilities `dayToken` and `slug`, specifically verifying edge case robustness against falsy parameters. Includes expanded test cases for `CopyButton` component prop attributes. Fixes coverage reporting on components.

---
*PR created automatically by Jules for task [11526947729343968487](https://jules.google.com/task/11526947729343968487) started by @saint2706*