### PR TITLE
🔍 Hunter: Fixed 4 any type errors - Removed remaining implicit any usages

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -142,3 +142,10 @@
 ## Session 24
 - **Fixed:** Resolved `TypeError: activeLink.scrollIntoView is not a function` in `src/components/__tests__/SidebarPerf.test.tsx` by globally mocking `window.HTMLElement.prototype.scrollIntoView = vi.fn()` within the `src/test/setup.ts` JSDOM environment config.
 - **Verified:** Build, lint, and tests pass successfully without unhandled exceptions.
+
+## Session 25
+- **Fixed:** Removed `any` type in `src/components/__tests__/SidebarPerf.test.tsx` by updating Zustand store mock typing.
+- **Fixed:** Removed `any` type in `src/components/__tests__/Sidebar.test.tsx` by updating Zustand store mock typing.
+- **Fixed:** Removed `any` type in `src/hooks/__tests__/useLearningAnalytics.test.tsx` by updating mock state type to `Partial<ReturnType<typeof useLearningAnalyticsStore.getState>>`.
+- **Fixed:** Removed `any` type in `src/utils/rehype-slug-custom.ts` by correctly casting the recursive node element.
+- **Verified:** Build, lint, and tests pass successfully without unhandled exceptions.

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -21,11 +21,9 @@ vi.mock('../../utils/contentLoader', async () => {
 
 // Mock store
 const useProgressStoreMock = vi.fn((selector) =>
-  selector(
-    { completedLessons: [] } as unknown as ReturnType<
-      typeof import('../../stores/progressStore').useProgressStore.getState
-    >
-  )
+  selector({ completedLessons: [] } as unknown as ReturnType<
+    typeof import('../../stores/progressStore').useProgressStore.getState
+  >),
 )
 vi.mock('../../stores/progressStore', () => ({
   useProgressStore: (selector: (state: unknown) => unknown) => useProgressStoreMock(selector),

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -20,9 +20,15 @@ vi.mock('../../utils/contentLoader', async () => {
 })
 
 // Mock store
-const useProgressStoreMock = vi.fn((selector) => selector({ completedLessons: [] }))
+const useProgressStoreMock = vi.fn((selector) =>
+  selector(
+    { completedLessons: [] } as unknown as ReturnType<
+      typeof import('../../stores/progressStore').useProgressStore.getState
+    >
+  )
+)
 vi.mock('../../stores/progressStore', () => ({
-  useProgressStore: (selector: any) => useProgressStoreMock(selector),
+  useProgressStore: (selector: (state: unknown) => unknown) => useProgressStoreMock(selector),
 }))
 
 vi.mock('../../utils/reviewTracker', () => ({

--- a/src/components/__tests__/SidebarPerf.test.tsx
+++ b/src/components/__tests__/SidebarPerf.test.tsx
@@ -14,11 +14,9 @@ vi.mock('../../utils/contentLoader', () => ({
 
 // Mock store
 const useProgressStoreMock = vi.fn((selector) =>
-  selector(
-    { completedLessons: [] } as unknown as ReturnType<
-      typeof import('../../stores/progressStore').useProgressStore.getState
-    >
-  )
+  selector({ completedLessons: [] } as unknown as ReturnType<
+    typeof import('../../stores/progressStore').useProgressStore.getState
+  >),
 )
 vi.mock('../../stores/progressStore', () => ({
   useProgressStore: (selector: (state: unknown) => unknown) => useProgressStoreMock(selector),

--- a/src/components/__tests__/SidebarPerf.test.tsx
+++ b/src/components/__tests__/SidebarPerf.test.tsx
@@ -13,9 +13,15 @@ vi.mock('../../utils/contentLoader', () => ({
 }))
 
 // Mock store
-const useProgressStoreMock = vi.fn((selector) => selector({ completedLessons: [] }))
+const useProgressStoreMock = vi.fn((selector) =>
+  selector(
+    { completedLessons: [] } as unknown as ReturnType<
+      typeof import('../../stores/progressStore').useProgressStore.getState
+    >
+  )
+)
 vi.mock('../../stores/progressStore', () => ({
-  useProgressStore: (selector: any) => useProgressStoreMock(selector),
+  useProgressStore: (selector: (state: unknown) => unknown) => useProgressStoreMock(selector),
 }))
 
 vi.mock('../../utils/reviewTracker', () => ({

--- a/src/hooks/__tests__/useLearningAnalytics.test.tsx
+++ b/src/hooks/__tests__/useLearningAnalytics.test.tsx
@@ -16,7 +16,7 @@ vi.mock('../../stores/learningAnalyticsStore', () => {
 describe('useLearningAnalytics', () => {
   let container: HTMLDivElement | null = null
   let root: ReturnType<typeof createRoot> | null = null
-  let mockStoreState: any
+  let mockStoreState: Partial<ReturnType<typeof useLearningAnalyticsStore.getState>>
 
   beforeEach(() => {
     container = document.createElement('div')
@@ -31,7 +31,7 @@ describe('useLearningAnalytics', () => {
       stopTracking: vi.fn(),
     }
 
-    vi.mocked(useLearningAnalyticsStore.getState).mockReturnValue(mockStoreState)
+    vi.mocked(useLearningAnalyticsStore.getState).mockReturnValue(mockStoreState as ReturnType<typeof useLearningAnalyticsStore.getState>)
   })
 
   afterEach(() => {

--- a/src/hooks/__tests__/useLearningAnalytics.test.tsx
+++ b/src/hooks/__tests__/useLearningAnalytics.test.tsx
@@ -31,7 +31,9 @@ describe('useLearningAnalytics', () => {
       stopTracking: vi.fn(),
     }
 
-    vi.mocked(useLearningAnalyticsStore.getState).mockReturnValue(mockStoreState as ReturnType<typeof useLearningAnalyticsStore.getState>)
+    vi.mocked(useLearningAnalyticsStore.getState).mockReturnValue(
+      mockStoreState as ReturnType<typeof useLearningAnalyticsStore.getState>,
+    )
   })
 
   afterEach(() => {

--- a/src/utils/rehype-slug-custom.ts
+++ b/src/utils/rehype-slug-custom.ts
@@ -2,10 +2,11 @@ import { visit } from 'unist-util-visit'
 import { createSlugger } from './slug'
 import type { Element, Root } from 'hast'
 
-function toString(node: any): string {
-  if (typeof node.value === 'string') return node.value
-  if (Array.isArray(node.children)) {
-    return node.children.map(toString).join('')
+function toString(node: unknown): string {
+  const n = node as { value?: string; children?: unknown[] }
+  if (typeof n.value === 'string') return n.value
+  if (Array.isArray(n.children)) {
+    return n.children.map(toString).join('')
   }
   return ''
 }


### PR DESCRIPTION
Replaces remaining loose `any` types with explicit `unknown`, `Partial`, and type assertions in test setups and a rehype utility. This eliminates TypeScript/lint errors related to implicit `any` parameter types. Builds and tests successfully verify the fix.

---
*PR created automatically by Jules for task [8385512423119351274](https://jules.google.com/task/8385512423119351274) started by @saint2706*