### PR TITLE
📚 Docs: Audit documentation and improve JSDoc script

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -78,3 +78,8 @@ Added complete and well-formatted JSDoc to the following exported components, fu
 - `src/utils/linkSafety.ts`: Added JSDoc for `LinkProps`.
 - `src/utils/searchIndex.ts`: Added JSDoc for `SearchResult` and `SearchIndexStatus`.
 - **Completed:** Added missing JSDoc comments to Breadcrumb.tsx, ExerciseCard.tsx, MarkdownRenderer.tsx, SidebarPhaseGroup.tsx, userPreferencesStore.ts, contentLoader.ts, curriculumConfig.ts, exercise-extractor-core.d.ts, exerciseExtractor.ts, frontmatter-core.d.ts, searchIndex.ts, and shortcuts.ts to ensure documentation accuracy and completeness.
+- Audited README and verified What's Inside section is up to date (up to Phase 12).
+- Checked for broken internal links. No broken links found outside node_modules.
+- Verified no missing JSDoc comments for exported functions and components in `src/` folder.
+- Checked docs/todo.md against README.md, everything looks accurate.
+- Ensured build passes (no errors or warnings).

--- a/scripts/find-missing-jsdoc.cjs
+++ b/scripts/find-missing-jsdoc.cjs
@@ -20,7 +20,7 @@ function findMissingJSDoc(dir) {
   return files;
 }
 
-const allFiles = [...findMissingJSDoc('src/utils'), ...findMissingJSDoc('src/components')];
+const allFiles = findMissingJSDoc('src');
 
 const missing = [];
 


### PR DESCRIPTION
Audited documentation to ensure consistency with the codebase and `todo.md`. Updated `scripts/find-missing-jsdoc.cjs` to search the entire `src` directory for missing JSDoc comments to improve linting coverage. Logged progress in `.jules/docs-progress.md`. Validated links, JSDoc coverage, and build successfully.

---
*PR created automatically by Jules for task [627049623576234352](https://jules.google.com/task/627049623576234352) started by @saint2706*