### PR TITLE
📚 Docs: Fix missing JSDoc return tags

### DIFF
--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -17,8 +17,9 @@ import { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'
  * - Provide quick access to primary app sections (Home, Learn, Progress, Explore).
  * - Highlight active route state.
  * - Hide on desktop viewports via CSS media queries.
+ *
+ * @returns {JSX.Element} The rendered mobile navigation bar.
  */
-
 export default function MobileNav() {
   const location = useLocation()
   const isLesson = location.pathname.startsWith('/lesson/')

--- a/src/hooks/useLearningAnalytics.ts
+++ b/src/hooks/useLearningAnalytics.ts
@@ -19,7 +19,8 @@ let activeSubscribers = 0
  * Tracks engagement time for a specific route.
  * Handles visibility changes (pausing/resuming) and cleanup automatically.
  *
- * @param route - The identifier for the current route/page (e.g., "Lesson 1").
+ * @param {string} route - The identifier for the current route/page (e.g., "Lesson 1").
+ * @returns {void}
  */
 export function useLearningAnalytics(route: string): void {
   useEffect(() => {

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -35,8 +35,9 @@ function getRatingLabel(rating: ReviewRating): string {
  * - Display cards one by one (Front -> Reveal -> Rate).
  * - Handle user ratings (Again/Hard/Good/Easy) to update schedules.
  * - Show daily streak and total due count.
+ *
+ * @returns {JSX.Element} The rendered review page.
  */
-
 export default function Review() {
   const [now, setNow] = useState(() => new Date())
   const [showAnswer, setShowAnswer] = useState(false)

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -652,6 +652,8 @@ let contentStatsCache: {
 /**
  * Retrieves comprehensive content statistics for the curriculum.
  * The statistics are computed once and cached to avoid O(N) recalculations on render.
+ *
+ * @returns {ContentStats} Comprehensive statistics about the curriculum content.
  */
 export function getContentStats() {
   if (contentStatsCache === null) {

--- a/src/utils/prefetchRoutes.ts
+++ b/src/utils/prefetchRoutes.ts
@@ -35,6 +35,7 @@ const prefetchedRoutes = new Set<string>()
  * Safe to call multiple times; will only load once.
  *
  * @param {string} path - The route path to prefetch (e.g., '/lesson/1').
+ * @returns {void}
  */
 export function prefetchRoute(path: string) {
   if (prefetchedRoutes.has(path)) {

--- a/src/utils/reviewTracker.ts
+++ b/src/utils/reviewTracker.ts
@@ -247,6 +247,8 @@ export function getReviewStreak(now = new Date()): number {
 
 /**
  * Clears all review state from localStorage and cache.
+ *
+ * @returns {void}
  */
 export function clearReviewState(): void {
   reviewStateCache = null

--- a/src/utils/searchIndex.ts
+++ b/src/utils/searchIndex.ts
@@ -283,6 +283,8 @@ function processChunk() {
  * Initiates background processing to build the search index.
  * It chunks document processing during browser idle time to avoid freezing the UI.
  * Once complete, the cached engine is available for fast searching.
+ *
+ * @returns {void}
  */
 export function startBackgroundIndexing(): void {
   if (isIndexing || indexingComplete || cachedEngine) return
@@ -377,6 +379,8 @@ export function getSearchSnippet(content: string, query: string, maxLength = 180
 /**
  * Safely triggers the background preloading of the search index.
  * Designed to be called on idle, deferring the heavy work of parsing documents.
+ *
+ * @returns {void}
  */
 export function preloadSearchIndex(): void {
   try {


### PR DESCRIPTION
I have audited the codebase and added missing `@returns` JSDoc comments to exported functions and components.

The initial automated attempt falsely added `@returns {void}` to functions that returned actual values, which I subsequently fixed. The changes are strictly confined to comments and don't introduce regressions, as verified by the CI scripts (`npm run test`, `npm run lint`, `npm run format`, and `npm run build`).

---
*PR created automatically by Jules for task [13954027485130745930](https://jules.google.com/task/13954027485130745930) started by @saint2706*