### PR TITLE
⚡ Bolt: Avoid duplicate markdown parsing for interactive blocks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,7 @@
 - Resolved a critical React rendering race condition in `MarkdownRenderer.tsx` by replacing the globally shared, stateful `glossaryRegex` (which mutated `lastIndex`) with a stateless, deterministic `Array.from(text.matchAll(new RegExp(...)))` implementation. This prevents unpredictable UI bugs and missing glossary tooltips during Concurrent Mode renders while maintaining excellent V8 execution performance.
 >> 2026-04-04 19:28:06 UTC - ⚡ Bolt | Optimized SearchResults.tsx List Rendering | Wrapped results.map(...) in useMemo to prevent recreating complex DOM nodes on every re-render (e.g. keystrokes).
 >> 2026-04-04 19:28:06 UTC - ⚡ Bolt | Optimized Home.tsx Phase Cards Rendering | Extracted phases.map(...) into a top-level useMemo hook to prevent O(N) array filtering operations from running unnecessarily on every component render.
+>> 2024-04-XX - ⚡ Bolt: Avoid duplicate markdown parsing for interactive blocks
+   - **Problem**: `findInteractiveBlocks(lesson.content)` was being called twice on the `Lesson` page. Once to extract mastery questions for JSON-LD SEO schemas, and again inside `MarkdownRenderer` to render the interactive widgets.
+   - **Solution**: Updated `MarkdownRenderer` to accept a `precomputedBlocks?: InteractiveBlock[]` prop. In `src/pages/Lesson.tsx`, passed the already computed `interactiveBlocks` to the `<MarkdownRenderer />` component.
+   - **Metrics**: Reduces main thread blocking time during initial lesson render by eliminating a redundant markdown AST parsing operation via `remark-parse`.

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -290,7 +290,7 @@ interface ParsedMasteryQuestion {
   answer: string
 }
 
-interface InteractiveBlock {
+export interface InteractiveBlock {
   type: 'exercise' | 'mastery'
   startIndex: number
   endIndex: number
@@ -611,8 +611,17 @@ const rehypePlugins: NonNullable<ComponentProps<typeof ReactMarkdown>['rehypePlu
 
 const remarkPlugins = [remarkGfm]
 
-function InteractiveContent({ content }: { content: string }) {
-  const blocks = useMemo(() => findInteractiveBlocks(content), [content])
+function InteractiveContent({
+  content,
+  precomputedBlocks,
+}: {
+  content: string
+  precomputedBlocks?: InteractiveBlock[]
+}) {
+  const blocks = useMemo(
+    () => precomputedBlocks || findInteractiveBlocks(content),
+    [content, precomputedBlocks],
+  )
 
   if (blocks.length === 0) {
     return (
@@ -699,6 +708,7 @@ function InteractiveContent({ content }: { content: string }) {
 
 interface MarkdownRendererProps {
   content: string
+  precomputedBlocks?: InteractiveBlock[]
 }
 
 /**
@@ -709,7 +719,7 @@ interface MarkdownRendererProps {
  * @param {string} props.content - The raw markdown content string to be rendered.
  * @returns {React.ReactElement} The rendered markdown content wrapped in a responsive container.
  */
-function MarkdownRenderer({ content }: MarkdownRendererProps) {
+function MarkdownRenderer({ content, precomputedBlocks }: MarkdownRendererProps) {
   if (!content) {
     return (
       <div className="markdown-body">
@@ -720,7 +730,7 @@ function MarkdownRenderer({ content }: MarkdownRendererProps) {
 
   return (
     <div className="markdown-body">
-      <InteractiveContent content={content} />
+      <InteractiveContent content={content} precomputedBlocks={precomputedBlocks} />
     </div>
   )
 }

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -341,7 +341,7 @@ export default function Lesson() {
 
         {/* Markdown content wrapped in semantic article tag */}
         <article>
-          <MarkdownRenderer content={lesson.content} />
+          <MarkdownRenderer content={lesson.content} precomputedBlocks={interactiveBlocks} />
         </article>
 
         {/* Prev/Next navigation */}


### PR DESCRIPTION
⚡ **Bolt**: Optimize Markdown Parsing on Lesson Pages

**Discovery & Analysis:**
While profiling the main application, I identified a bottleneck on the `Lesson` page. The `findInteractiveBlocks(lesson.content)` function, which involves synchronously parsing the markdown string into an AST using `unified/remark`, was being executed twice. First in `Lesson.tsx` (to generate JSON-LD schema) and then again within the `MarkdownRenderer` component. 

**Prioritization:**
This is a Medium-High priority optimization as it directly impacts main thread blocking time during a core user flow (navigating between lessons).

**Implementation:**
1. Exported the `InteractiveBlock` interface from `src/components/MarkdownRenderer.tsx`.
2. Updated `MarkdownRendererProps` to accept an optional `precomputedBlocks?: InteractiveBlock[]` prop.
3. Updated the `InteractiveContent` component to utilize `precomputedBlocks` if provided, bypassing the redundant call to `findInteractiveBlocks`.
4. In `src/pages/Lesson.tsx`, passed the already computed `interactiveBlocks` down into `<MarkdownRenderer />`.

**Verification:**
- Ran `npm run test` (All 575 tests pass).
- Built via `npm run build` with no errors or type issues.
- Confirmed AST parsing only happens once via `useMemo` in `Lesson.tsx`.

**Documentation:**
- Logged improvements in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [1533848258240497422](https://jules.google.com/task/1533848258240497422) started by @saint2706*