### PR TITLE
🎨 Picasso: Polish ErrorBoundary buttons accessibility

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -42,3 +42,4 @@ Learned that missing aria labels for decorative emojis in React can be fixed by 
 - Added `aria-hidden='true'` to the decorative phase icon in `ExerciseCard.tsx`.
 - Added `focus-visible` utility classes to the close button in `KeyboardShortcutsOverlay.tsx` to improve keyboard navigation.
 >> Added aria-labels to SidebarPhaseGroup and ExerciseWidget toggle buttons to improve accessibility for screen readers.
+\n### ErrorBoundary Accessibility Fix\n**Date:** 2024-05-20\n**Goal:** Improve keyboard accessibility for ErrorBoundary fallback UI.\n**Changes Made:**\n- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` to the retry and reload buttons in `src/components/ErrorBoundary.tsx`.\n**Learning:** To ensure keyboard accessibility for custom interactive elements (e.g., buttons lacking default focus states), apply standard Tailwind utility classes to maintain visual consistency across the application.

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -56,10 +56,18 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
           <h1>Something went wrong</h1>
           <p>We hit an unexpected issue while loading this page.</p>
           <div>
-            <button type="button" onClick={this.handleRetry}>
+            <button
+              type="button"
+              className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+              onClick={this.handleRetry}
+            >
               Try again
             </button>
-            <button type="button" onClick={this.handleReload}>
+            <button
+              type="button"
+              className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+              onClick={this.handleReload}
+            >
               Reload page
             </button>
           </div>


### PR DESCRIPTION
Improves keyboard accessibility for the fallback UI buttons in the `ErrorBoundary` component by adding the project's standard `focus-visible` utility classes. This ensures that users navigating via keyboard can clearly see which button has focus when an error occurs.

---
*PR created automatically by Jules for task [1689957504549887667](https://jules.google.com/task/1689957504549887667) started by @saint2706*