### PR TITLE
📚 Docs: Add missing JSDoc comments to exported functions

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -60,3 +60,4 @@
 - **Completed:** Checked for broken links across `.md` files; no broken user-facing links were found.
 - **Completed:** Updated `CONTRIBUTING.md` to explicitly state the JSDoc requirements for exported functions and React components.
 - **Verified:** Ensured `npm run test`, `npm run format`, and `npm run lint` all passed after making these changes.
+>> Added missing JSDoc comments to App.tsx, SearchResults.tsx, Curriculum.tsx, and ThemeProvider.tsx to ensure documentation accuracy and completeness.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,11 @@ const MobileNav = lazy(() => import('./components/MobileNav'))
 const KeyboardShortcutsOverlay = lazy(() => import('./components/KeyboardShortcutsOverlay'))
 const CustomCursor = lazy(() => import('./components/CustomCursor'))
 
+/**
+ * Main application component that sets up routing, layout, and global context providers.
+ *
+ * @returns The main application element tree.
+ */
 export default function App() {
   const sidebarDefaultOpen = useUserPreferencesStore((state) => state.sidebarDefaultOpen)
   const customCursorEnabled = useUserPreferencesStore((state) => state.customCursorEnabled)

--- a/src/context/ThemeProvider.tsx
+++ b/src/context/ThemeProvider.tsx
@@ -22,6 +22,16 @@ function getPaletteType(palette: ColorPalette): 'dark' | 'light' {
   return DARK_PALETTES.includes(palette) ? 'dark' : 'light'
 }
 
+/**
+ * Theme Provider component.
+ *
+ * Wraps the application to provide theme context and injects CSS variables
+ * for palette, font size, and density settings based on user preferences.
+ *
+ * @param props - The component props.
+ * @param props.children - The child components to render.
+ * @returns The theme provider element tree.
+ */
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const palette = useUserPreferencesStore((state) => state.palette)
   const setPalette = useUserPreferencesStore((state) => state.setPalette)

--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -24,6 +24,7 @@ import {
 import { dayTokenToProgressId } from '../utils/dayToken'
 import Breadcrumb from '../components/Breadcrumb'
 import ProgressBar from '../components/ProgressBar'
+import { useProgressStore } from '../stores/progressStore'
 
 /**
  * Curriculum roadmap page component.
@@ -34,9 +35,6 @@ import ProgressBar from '../components/ProgressBar'
  *
  * @returns The rendered curriculum roadmap page
  */
-
-import { useProgressStore } from '../stores/progressStore'
-
 export default function Curriculum() {
   const phases = getAllPhases()
   const prefersReducedMotion = useReducedMotion()

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -18,6 +18,14 @@ import {
   type SearchResult,
 } from '../utils/searchIndex'
 
+/**
+ * Search results page component.
+ *
+ * Provides a search interface for finding lessons and content across the curriculum.
+ * Features a debounced search input, keyboard shortcuts, and highlights matched terms.
+ *
+ * @returns The rendered search results page.
+ */
 export default function SearchResults() {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()


### PR DESCRIPTION
Adds missing JSDoc comments to exported functions and components to improve documentation completeness and adhere to the project's export JSDoc requirement. Also fixes a structural issue in `Curriculum.tsx` where an import statement was placed between a JSDoc block and its corresponding export.

### Changed Files
- `src/App.tsx`: Added JSDoc for the default exported App component.
- `src/pages/SearchResults.tsx`: Added JSDoc for the SearchResults component.
- `src/pages/Curriculum.tsx`: Added missing JSDoc and moved the `useProgressStore` import to properly associate the documentation block with the export.
- `src/context/ThemeProvider.tsx`: Added JSDoc for the ThemeProvider component.

---
*PR created automatically by Jules for task [10094601344626428746](https://jules.google.com/task/10094601344626428746) started by @saint2706*