### PR TITLE
🔍 Hunter: Fixed 3 errors - Removed `as any` type casting in tests

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -97,3 +97,8 @@
 - **Fixed:** Replaced `// @ts-expect-error` comments in `src/utils/__tests__/linkSafety.test.ts` with `as unknown as string` type assertions for invalid inputs.
 - **Fixed:** Replaced `as any` cast on JS module import in `src/utils/__tests__/contentSchemas.test.ts` with `as unknown as { ... }` type assertion.
 - **Verified:** Build, lint, and tests pass.
+## Session 16
+- **Fixed:** Removed leftover `as any` type casting in `src/utils/__tests__/slug.test.ts` by using `as unknown as React.ReactNode`.
+- **Fixed:** Removed leftover `as any` type casting in `src/utils/__tests__/dayToken.test.ts` by using `as unknown as string`.
+- **Fixed:** Removed leftover `as any` type casting for `root` variable in `src/pages/__tests__/ContentStats.test.tsx`, `src/pages/__tests__/NotFound.test.tsx`, and `src/pages/__tests__/PhaseOverview.test.tsx` by typing it correctly as `ReturnType<typeof createRoot> | null`.
+- **Verified:** Build, lint, and tests pass.

--- a/src/pages/__tests__/ContentStats.test.tsx
+++ b/src/pages/__tests__/ContentStats.test.tsx
@@ -25,7 +25,7 @@ vi.mock('../../utils/contentLoader', () => ({
 
 describe('ContentStats', () => {
   let container: HTMLDivElement | null = null
-  let root: any = null
+  let root: ReturnType<typeof createRoot> | null = null
 
   beforeEach(() => {
     container = document.createElement('div')
@@ -35,7 +35,7 @@ describe('ContentStats', () => {
 
   afterEach(() => {
     act(() => {
-      root.unmount()
+      root!.unmount()
     })
     if (container && container.parentNode) {
       container.parentNode.removeChild(container)
@@ -73,7 +73,7 @@ describe('ContentStats', () => {
     })
 
     act(() => {
-      root.render(
+      root!.render(
         <MemoryRouter>
           <ContentStats />
         </MemoryRouter>,

--- a/src/pages/__tests__/NotFound.test.tsx
+++ b/src/pages/__tests__/NotFound.test.tsx
@@ -16,7 +16,7 @@ vi.mock('../../utils/contentLoader', () => ({
 
 describe('NotFound', () => {
   let container: HTMLDivElement | null = null
-  let root: any = null
+  let root: ReturnType<typeof createRoot> | null = null
 
   beforeEach(() => {
     container = document.createElement('div')
@@ -26,7 +26,7 @@ describe('NotFound', () => {
 
   afterEach(() => {
     act(() => {
-      root.unmount()
+      root!.unmount()
     })
     if (container && container.parentNode) {
       container.parentNode.removeChild(container)
@@ -58,7 +58,7 @@ describe('NotFound', () => {
     ])
 
     act(() => {
-      root.render(
+      root!.render(
         <MemoryRouter>
           <NotFound />
         </MemoryRouter>,

--- a/src/pages/__tests__/PhaseOverview.test.tsx
+++ b/src/pages/__tests__/PhaseOverview.test.tsx
@@ -50,7 +50,7 @@ vi.mock('motion/react', () => ({
 
 describe('PhaseOverview', () => {
   let container: HTMLDivElement | null = null
-  let root: any = null
+  let root: ReturnType<typeof createRoot> | null = null
 
   beforeEach(() => {
     container = document.createElement('div')
@@ -60,7 +60,7 @@ describe('PhaseOverview', () => {
 
   afterEach(() => {
     act(() => {
-      root.unmount()
+      root!.unmount()
     })
     if (container && container.parentNode) {
       container.parentNode.removeChild(container)
@@ -77,7 +77,7 @@ describe('PhaseOverview', () => {
     )
 
     act(() => {
-      root.render(
+      root!.render(
         <MemoryRouter initialEntries={['/phase/99']}>
           <Routes>
             <Route path="/phase/:phaseNum" element={<PhaseOverview />} />
@@ -130,7 +130,7 @@ describe('PhaseOverview', () => {
     )
 
     act(() => {
-      root.render(
+      root!.render(
         <MemoryRouter initialEntries={['/phase/1']}>
           <Routes>
             <Route path="/phase/:phaseNum" element={<PhaseOverview />} />

--- a/src/utils/__tests__/dayToken.test.ts
+++ b/src/utils/__tests__/dayToken.test.ts
@@ -10,8 +10,8 @@ import {
 
 describe('dayToken utilities', () => {
   it('normalizes invalid day tokens deterministically', () => {
-    expect(normalizeDayToken(null as any)).toBe('')
-    expect(normalizeDayToken(undefined as any)).toBe('')
+    expect(normalizeDayToken(null as unknown as string)).toBe('')
+    expect(normalizeDayToken(undefined as unknown as string)).toBe('')
     expect(normalizeDayToken('')).toBe('')
     expect(normalizeDayToken('invalid')).toBe('INVALID')
   })

--- a/src/utils/__tests__/slug.test.ts
+++ b/src/utils/__tests__/slug.test.ts
@@ -42,6 +42,6 @@ describe('slug utilities', () => {
   })
 
   it('handles arbitrary objects gracefully', () => {
-    expect(extractTextFromReactNode({} as any)).toBe('')
+    expect(extractTextFromReactNode({} as unknown as React.ReactNode)).toBe('')
   })
 })


### PR DESCRIPTION
## Session 16
- **Fixed:** Removed leftover `as any` type casting in `src/utils/__tests__/slug.test.ts` by using `as unknown as React.ReactNode`.
- **Fixed:** Removed leftover `as any` type casting in `src/utils/__tests__/dayToken.test.ts` by using `as unknown as string`.
- **Fixed:** Removed leftover `as any` type casting for `root` variable in `src/pages/__tests__/ContentStats.test.tsx`, `src/pages/__tests__/NotFound.test.tsx`, and `src/pages/__tests__/PhaseOverview.test.tsx` by typing it correctly as `ReturnType<typeof createRoot> | null`.
- **Verified:** Build, lint, and tests pass.

---
*PR created automatically by Jules for task [15914883531166569284](https://jules.google.com/task/15914883531166569284) started by @saint2706*