### PR TITLE
🧪 Testing: Add unit tests for ThemeContext components

### DIFF
--- a/src/context/__tests__/ThemeProvider.test.tsx
+++ b/src/context/__tests__/ThemeProvider.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { ThemeProvider } from '../ThemeProvider'
+import * as userPreferencesStore from '../../stores/userPreferencesStore'
+import { ThemeContext } from '../ThemeContext'
+
+// Mock the user preferences store
+vi.mock('../../stores/userPreferencesStore', async () => {
+  const actual = await vi.importActual('../../stores/userPreferencesStore')
+  return {
+    ...actual,
+    useUserPreferencesStore: vi.fn()
+  }
+})
+
+describe('ThemeProvider', () => {
+  const mockSetPalette = vi.fn()
+
+  const setupMockStore = (overrides = {}) => {
+    const defaultState = {
+      palette: 'gradient-blues',
+      setPalette: mockSetPalette,
+      fontSize: 'md',
+      density: 'comfortable',
+      ...overrides
+    }
+
+    vi.mocked(userPreferencesStore.useUserPreferencesStore).mockImplementation((selector: any) => {
+      return selector(defaultState)
+    })
+  }
+
+  beforeEach(() => {
+    // Reset DOM state before each test
+    document.documentElement.removeAttribute('data-palette')
+    document.documentElement.removeAttribute('data-palette-type')
+    document.documentElement.removeAttribute('data-density')
+    document.documentElement.removeAttribute('data-font-size')
+    document.documentElement.style.removeProperty('--app-font-size')
+    document.documentElement.style.removeProperty('--density-scale')
+
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('renders children correctly', () => {
+    setupMockStore()
+
+    render(
+      <ThemeProvider>
+        <div data-testid="child-element">Child Content</div>
+      </ThemeProvider>
+    )
+
+    expect(screen.getByTestId('child-element')).toBeDefined()
+    expect(screen.getByText('Child Content')).toBeDefined()
+  })
+
+  it('provides the correct context values', () => {
+    setupMockStore({ palette: 'neon-party' })
+
+    let contextValue: any
+
+    const ContextConsumer = () => {
+      return (
+        <ThemeContext.Consumer>
+          {(value) => {
+            contextValue = value
+            return null
+          }}
+        </ThemeContext.Consumer>
+      )
+    }
+
+    render(
+      <ThemeProvider>
+        <ContextConsumer />
+      </ThemeProvider>
+    )
+
+    expect(contextValue.palette).toBe('neon-party')
+
+    contextValue.setPalette('deep-ocean-blue')
+    expect(mockSetPalette).toHaveBeenCalledWith('deep-ocean-blue')
+  })
+
+  describe('Palette injection', () => {
+    it('applies dark palette type for dark palettes', () => {
+      setupMockStore({ palette: 'neon-party' }) // neon-party is a dark palette
+
+      render(<ThemeProvider><div /></ThemeProvider>)
+
+      expect(document.documentElement.getAttribute('data-palette')).toBe('neon-party')
+      expect(document.documentElement.getAttribute('data-palette-type')).toBe('dark')
+    })
+
+    it('applies light palette type for light palettes', () => {
+      setupMockStore({ palette: 'minimalist-monochrome' }) // minimalist-monochrome is light
+
+      render(<ThemeProvider><div /></ThemeProvider>)
+
+      expect(document.documentElement.getAttribute('data-palette')).toBe('minimalist-monochrome')
+      expect(document.documentElement.getAttribute('data-palette-type')).toBe('light')
+    })
+  })
+
+  describe('Typography and Density injection', () => {
+    it('applies default (md/comfortable) values correctly', () => {
+      setupMockStore({ fontSize: 'md', density: 'comfortable' })
+
+      render(<ThemeProvider><div /></ThemeProvider>)
+
+      expect(document.documentElement.style.getPropertyValue('--app-font-size')).toBe('1rem')
+      expect(document.documentElement.style.getPropertyValue('--density-scale')).toBe('1')
+      expect(document.documentElement.dataset.fontSize).toBe('md')
+      expect(document.documentElement.dataset.density).toBe('comfortable')
+    })
+
+    it('applies small font size correctly', () => {
+      setupMockStore({ fontSize: 'sm' })
+
+      render(<ThemeProvider><div /></ThemeProvider>)
+
+      expect(document.documentElement.style.getPropertyValue('--app-font-size')).toBe('0.9375rem')
+      expect(document.documentElement.dataset.fontSize).toBe('sm')
+    })
+
+    it('applies large font size correctly', () => {
+      setupMockStore({ fontSize: 'lg' })
+
+      render(<ThemeProvider><div /></ThemeProvider>)
+
+      expect(document.documentElement.style.getPropertyValue('--app-font-size')).toBe('1.0625rem')
+      expect(document.documentElement.dataset.fontSize).toBe('lg')
+    })
+
+    it('applies compact density correctly', () => {
+      setupMockStore({ density: 'compact' })
+
+      render(<ThemeProvider><div /></ThemeProvider>)
+
+      expect(document.documentElement.style.getPropertyValue('--density-scale')).toBe('0.88')
+      expect(document.documentElement.dataset.density).toBe('compact')
+    })
+  })
+})

--- a/src/context/__tests__/ThemeProvider.test.tsx
+++ b/src/context/__tests__/ThemeProvider.test.tsx
@@ -9,7 +9,7 @@ vi.mock('../../stores/userPreferencesStore', async () => {
   const actual = await vi.importActual('../../stores/userPreferencesStore')
   return {
     ...actual,
-    useUserPreferencesStore: vi.fn()
+    useUserPreferencesStore: vi.fn(),
   }
 })
 
@@ -22,7 +22,7 @@ describe('ThemeProvider', () => {
       setPalette: mockSetPalette,
       fontSize: 'md',
       density: 'comfortable',
-      ...overrides
+      ...overrides,
     }
 
     vi.mocked(userPreferencesStore.useUserPreferencesStore).mockImplementation((selector: any) => {
@@ -52,7 +52,7 @@ describe('ThemeProvider', () => {
     render(
       <ThemeProvider>
         <div data-testid="child-element">Child Content</div>
-      </ThemeProvider>
+      </ThemeProvider>,
     )
 
     expect(screen.getByTestId('child-element')).toBeDefined()
@@ -78,7 +78,7 @@ describe('ThemeProvider', () => {
     render(
       <ThemeProvider>
         <ContextConsumer />
-      </ThemeProvider>
+      </ThemeProvider>,
     )
 
     expect(contextValue.palette).toBe('neon-party')
@@ -91,7 +91,11 @@ describe('ThemeProvider', () => {
     it('applies dark palette type for dark palettes', () => {
       setupMockStore({ palette: 'neon-party' }) // neon-party is a dark palette
 
-      render(<ThemeProvider><div /></ThemeProvider>)
+      render(
+        <ThemeProvider>
+          <div />
+        </ThemeProvider>,
+      )
 
       expect(document.documentElement.getAttribute('data-palette')).toBe('neon-party')
       expect(document.documentElement.getAttribute('data-palette-type')).toBe('dark')
@@ -100,7 +104,11 @@ describe('ThemeProvider', () => {
     it('applies light palette type for light palettes', () => {
       setupMockStore({ palette: 'minimalist-monochrome' }) // minimalist-monochrome is light
 
-      render(<ThemeProvider><div /></ThemeProvider>)
+      render(
+        <ThemeProvider>
+          <div />
+        </ThemeProvider>,
+      )
 
       expect(document.documentElement.getAttribute('data-palette')).toBe('minimalist-monochrome')
       expect(document.documentElement.getAttribute('data-palette-type')).toBe('light')
@@ -111,7 +119,11 @@ describe('ThemeProvider', () => {
     it('applies default (md/comfortable) values correctly', () => {
       setupMockStore({ fontSize: 'md', density: 'comfortable' })
 
-      render(<ThemeProvider><div /></ThemeProvider>)
+      render(
+        <ThemeProvider>
+          <div />
+        </ThemeProvider>,
+      )
 
       expect(document.documentElement.style.getPropertyValue('--app-font-size')).toBe('1rem')
       expect(document.documentElement.style.getPropertyValue('--density-scale')).toBe('1')
@@ -122,7 +134,11 @@ describe('ThemeProvider', () => {
     it('applies small font size correctly', () => {
       setupMockStore({ fontSize: 'sm' })
 
-      render(<ThemeProvider><div /></ThemeProvider>)
+      render(
+        <ThemeProvider>
+          <div />
+        </ThemeProvider>,
+      )
 
       expect(document.documentElement.style.getPropertyValue('--app-font-size')).toBe('0.9375rem')
       expect(document.documentElement.dataset.fontSize).toBe('sm')
@@ -131,7 +147,11 @@ describe('ThemeProvider', () => {
     it('applies large font size correctly', () => {
       setupMockStore({ fontSize: 'lg' })
 
-      render(<ThemeProvider><div /></ThemeProvider>)
+      render(
+        <ThemeProvider>
+          <div />
+        </ThemeProvider>,
+      )
 
       expect(document.documentElement.style.getPropertyValue('--app-font-size')).toBe('1.0625rem')
       expect(document.documentElement.dataset.fontSize).toBe('lg')
@@ -140,7 +160,11 @@ describe('ThemeProvider', () => {
     it('applies compact density correctly', () => {
       setupMockStore({ density: 'compact' })
 
-      render(<ThemeProvider><div /></ThemeProvider>)
+      render(
+        <ThemeProvider>
+          <div />
+        </ThemeProvider>,
+      )
 
       expect(document.documentElement.style.getPropertyValue('--density-scale')).toBe('0.88')
       expect(document.documentElement.dataset.density).toBe('compact')

--- a/src/context/__tests__/useTheme.test.tsx
+++ b/src/context/__tests__/useTheme.test.tsx
@@ -1,0 +1,34 @@
+import { renderHook } from '@testing-library/react'
+import { vi, describe, it, expect } from 'vitest'
+import { ReactNode } from 'react'
+import { useTheme } from '../useTheme'
+import { ThemeContext } from '../ThemeContext'
+import type { ColorPalette } from '../../stores/userPreferencesStore'
+
+describe('useTheme', () => {
+  it('returns the default context value when not wrapped in a provider', () => {
+    const { result } = renderHook(() => useTheme())
+
+    expect(result.current.palette).toBe('gradient-blues')
+    expect(typeof result.current.setPalette).toBe('function')
+  })
+
+  it('returns the provided context value when wrapped in a provider', () => {
+    const mockSetPalette = vi.fn()
+    const customPalette: ColorPalette = 'neon-party'
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ThemeContext.Provider value={{ palette: customPalette, setPalette: mockSetPalette }}>
+        {children}
+      </ThemeContext.Provider>
+    )
+
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    expect(result.current.palette).toBe(customPalette)
+
+    // Test the setPalette function
+    result.current.setPalette('pastel-dreamland')
+    expect(mockSetPalette).toHaveBeenCalledWith('pastel-dreamland')
+  })
+})


### PR DESCRIPTION
🧪 Testing: Added comprehensive unit tests for `useTheme` and `ThemeProvider` inside `src/context/` to increase overall test coverage and verify context-based CSS variable injection logic.

---
*PR created automatically by Jules for task [633447515818530335](https://jules.google.com/task/633447515818530335) started by @saint2706*