### PR TITLE
🔍 Hunter: Fixed 1 errors - Removed type casting in contentSchemas tests

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -102,3 +102,6 @@
 - **Fixed:** Removed leftover `as any` type casting in `src/utils/__tests__/dayToken.test.ts` by using `as unknown as string`.
 - **Fixed:** Removed leftover `as any` type casting for `root` variable in `src/pages/__tests__/ContentStats.test.tsx`, `src/pages/__tests__/NotFound.test.tsx`, and `src/pages/__tests__/PhaseOverview.test.tsx` by typing it correctly as `ReturnType<typeof createRoot> | null`.
 - **Verified:** Build, lint, and tests pass.
+## Session 17
+- **Fixed:** Removed `as any` type casting in `src/utils/__tests__/contentSchemas.test.ts` by adding proper interface types for the destructured variables.
+- **Verified:** Build, lint, and tests pass.

--- a/src/utils/__tests__/contentSchemas.test.ts
+++ b/src/utils/__tests__/contentSchemas.test.ts
@@ -7,10 +7,30 @@ const {
   lessonFrontmatterSchema,
   phaseOverviewFrontmatterSchema,
 } = contentSchemas as unknown as {
-  difficultyLevelSchema: { safeParse: (data: unknown) => { success: boolean; error?: { issues: Array<{ path: Array<string | number> }> } } }
-  exerciseSchema: { safeParse: (data: unknown) => { success: boolean; error?: { issues: Array<{ path: Array<string | number> }> } } }
-  lessonFrontmatterSchema: { safeParse: (data: unknown) => { success: boolean; error?: { issues: Array<{ path: Array<string | number> }> } } }
-  phaseOverviewFrontmatterSchema: { safeParse: (data: unknown) => { success: boolean; error?: { issues: Array<{ path: Array<string | number> }> } } }
+  difficultyLevelSchema: {
+    safeParse: (data: unknown) => {
+      success: boolean
+      error?: { issues: Array<{ path: Array<string | number> }> }
+    }
+  }
+  exerciseSchema: {
+    safeParse: (data: unknown) => {
+      success: boolean
+      error?: { issues: Array<{ path: Array<string | number> }> }
+    }
+  }
+  lessonFrontmatterSchema: {
+    safeParse: (data: unknown) => {
+      success: boolean
+      error?: { issues: Array<{ path: Array<string | number> }> }
+    }
+  }
+  phaseOverviewFrontmatterSchema: {
+    safeParse: (data: unknown) => {
+      success: boolean
+      error?: { issues: Array<{ path: Array<string | number> }> }
+    }
+  }
 }
 
 describe('content zod schemas', () => {

--- a/src/utils/__tests__/contentSchemas.test.ts
+++ b/src/utils/__tests__/contentSchemas.test.ts
@@ -7,10 +7,10 @@ const {
   lessonFrontmatterSchema,
   phaseOverviewFrontmatterSchema,
 } = contentSchemas as unknown as {
-  difficultyLevelSchema: any
-  exerciseSchema: any
-  lessonFrontmatterSchema: any
-  phaseOverviewFrontmatterSchema: any
+  difficultyLevelSchema: { safeParse: (data: unknown) => { success: boolean; error?: { issues: Array<{ path: Array<string | number> }> } } }
+  exerciseSchema: { safeParse: (data: unknown) => { success: boolean; error?: { issues: Array<{ path: Array<string | number> }> } } }
+  lessonFrontmatterSchema: { safeParse: (data: unknown) => { success: boolean; error?: { issues: Array<{ path: Array<string | number> }> } } }
+  phaseOverviewFrontmatterSchema: { safeParse: (data: unknown) => { success: boolean; error?: { issues: Array<{ path: Array<string | number> }> } } }
 }
 
 describe('content zod schemas', () => {
@@ -44,7 +44,7 @@ describe('content zod schemas', () => {
 
     if (result.success) throw new Error('Expected invalid lesson fixture to fail')
     expect(
-      result.error.issues.map((issue: { path: Array<string | number> }) => issue.path.join('.')),
+      result.error?.issues.map((issue: { path: Array<string | number> }) => issue.path.join('.')),
     ).toEqual(expect.arrayContaining(['day', 'title', 'difficulty', 'duration', 'tags.1']))
   })
 


### PR DESCRIPTION
This PR addresses the \`any\` type usage in \`src/utils/__tests__/contentSchemas.test.ts\` by adding a specific interface for Zod-like \`safeParse\` results. It eliminates type casting lint concerns without modifying actual test logic and incorporates a fix for a compiler warning regarding \`result.error\` being potentially undefined. Build and lint passes ✅.

---
*PR created automatically by Jules for task [13076539580778883161](https://jules.google.com/task/13076539580778883161) started by @saint2706*