### PR TITLE
🧘 Buddha: [GEO][SEO] Fix JSON-LD Schema Escaping Syntax

### DIFF
--- a/src/components/MasteryCheck.tsx
+++ b/src/components/MasteryCheck.tsx
@@ -53,7 +53,7 @@ export default function MasteryCheck({
       <script
         type="application/ld+json"
         /* nosec */ dangerouslySetInnerHTML={{
-          __html: JSON.stringify(faqSchema).replace(/</g, '\\\\u003c'),
+          __html: JSON.stringify(faqSchema).replace(/</g, '\\u003c'),
         }}
       />
       <div className="mastery-check__header">

--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -129,7 +129,7 @@ export default function SEOHead({
           key={`jsonld-${i}`}
           type="application/ld+json"
           /* nosec */ dangerouslySetInnerHTML={{
-            __html: JSON.stringify(schema).replace(/</g, '\\\\u003c'),
+            __html: JSON.stringify(schema).replace(/</g, '\\u003c'),
           }}
         />
       ))}


### PR DESCRIPTION
Fixed JSON-LD script escaping logic in `SEOHead.tsx` and `MasteryCheck.tsx` to correctly output the unicode escape `\u003c` instead of literal backslashes, ensuring search engines can parse the structured data without syntax errors while still preventing XSS.

---
*PR created automatically by Jules for task [9764503992806998785](https://jules.google.com/task/9764503992806998785) started by @saint2706*