### PR TITLE
📚 Docs: Add missing JSDoc comments to exports

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -77,3 +77,4 @@ Added complete and well-formatted JSDoc to the following exported components, fu
 - `src/utils/frontmatter-core.d.ts`: Added JSDoc for `ParsedMarkdown`.
 - `src/utils/linkSafety.ts`: Added JSDoc for `LinkProps`.
 - `src/utils/searchIndex.ts`: Added JSDoc for `SearchResult` and `SearchIndexStatus`.
+- **Completed:** Added missing JSDoc comments to Breadcrumb.tsx, ExerciseCard.tsx, MarkdownRenderer.tsx, SidebarPhaseGroup.tsx, userPreferencesStore.ts, contentLoader.ts, curriculumConfig.ts, exercise-extractor-core.d.ts, exerciseExtractor.ts, frontmatter-core.d.ts, searchIndex.ts, and shortcuts.ts to ensure documentation accuracy and completeness.

--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -11,6 +11,9 @@
 
 import { Link } from 'react-router-dom'
 
+/**
+ * Represents a single item in the breadcrumb navigation.
+ */
 export interface BreadcrumbItem {
   label: string
   to?: string

--- a/src/components/ExerciseCard.tsx
+++ b/src/components/ExerciseCard.tsx
@@ -46,4 +46,12 @@ function ExerciseCard({ exercise }: ExerciseCardProps) {
   )
 }
 
+/**
+ * Renders a single exercise item in the exercises list.
+ * Memoized to prevent re-rendering when list filters change but the item itself remains the same.
+ *
+ * @param {ExerciseCardProps} props - The component props.
+ * @param {Exercise} props.exercise - The exercise data to render.
+ * @returns {JSX.Element} The exercise card component.
+ */
 export default memo(ExerciseCard)

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -721,5 +721,17 @@ function MarkdownRenderer({ content }: MarkdownRendererProps) {
   )
 }
 
+/**
+ * Interactive block utilities and types for parsing mastery questions and exercises.
+ */
 export { findInteractiveBlocks, type ParsedMasteryQuestion, type ParsedExercise }
+
+/**
+ * Render lesson markdown with safe HTML, custom code blocks, glossary tooltips,
+ * and interactive exercise/mastery widgets. Memoized to prevent unnecessary re-renders.
+ *
+ * @param {MarkdownRendererProps} props - The component properties.
+ * @param {string} props.content - The raw markdown content string to be rendered.
+ * @returns {React.ReactElement} The rendered markdown content wrapped in a responsive container.
+ */
 export default memo(MarkdownRenderer)

--- a/src/components/SidebarPhaseGroup.tsx
+++ b/src/components/SidebarPhaseGroup.tsx
@@ -179,4 +179,11 @@ function propsAreEqual(
   return true
 }
 
+/**
+ * Renders an accordion group of lessons for a specific phase in the sidebar curriculum.
+ * Memoized to prevent re-rendering when navigation occurs outside of the current phase.
+ *
+ * @param {SidebarPhaseGroupProps} props - The component props.
+ * @returns {JSX.Element} The phase group accordion block.
+ */
 export default memo(SidebarPhaseGroup, propsAreEqual)

--- a/src/stores/userPreferencesStore.ts
+++ b/src/stores/userPreferencesStore.ts
@@ -33,10 +33,24 @@ const DensityPreferenceSchema = z.enum(['comfortable', 'compact'])
  * Available color palette themes for the user interface.
  */
 export type ColorPalette = z.infer<typeof ColorPaletteSchema>
+/**
+ * Editor font size preference.
+ */
 export type FontSizePreference = z.infer<typeof FontSizePreferenceSchema>
+
+/**
+ * Default programming language preference for code examples.
+ */
 export type CodeLanguagePreference = z.infer<typeof CodeLanguagePreferenceSchema>
+
+/**
+ * UI layout density preference.
+ */
 export type DensityPreference = z.infer<typeof DensityPreferenceSchema>
 
+/**
+ * Zustand store state shape for user UI preferences.
+ */
 export type UserPreferencesStore = {
   palette: ColorPalette
   sidebarDefaultOpen: boolean

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -42,7 +42,9 @@ export interface Lesson {
   [key: string]: unknown
 }
 
-/** Phase metadata and overview markdown content. */
+/**
+ * Phase metadata and overview markdown content.
+ */
 export interface Phase {
   phase: number
   title: string
@@ -54,7 +56,9 @@ export interface Phase {
   [key: string]: unknown
 }
 
-/** A bonus file from a phase's extras/ folder. */
+/**
+ * A bonus file from a phase's extras/ folder.
+ */
 export interface ExtraFile {
   phase: number
   filename: string
@@ -237,7 +241,9 @@ export function getAdjacentLessons(dayNum: string | number): {
   }
 }
 
-/** Exercise parsed from lesson markdown. */
+/**
+ * Exercise parsed from lesson markdown.
+ */
 export interface Exercise {
   id: string
   day: DayToken
@@ -407,7 +413,9 @@ export function getAllReviewCardSeeds(): readonly ImmutableReviewCardSeed[] {
   return immutableReviewCards
 }
 
-/** Jupyter notebook cell shape used by imported phase notebooks. */
+/**
+ * Jupyter notebook cell shape used by imported phase notebooks.
+ */
 export interface NotebookCell {
   cell_type: 'code' | 'markdown' | 'raw'
   source: readonly string[]
@@ -422,7 +430,9 @@ export interface NotebookCell {
   execution_count?: number | null
 }
 
-/** Parsed notebook metadata for a phase solution file. */
+/**
+ * Parsed notebook metadata for a phase solution file.
+ */
 export interface Notebook {
   phase: number
   cells: readonly NotebookCell[]
@@ -844,6 +854,10 @@ export function getRelatedLessons(lesson: Readonly<Lesson>, count = 4): readonly
   return result
 }
 
+/**
+ * UI configuration objects exported for external components
+ * to map phase numbers to icons and difficulty tags to colors.
+ */
 export { difficultyConfig, phaseIcons }
 
 /** Shared shape for a case study or capstone project entry. */
@@ -857,10 +871,14 @@ export interface ProjectLike {
   path: string
 }
 
-/** A case study entry parsed from a case-studies README. */
+/**
+ * A case study entry parsed from a case-studies README.
+ */
 export type CaseStudy = ProjectLike
 
-/** A project entry parsed from a projects README. */
+/**
+ * A project entry parsed from a projects README.
+ */
 export type Project = ProjectLike
 
 const caseStudyFiles = import.meta.glob('/content/case-studies/**/README.md', {

--- a/src/utils/curriculumConfig.ts
+++ b/src/utils/curriculumConfig.ts
@@ -26,7 +26,16 @@ const phaseIconsSchema = z.array(z.string().min(1)).length(9)
  * Defines the label text, foreground color, and background color.
  */
 export type DifficultyInfo = z.infer<typeof difficultyInfoSchema>
+
+/**
+ * Record mapping string keys to DifficultyInfo schemas, defining visual styles
+ * for different difficulty levels.
+ */
 export type DifficultyConfig = z.infer<typeof difficultyConfigSchema>
+
+/**
+ * Ordered array of strings used as icons representing different curriculum phases.
+ */
 export type PhaseIcons = z.infer<typeof phaseIconsSchema>
 
 /**

--- a/src/utils/exercise-extractor-core.d.ts
+++ b/src/utils/exercise-extractor-core.d.ts
@@ -1,3 +1,7 @@
+/**
+ * Represents the structure of an exercise extracted from markdown content.
+ * Lacks overarching lesson metadata.
+ */
 export interface ExtractedExercise {
   title: string
   goal: string

--- a/src/utils/exerciseExtractor.ts
+++ b/src/utils/exerciseExtractor.ts
@@ -1,5 +1,9 @@
 import { extractExercisesFromContent, ExtractedExercise } from './exercise-extractor-core.js'
 
+/**
+ * Type representing an extracted exercise from raw markdown.
+ * Lacks overarching lesson metadata.
+ */
 export type { ExtractedExercise }
 
 /**

--- a/src/utils/frontmatter-core.d.ts
+++ b/src/utils/frontmatter-core.d.ts
@@ -1,3 +1,7 @@
+/**
+ * Represents structured frontmatter data extracted from a markdown document.
+ * Values can be strings, numbers, booleans, or arrays of strings/numbers.
+ */
 export interface Frontmatter {
   [key: string]: string | number | boolean | (string | number)[]
 }

--- a/src/utils/searchIndex.ts
+++ b/src/utils/searchIndex.ts
@@ -15,6 +15,10 @@ import Fuse, { type IFuseOptions } from 'fuse.js'
 import { getAllLessons, type Lesson } from './contentLoader'
 import { parseDayToken } from './dayToken'
 
+/**
+ * Represents a document in the search index, extending a standard Lesson
+ * with additional pre-computed string fields optimized for searching and indexing.
+ */
 export interface SearchDocument extends Lesson {
   plainContent: string
   dayText: string

--- a/src/utils/shortcuts.ts
+++ b/src/utils/shortcuts.ts
@@ -9,8 +9,14 @@
  * - Provide a utility to detect if a user is typing in an input field.
  */
 
+/**
+ * Defines the logical scope in which a keyboard shortcut is active.
+ */
 export type ShortcutScope = 'Global' | 'Search' | 'Lesson' | 'Review'
 
+/**
+ * Represents a predefined keyboard shortcut mapping.
+ */
 export interface ShortcutDefinition {
   keys: string
   description: string


### PR DESCRIPTION
Added JSDoc/TSDoc to previously undocumented exported interfaces, types, and components across the codebase.

---
*PR created automatically by Jules for task [15447668951377755287](https://jules.google.com/task/15447668951377755287) started by @saint2706*