### PR TITLE
🔍 Hunter: Fixed 4 errors - removed "as any" type casts in store tests

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -105,3 +105,7 @@
 ## Session 17
 - **Fixed:** Removed `as any` type casting in `src/utils/__tests__/contentSchemas.test.ts` by adding proper interface types for the destructured variables.
 - **Verified:** Build, lint, and tests pass.
+
+## Session 18
+- **Fixed:** Replaced `as any` type casting with proper type assertions (`as unknown as ReturnType<typeof ...getState>` and `import('zustand/middleware').StorageValue<unknown>`) in `src/stores/__tests__/userPreferencesStore.test.ts`, `src/stores/__tests__/gamificationStore.test.ts`, `src/stores/__tests__/learningAnalyticsStore.test.ts`, and `src/stores/__tests__/progressStore.test.ts`.
+- **Verified:** Build, lint, and tests pass.

--- a/src/stores/__tests__/gamificationStore.test.ts
+++ b/src/stores/__tests__/gamificationStore.test.ts
@@ -321,7 +321,9 @@ describe('gamificationStore persisted storage edge cases', () => {
 
   it('covers migrate function failure block', () => {
     const migrate = useGamificationStore.persist.getOptions().migrate!
-    const parsed = migrate({ xpTotal: 'not a number' }, 1) as any
+    const parsed = migrate({ xpTotal: 'not a number' }, 1) as unknown as ReturnType<
+      typeof useGamificationStore.getState
+    >
     expect(parsed.xpTotal).toBe(0)
   })
 })
@@ -347,7 +349,9 @@ it('covers safe storage catch blocks', () => {
 
   const storage = useGamificationStore.persist.getOptions().storage!
   expect(storage.getItem('test')).toBe(null) // Should catch and return null
-  expect(() => storage.setItem('test', 'value' as any)).not.toThrow() // Should ignore
+  expect(() =>
+    storage.setItem('test', 'value' as unknown as import('zustand/middleware').StorageValue<unknown>),
+  ).not.toThrow() // Should ignore
   expect(() => storage.removeItem('test')).not.toThrow() // Should ignore
 
   // Restore localStorage
@@ -371,10 +375,12 @@ it('covers migrate success and Zod transform', () => {
 
   // Line 378 is return defaultValue when parsing fails but Zod with catches won't fail normally.
   // However, if we pass null or undefined, Zod might succeed but return defaults via catch.
-  const result1 = migrate(validState, 1) as any
+  const result1 = migrate(validState, 1) as unknown as ReturnType<
+    typeof useGamificationStore.getState
+  >
   expect(result1.xpTotal).toBe(100)
 
-  const result2 = migrate(null, 1) as any
+  const result2 = migrate(null, 1) as unknown as ReturnType<typeof useGamificationStore.getState>
   expect(result2.xpTotal).toBe(0)
 })
 
@@ -388,6 +394,8 @@ it('covers migrate failure block (line 378)', () => {
 
   // Pass a primitive that is not an object, which might fail z.object() even if fields have catch,
   // actually z.object().safeParse("string") will fail because it's not an object!
-  const result3 = migrate('this is a string, not an object', 1) as any
+  const result3 = migrate('this is a string, not an object', 1) as unknown as ReturnType<
+    typeof useGamificationStore.getState
+  >
   expect(result3.xpTotal).toBe(0) // Should hit line 378 and return defaults
 })

--- a/src/stores/__tests__/gamificationStore.test.ts
+++ b/src/stores/__tests__/gamificationStore.test.ts
@@ -350,7 +350,10 @@ it('covers safe storage catch blocks', () => {
   const storage = useGamificationStore.persist.getOptions().storage!
   expect(storage.getItem('test')).toBe(null) // Should catch and return null
   expect(() =>
-    storage.setItem('test', 'value' as unknown as import('zustand/middleware').StorageValue<unknown>),
+    storage.setItem(
+      'test',
+      'value' as unknown as import('zustand/middleware').StorageValue<unknown>,
+    ),
   ).not.toThrow() // Should ignore
   expect(() => storage.removeItem('test')).not.toThrow() // Should ignore
 

--- a/src/stores/__tests__/learningAnalyticsStore.test.ts
+++ b/src/stores/__tests__/learningAnalyticsStore.test.ts
@@ -90,7 +90,10 @@ it('covers store setup and missing coverage (migrate, partialize, hydration, err
   const storage = options.storage!
   expect(storage.getItem('test')).toBe(null) // Should catch and return null
   expect(() =>
-    storage.setItem('test', 'value' as unknown as import('zustand/middleware').StorageValue<unknown>),
+    storage.setItem(
+      'test',
+      'value' as unknown as import('zustand/middleware').StorageValue<unknown>,
+    ),
   ).not.toThrow() // Should ignore
   expect(() => storage.removeItem('test')).not.toThrow() // Should ignore
 
@@ -116,9 +119,10 @@ it('covers store setup and missing coverage (migrate, partialize, hydration, err
   expect(partial).toHaveProperty('visitsByLessonDay')
 
   // 4. migrate (314) and normalizePersistedState logic
-  const migratedState = options.migrate!({ timeByLessonDay: 'invalid' }, 1) as unknown as ReturnType<
-    typeof useLearningAnalyticsStore.getState
-  >
+  const migratedState = options.migrate!(
+    { timeByLessonDay: 'invalid' },
+    1,
+  ) as unknown as ReturnType<typeof useLearningAnalyticsStore.getState>
   expect(migratedState.timeByLessonDay).toEqual({})
 
   // 5. todayLearningMs (286)
@@ -180,9 +184,8 @@ it('covers parsing missing states or values from migrate', () => {
 it('covers returning default from normalize if parse fails (line 119)', () => {
   const normalize = useLearningAnalyticsStore.persist.getOptions().migrate!
   // Since Zod has catch everywhere, the only way parsed.success is false is if we pass a completely malformed object structure like a string
-  const normalized = normalize(
-    'completely invalid',
-    1,
-  ) as unknown as ReturnType<typeof useLearningAnalyticsStore.getState>
+  const normalized = normalize('completely invalid', 1) as unknown as ReturnType<
+    typeof useLearningAnalyticsStore.getState
+  >
   expect(normalized.timeByLessonDay).toEqual({})
 })

--- a/src/stores/__tests__/learningAnalyticsStore.test.ts
+++ b/src/stores/__tests__/learningAnalyticsStore.test.ts
@@ -89,7 +89,9 @@ it('covers store setup and missing coverage (migrate, partialize, hydration, err
   const options = useLearningAnalyticsStore.persist.getOptions()
   const storage = options.storage!
   expect(storage.getItem('test')).toBe(null) // Should catch and return null
-  expect(() => storage.setItem('test', 'value' as any)).not.toThrow() // Should ignore
+  expect(() =>
+    storage.setItem('test', 'value' as unknown as import('zustand/middleware').StorageValue<unknown>),
+  ).not.toThrow() // Should ignore
   expect(() => storage.removeItem('test')).not.toThrow() // Should ignore
 
   // Restore localStorage
@@ -114,7 +116,9 @@ it('covers store setup and missing coverage (migrate, partialize, hydration, err
   expect(partial).toHaveProperty('visitsByLessonDay')
 
   // 4. migrate (314) and normalizePersistedState logic
-  const migratedState = options.migrate!({ timeByLessonDay: 'invalid' }, 1) as any
+  const migratedState = options.migrate!({ timeByLessonDay: 'invalid' }, 1) as unknown as ReturnType<
+    typeof useLearningAnalyticsStore.getState
+  >
   expect(migratedState.timeByLessonDay).toEqual({})
 
   // 5. todayLearningMs (286)
@@ -166,7 +170,7 @@ it('covers parsing missing states or values from migrate', () => {
       visitsByLessonDay: { b: 10, '2': 2 },
     },
     1,
-  ) as any
+  ) as unknown as ReturnType<typeof useLearningAnalyticsStore.getState>
 
   expect(normalized.timeByLessonDay).toEqual({ 1: 50 })
   expect(normalized.timeByDate).toEqual({})
@@ -176,6 +180,9 @@ it('covers parsing missing states or values from migrate', () => {
 it('covers returning default from normalize if parse fails (line 119)', () => {
   const normalize = useLearningAnalyticsStore.persist.getOptions().migrate!
   // Since Zod has catch everywhere, the only way parsed.success is false is if we pass a completely malformed object structure like a string
-  const normalized = normalize('completely invalid', 1) as any
+  const normalized = normalize(
+    'completely invalid',
+    1,
+  ) as unknown as ReturnType<typeof useLearningAnalyticsStore.getState>
   expect(normalized.timeByLessonDay).toEqual({})
 })

--- a/src/stores/__tests__/progressStore.test.ts
+++ b/src/stores/__tests__/progressStore.test.ts
@@ -143,7 +143,10 @@ it('covers storage catch blocks', () => {
   const storage = useProgressStore.persist.getOptions().storage!
   expect(storage.getItem('test')).toBe(null)
   expect(() =>
-    storage.setItem('test', 'value' as unknown as import('zustand/middleware').StorageValue<unknown>),
+    storage.setItem(
+      'test',
+      'value' as unknown as import('zustand/middleware').StorageValue<unknown>,
+    ),
   ).not.toThrow()
   expect(() => storage.removeItem('test')).not.toThrow()
 

--- a/src/stores/__tests__/progressStore.test.ts
+++ b/src/stores/__tests__/progressStore.test.ts
@@ -142,7 +142,9 @@ it('covers storage catch blocks', () => {
 
   const storage = useProgressStore.persist.getOptions().storage!
   expect(storage.getItem('test')).toBe(null)
-  expect(() => storage.setItem('test', 'value' as any)).not.toThrow()
+  expect(() =>
+    storage.setItem('test', 'value' as unknown as import('zustand/middleware').StorageValue<unknown>),
+  ).not.toThrow()
   expect(() => storage.removeItem('test')).not.toThrow()
 
   Object.defineProperty(global, 'localStorage', { value: originalLocalStorage })
@@ -152,11 +154,15 @@ it('covers migrate legacy paths', () => {
   const migrate = useProgressStore.persist.getOptions().migrate!
 
   // Simulate legacy string array
-  const migrated1 = migrate(['1', '2'], 1) as any
+  const migrated1 = migrate(['1', '2'], 1) as unknown as ReturnType<
+    typeof useProgressStore.getState
+  >
   expect(migrated1.completedLessons).toEqual([])
 
   // Simulate parsing failure where state is not an object or array
-  const migrated2 = migrate('not valid', 1) as any
+  const migrated2 = migrate('not valid', 1) as unknown as ReturnType<
+    typeof useProgressStore.getState
+  >
   expect(migrated2.completedLessons).toEqual([])
 })
 
@@ -209,7 +215,7 @@ it('covers parsing valid days and mergeLegacyLastVisited (line 143-146)', () => 
       completionDates: {},
     },
     1,
-  ) as any
+  ) as unknown as ReturnType<typeof useProgressStore.getState>
 
   expect(migrated.lastVisitedLesson).toBe(42)
 
@@ -233,7 +239,7 @@ it('covers migrate parsing bad lastVisitedLesson', () => {
       lastVisitedLesson: -5, // negative is caught
     },
     1,
-  ) as any
+  ) as unknown as ReturnType<typeof useProgressStore.getState>
   expect(migrated.lastVisitedLesson).toBe(null) // assuming legacy doesn't have it
 })
 
@@ -248,7 +254,9 @@ it('covers parsing bad lastVisited legacy values', () => {
   })
 
   const migrate = useProgressStore.persist.getOptions().migrate!
-  const migrated = migrate({ completedLessons: [] }, 1) as any
+  const migrated = migrate({ completedLessons: [] }, 1) as unknown as ReturnType<
+    typeof useProgressStore.getState
+  >
   expect(migrated.lastVisitedLesson).toBe(null) // Hits line 144
 
   Object.defineProperty(global, 'localStorage', { value: originalLocalStorage })
@@ -257,6 +265,8 @@ it('covers parsing bad lastVisited legacy values', () => {
 it('covers returning default from migrate if parse fails completely', () => {
   const migrate = useProgressStore.persist.getOptions().migrate!
   // safeParse fails when value is not an object or completely malformed
-  const result = migrate('this is a string, not an object', 1) as any
+  const result = migrate('this is a string, not an object', 1) as unknown as ReturnType<
+    typeof useProgressStore.getState
+  >
   expect(result.completedLessons).toEqual([]) // Hits line 160 fallback logic
 })

--- a/src/stores/__tests__/userPreferencesStore.test.ts
+++ b/src/stores/__tests__/userPreferencesStore.test.ts
@@ -164,7 +164,10 @@ it('covers storage catch blocks', () => {
   const storage = useUserPreferencesStore.persist.getOptions().storage!
   expect(storage.getItem('test')).toBe(null)
   expect(() =>
-    storage.setItem('test', 'value' as unknown as import('zustand/middleware').StorageValue<unknown>),
+    storage.setItem(
+      'test',
+      'value' as unknown as import('zustand/middleware').StorageValue<unknown>,
+    ),
   ).not.toThrow()
   expect(() => storage.removeItem('test')).not.toThrow()
 
@@ -185,12 +188,18 @@ it('covers migrate legacy paths and fallback on complete parse failure', () => {
 
   // Test legacy themes
   expect(
-    (migrate({ theme: 'light' }, 1) as unknown as ReturnType<typeof useUserPreferencesStore.getState>)
-      .palette,
+    (
+      migrate({ theme: 'light' }, 1) as unknown as ReturnType<
+        typeof useUserPreferencesStore.getState
+      >
+    ).palette,
   ).toBe('light-steel')
   expect(
-    (migrate({ theme: 'dark' }, 1) as unknown as ReturnType<typeof useUserPreferencesStore.getState>)
-      .palette,
+    (
+      migrate({ theme: 'dark' }, 1) as unknown as ReturnType<
+        typeof useUserPreferencesStore.getState
+      >
+    ).palette,
   ).toBe('gradient-blues')
   expect(
     (

--- a/src/stores/__tests__/userPreferencesStore.test.ts
+++ b/src/stores/__tests__/userPreferencesStore.test.ts
@@ -163,7 +163,9 @@ it('covers storage catch blocks', () => {
 
   const storage = useUserPreferencesStore.persist.getOptions().storage!
   expect(storage.getItem('test')).toBe(null)
-  expect(() => storage.setItem('test', 'value' as any)).not.toThrow()
+  expect(() =>
+    storage.setItem('test', 'value' as unknown as import('zustand/middleware').StorageValue<unknown>),
+  ).not.toThrow()
   expect(() => storage.removeItem('test')).not.toThrow()
 
   Object.defineProperty(global, 'localStorage', { value: originalLocalStorage })
@@ -172,7 +174,9 @@ it('covers storage catch blocks', () => {
 it('covers migrate failure block (line 160)', () => {
   const migrate = useUserPreferencesStore.persist.getOptions().migrate!
   // safeParse fails when value is not an object or completely malformed
-  const result = migrate('this is a string, not an object', 1) as any
+  const result = migrate('this is a string, not an object', 1) as unknown as ReturnType<
+    typeof useUserPreferencesStore.getState
+  >
   expect(result.palette).toBe('gradient-blues') // default fallback
 })
 
@@ -180,9 +184,21 @@ it('covers migrate legacy paths and fallback on complete parse failure', () => {
   const migrate = useUserPreferencesStore.persist.getOptions().migrate!
 
   // Test legacy themes
-  expect((migrate({ theme: 'light' }, 1) as any).palette).toBe('light-steel')
-  expect((migrate({ theme: 'dark' }, 1) as any).palette).toBe('gradient-blues')
-  expect((migrate({ theme: 'system' }, 1) as any).palette).toBe('gradient-blues')
+  expect(
+    (migrate({ theme: 'light' }, 1) as unknown as ReturnType<typeof useUserPreferencesStore.getState>)
+      .palette,
+  ).toBe('light-steel')
+  expect(
+    (migrate({ theme: 'dark' }, 1) as unknown as ReturnType<typeof useUserPreferencesStore.getState>)
+      .palette,
+  ).toBe('gradient-blues')
+  expect(
+    (
+      migrate({ theme: 'system' }, 1) as unknown as ReturnType<
+        typeof useUserPreferencesStore.getState
+      >
+    ).palette,
+  ).toBe('gradient-blues')
 
   // To trigger the final fallback, we need to pass something that fails Zod's safeParse.
   // However, if the schema is just z.object() and we pass an object, it succeeds.


### PR DESCRIPTION
This PR addresses type safety warnings by removing leftover `as any` type casts within the store test files (`src/stores/__tests__/*.test.ts`).

The type casts have been replaced with proper TypeScript assertions (`as unknown as ReturnType<typeof store.getState>` and `import('zustand/middleware').StorageValue<unknown>`), resolving strict typing issues without modifying the actual test logic or runtime behavior.

The build has been verified to pass successfully, and the progress has been documented in `.jules/hunter-progress.md`.

---
*PR created automatically by Jules for task [4235422060574227758](https://jules.google.com/task/4235422060574227758) started by @saint2706*