### PR TITLE
🛡️ Sentinel: Fix insecure ID generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -111,3 +111,9 @@
 - Scanned for hardcoded secrets (API keys, passwords, tokens); no instances found.
 - Code execution environments handle sandboxing robustly (Pyodide validation prevents sandbox escape via dunder methods and eval variants).
 - Local storage operations utilize safe parsers and Zod schemas to prevent prototype pollution or invalid state injection.
+
+## Security Fix: Replaced Insecure ID Generation
+
+- **Severity:** Low
+- **Vulnerability:** Weak PRNG used for ID generation (`Math.random`).
+- **Fix:** Replaced the use of `Math.random().toString(36)` in `src/stores/quizStore.ts` with the standard, cryptographically secure `crypto.randomUUID()` to generate unguessable attempt IDs.

--- a/src/stores/quizStore.ts
+++ b/src/stores/quizStore.ts
@@ -85,7 +85,7 @@ function asIsoString(value?: Date): string {
 }
 
 function createAttemptId(quizId: string, attemptedAt: string): string {
-  return `${quizId}:${attemptedAt}:${Math.random().toString(36).slice(2, 8)}`
+  return `${quizId}:${attemptedAt}:${crypto.randomUUID().slice(0, 8)}`
 }
 
 function computeStats(attempts: QuizAttempt[], quizId: string): QuizStats | null {


### PR DESCRIPTION
This PR addresses a low-severity security issue found in the codebase.

**Severity:** Low
**Vulnerability:** Weak PRNG used for ID generation (`Math.random()`).
**Fix:** Replaced the use of `Math.random().toString(36)` in `src/stores/quizStore.ts` with the standard, cryptographically secure `crypto.randomUUID()` to generate unguessable attempt IDs.

This aligns with the Sentinel persona rules to fix security vulnerabilities and log learnings without adding dependencies or exposing sensitive details.

---
*PR created automatically by Jules for task [2581658592858931603](https://jules.google.com/task/2581658592858931603) started by @saint2706*