### PR TITLE
🔍 Hunter: Fixed 4 errors - Replaced 'any' types in test mocks

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -109,3 +109,10 @@
 ## Session 18
 - **Fixed:** Replaced `as any` type casting with proper type assertions (`as unknown as ReturnType<typeof ...getState>` and `import('zustand/middleware').StorageValue<unknown>`) in `src/stores/__tests__/userPreferencesStore.test.ts`, `src/stores/__tests__/gamificationStore.test.ts`, `src/stores/__tests__/learningAnalyticsStore.test.ts`, and `src/stores/__tests__/progressStore.test.ts`.
 - **Verified:** Build, lint, and tests pass.
+
+## Session 19
+- **Fixed:** Replaced `any` type casting with proper type assertions `(selector: (state: { completedLessons: string[] }) => unknown)` for `useProgressStore` selector mock in `src/pages/__tests__/Lesson.test.tsx`.
+- **Fixed:** Replaced `any` type casting with proper props types for component mocks (`MarkdownRenderer` with `{ content: string }`, `CodePlayground` with `{ initialCode: string }`) in `src/pages/__tests__/NotebookViewer.test.tsx`.
+- **Fixed:** Replaced `any` type casting with proper props type `{ value: number; suffix?: string }` for `AnimatedCounter` mock in `src/pages/__tests__/ContentStats.test.tsx`.
+- **Fixed:** Replaced `any` type casting with proper props types for component mocks (`MarkdownRenderer` with `{ content: string }`, `motion.div` with `React.ComponentProps<'div'>`) in `src/pages/__tests__/CaseStudies.test.tsx`.
+- **Verified:** Build, lint, and tests pass.

--- a/src/pages/__tests__/CaseStudies.test.tsx
+++ b/src/pages/__tests__/CaseStudies.test.tsx
@@ -10,7 +10,7 @@ vi.mock('../../components/SEOHead', () => ({
 }))
 
 vi.mock('../../components/MarkdownRenderer', () => ({
-  default: ({ content }: any) => <div data-testid="markdown-renderer">{content}</div>,
+  default: ({ content }: { content: string }) => <div data-testid="markdown-renderer">{content}</div>,
 }))
 
 vi.mock('../../utils/contentLoader', () => ({
@@ -25,7 +25,14 @@ vi.mock('../../utils/contentLoader', () => ({
 
 vi.mock('motion/react', () => ({
   motion: {
-    div: ({ children, layout, initial, animate, transition, ...props }: any) => (
+    div: ({
+      children,
+      layout,
+      initial,
+      animate,
+      transition,
+      ...props
+    }: React.ComponentProps<'div'> & { layout?: boolean; initial?: unknown; animate?: unknown; transition?: unknown }) => (
       <div {...props}>{children}</div>
     ),
   },

--- a/src/pages/__tests__/CaseStudies.test.tsx
+++ b/src/pages/__tests__/CaseStudies.test.tsx
@@ -10,7 +10,9 @@ vi.mock('../../components/SEOHead', () => ({
 }))
 
 vi.mock('../../components/MarkdownRenderer', () => ({
-  default: ({ content }: { content: string }) => <div data-testid="markdown-renderer">{content}</div>,
+  default: ({ content }: { content: string }) => (
+    <div data-testid="markdown-renderer">{content}</div>
+  ),
 }))
 
 vi.mock('../../utils/contentLoader', () => ({
@@ -32,9 +34,12 @@ vi.mock('motion/react', () => ({
       animate,
       transition,
       ...props
-    }: React.ComponentProps<'div'> & { layout?: boolean; initial?: unknown; animate?: unknown; transition?: unknown }) => (
-      <div {...props}>{children}</div>
-    ),
+    }: React.ComponentProps<'div'> & {
+      layout?: boolean
+      initial?: unknown
+      animate?: unknown
+      transition?: unknown
+    }) => <div {...props}>{children}</div>,
   },
 }))
 

--- a/src/pages/__tests__/ContentStats.test.tsx
+++ b/src/pages/__tests__/ContentStats.test.tsx
@@ -10,7 +10,7 @@ vi.mock('../../components/SEOHead', () => ({
 }))
 
 vi.mock('../../components/AnimatedCounter', () => ({
-  default: ({ value, suffix }: any) => (
+  default: ({ value, suffix }: { value: number; suffix?: string }) => (
     <span data-testid="counter">
       {value}
       {suffix || ''}

--- a/src/pages/__tests__/Lesson.test.tsx
+++ b/src/pages/__tests__/Lesson.test.tsx
@@ -48,7 +48,8 @@ vi.mock('../../utils/progressTracker', () => ({
 
 vi.mock('../../stores/progressStore', () => ({
   useProgressStore: Object.assign(
-    (selector: (state: { completedLessons: string[] }) => unknown) => selector({ completedLessons: mockGetCompletedLessons() }),
+    (selector: (state: { completedLessons: string[] }) => unknown) =>
+      selector({ completedLessons: mockGetCompletedLessons() }),
     {
       getState: () => ({
         completedLessons: mockGetCompletedLessons(),

--- a/src/pages/__tests__/Lesson.test.tsx
+++ b/src/pages/__tests__/Lesson.test.tsx
@@ -48,7 +48,7 @@ vi.mock('../../utils/progressTracker', () => ({
 
 vi.mock('../../stores/progressStore', () => ({
   useProgressStore: Object.assign(
-    (selector: any) => selector({ completedLessons: mockGetCompletedLessons() }),
+    (selector: (state: { completedLessons: string[] }) => unknown) => selector({ completedLessons: mockGetCompletedLessons() }),
     {
       getState: () => ({
         completedLessons: mockGetCompletedLessons(),

--- a/src/pages/__tests__/NotebookViewer.test.tsx
+++ b/src/pages/__tests__/NotebookViewer.test.tsx
@@ -14,11 +14,15 @@ vi.mock('../../components/Breadcrumb', () => ({
 }))
 
 vi.mock('../../components/MarkdownRenderer', () => ({
-  default: ({ content }: { content: string }) => <div data-testid="markdown-renderer">{content}</div>,
+  default: ({ content }: { content: string }) => (
+    <div data-testid="markdown-renderer">{content}</div>
+  ),
 }))
 
 vi.mock('../../components/CodePlayground', () => ({
-  default: ({ initialCode }: { initialCode: string }) => <div data-testid="code-playground">{initialCode}</div>,
+  default: ({ initialCode }: { initialCode: string }) => (
+    <div data-testid="code-playground">{initialCode}</div>
+  ),
 }))
 
 vi.mock('../../components/BackToTop', () => ({

--- a/src/pages/__tests__/NotebookViewer.test.tsx
+++ b/src/pages/__tests__/NotebookViewer.test.tsx
@@ -14,11 +14,11 @@ vi.mock('../../components/Breadcrumb', () => ({
 }))
 
 vi.mock('../../components/MarkdownRenderer', () => ({
-  default: ({ content }: any) => <div data-testid="markdown-renderer">{content}</div>,
+  default: ({ content }: { content: string }) => <div data-testid="markdown-renderer">{content}</div>,
 }))
 
 vi.mock('../../components/CodePlayground', () => ({
-  default: ({ initialCode }: any) => <div data-testid="code-playground">{initialCode}</div>,
+  default: ({ initialCode }: { initialCode: string }) => <div data-testid="code-playground">{initialCode}</div>,
 }))
 
 vi.mock('../../components/BackToTop', () => ({


### PR DESCRIPTION
This PR autonomously fixes 4 `any` type casting issues in the Vitest suite in accordance with the Hunter persona's Priority 2 (Lint Errors/Types) directive.

Fixes include:
1. `src/pages/__tests__/Lesson.test.tsx`: Replaced `any` with a typed function signature `(selector: (state: { completedLessons: string[] }) => unknown)` for the `useProgressStore` selector.
2. `src/pages/__tests__/NotebookViewer.test.tsx`: Replaced `any` with explicit prop interfaces (`{ content: string }`, `{ initialCode: string }`) for `MarkdownRenderer` and `CodePlayground` component mocks.
3. `src/pages/__tests__/ContentStats.test.tsx`: Replaced `any` with `{ value: number; suffix?: string }` for the `AnimatedCounter` mock.
4. `src/pages/__tests__/CaseStudies.test.tsx`: Replaced `any` with `{ content: string }` for the `MarkdownRenderer` mock and `React.ComponentProps<'div'>` for the `motion.div` mock to strictly allow spreading HTML attributes onto native divs.

The build, lint (`tsc -b`), and full test suite (`vitest run`) pass cleanly. Progress logged to `.jules/hunter-progress.md` under Session 19.

---
*PR created automatically by Jules for task [15546513315265274533](https://jules.google.com/task/15546513315265274533) started by @saint2706*