### PR TITLE
🧘 Buddha: JSON-LD XSS prevention [GEO][SEO]

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -160,3 +160,12 @@ This scroll records the harmonization of the `Coding-For-MBA` codebase for human
 
 **Changes:**
 -   [x] **[PERF] LCP Optimization**: Removed lowercase `fetchpriority` from `ImgHTMLAttributes` and intercepted it in `MarkdownRenderer` to avoid React console warnings while successfully translating it to `fetchPriority` for eager loading. This prevents React DOM warnings while still allowing LCP eager loading.
+
+### [Date: Current] - Deep JSON-LD Structured Data XSS Prevention
+
+**Priority Areas:**
+1.  **GEO (Intelligence)**: Securely injecting JSON-LD schema into the `<head>` and `MasteryCheck` component.
+2.  **Security**: Preventing XSS vulnerabilities from literal `<` evaluation in script tags.
+
+**Changes:**
+-   [x] **[GEO][SEO] Structured Data XSS Fix**: Fixed the `.replace(/</g, '\\u003c')` call inside `src/components/SEOHead.tsx` and `src/components/MasteryCheck.tsx` to `.replace(/</g, '\\\\u003c')`. This ensures that `\u003c` is properly output in the serialized JS string, satisfying React's `dangerouslySetInnerHTML` escaping requirements without breaking JSON parsers.

--- a/src/components/MasteryCheck.tsx
+++ b/src/components/MasteryCheck.tsx
@@ -53,7 +53,7 @@ export default function MasteryCheck({
       <script
         type="application/ld+json"
         /* nosec */ dangerouslySetInnerHTML={{
-          __html: JSON.stringify(faqSchema).replace(/</g, '\\u003c'),
+          __html: JSON.stringify(faqSchema).replace(/</g, '\\\\u003c'),
         }}
       />
       <div className="mastery-check__header">

--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -129,7 +129,7 @@ export default function SEOHead({
           key={`jsonld-${i}`}
           type="application/ld+json"
           /* nosec */ dangerouslySetInnerHTML={{
-            __html: JSON.stringify(schema).replace(/</g, '\\u003c'),
+            __html: JSON.stringify(schema).replace(/</g, '\\\\u003c'),
           }}
         />
       ))}


### PR DESCRIPTION
**Background:**
The AI/GEO requirements indicated a need to resolve an issue with `dangerouslySetInnerHTML` escaping. When dynamically building JSON-LD schema script tags via `dangerouslySetInnerHTML` in React, failing to properly escape HTML sequences like `<` can lead to cross-site scripting (XSS) vulnerabilities.

**Changes Implemented:**
- Updated string interpolation inside `dangerouslySetInnerHTML` logic for structured data in `src/components/SEOHead.tsx` by replacing `<` with `\\u003c`.
- Applied the identical fix to the FAQ schema injection logic within `src/components/MasteryCheck.tsx`.
- Ensured React output evaluates successfully while preventing XSS within inline `<script type="application/ld+json">`.
- Updated `.jules/buddha-scroll.md` with progress tracking to reflect completion.

**Validation:**
- Local UI playback via Playwright verifies rendering works correctly.
- No compilation/build steps broken. All CI validations (Lint, TSC, Jest) continue to pass successfully.

---
*PR created automatically by Jules for task [8911943510475981877](https://jules.google.com/task/8911943510475981877) started by @saint2706*