### PR TITLE
🎨 Picasso: [UX improvement] Add ARIA labels to toggle buttons

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -41,3 +41,4 @@ Added aria-hidden='true' wrapper to decorative emojis across navigation and head
 Learned that missing aria labels for decorative emojis in React can be fixed by wrapping them with <span aria-hidden='true'></span> and fixing text assertions in React Testing Library using getByRole instead of getByText
 - Added `aria-hidden='true'` to the decorative phase icon in `ExerciseCard.tsx`.
 - Added `focus-visible` utility classes to the close button in `KeyboardShortcutsOverlay.tsx` to improve keyboard navigation.
+>> Added aria-labels to SidebarPhaseGroup and ExerciseWidget toggle buttons to improve accessibility for screen readers.

--- a/src/components/ExerciseWidget.tsx
+++ b/src/components/ExerciseWidget.tsx
@@ -249,6 +249,7 @@ export default function ExerciseWidget({
             onClick={handleToggleSolution}
             aria-expanded={showSolution}
             aria-controls={solutionId}
+            aria-label="Toggle solution"
           >
             {showSolution ? (
               <>

--- a/src/components/SidebarPhaseGroup.tsx
+++ b/src/components/SidebarPhaseGroup.tsx
@@ -48,6 +48,7 @@ function SidebarPhaseGroup({
         onClick={() => onToggle(phase.phase)}
         aria-expanded={isActive}
         aria-controls={`phase-${phase.phase}-days`}
+        aria-label={`Toggle phase ${phase.phase}`}
       >
         <span className="phase-toggle-icon" aria-hidden="true">
           {icon}


### PR DESCRIPTION
As the Picasso persona, I identified two interactive toggle buttons that relied solely on visual context or complex nested elements for their accessible name. I added clear `aria-label` attributes to these buttons (`SidebarPhaseGroup` and `ExerciseWidget` components) to improve the experience for screen reader users and fulfill accessibility guidelines.

All tests, builds, and linting have passed.

---
*PR created automatically by Jules for task [1673166672642209605](https://jules.google.com/task/1673166672642209605) started by @saint2706*