### PR TITLE
🔍 Hunter: Fixed 3 errors - Removed 'any' types in test files

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -161,3 +161,9 @@
 - **Fixed:** Removed duplicate import of `ReviewCard` in `src/pages/__tests__/Review.test.tsx`.
 - **Fixed:** Replaced `any` types with stricter types (`unknown`) in `src/utils/dayToken-core.js`, `src/utils/dayToken-core.d.ts`, and `src/utils/frontmatter-core.js`.
 - **Verified:** Build, lint, and tests pass successfully without unhandled exceptions.
+
+## Session 28
+- **Fixed:** Replaced `any` type casting in `src/utils/__tests__/toast.test.ts` by explicitly casting `toastMock` to `unknown` and then an inline type matching the `react-hot-toast` signature and Vitest mock fields.
+- **Fixed:** Replaced `any` types in `src/components/__tests__/PythonRunner.test.tsx` by using `ReturnType<typeof vi.fn>` for the run handler and accurately typing `usePyodide` return mocks as `unknown` to `ReturnType`.
+- **Fixed:** Replaced `any` type casting in `src/utils/__tests__/seoSchemas.test.ts` by casting `potentialAction` and its nested `target` property to `Record<string, unknown>`.
+- **Verified:** Build, formatting, lint, and tests pass successfully without unhandled exceptions.

--- a/src/components/__tests__/PythonRunner.test.tsx
+++ b/src/components/__tests__/PythonRunner.test.tsx
@@ -14,7 +14,7 @@ vi.mock('../../utils/codeSecurity', () => ({
 }))
 
 describe('PythonRunner', () => {
-  let mockRunPython: any
+  let mockRunPython: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -26,7 +26,7 @@ describe('PythonRunner', () => {
       ensureLoaded: vi.fn(),
       isReady: true,
       loadPyodide: vi.fn(),
-    } as any)
+    } as unknown as ReturnType<typeof usePyodideHook.usePyodide>)
     vi.mocked(codeSecurity.validatePythonCode).mockReturnValue({ valid: true, error: undefined })
   })
 
@@ -49,7 +49,7 @@ describe('PythonRunner', () => {
       ensureLoaded: vi.fn(),
       isReady: false,
       loadPyodide: vi.fn(),
-    } as any)
+    } as unknown as ReturnType<typeof usePyodideHook.usePyodide>)
     const { getByRole } = render(<PythonRunner code="print('hello')" />)
     const runBtn = getByRole('button', { name: /Loading Python environment.../i })
     expect(runBtn).toBeDefined()

--- a/src/utils/__tests__/seoSchemas.test.ts
+++ b/src/utils/__tests__/seoSchemas.test.ts
@@ -51,10 +51,12 @@ describe('seoSchemas', () => {
         description: expect.any(String),
       })
 
-      const potentialAction = schema.potentialAction as Record<string, any>
+      const potentialAction = schema.potentialAction as Record<string, unknown>
       expect(potentialAction).toBeDefined()
       expect(potentialAction['@type']).toBe('SearchAction')
-      expect(potentialAction.target.urlTemplate).toBe(`${SITE_URL}/#/search?q={search_term_string}`)
+      expect((potentialAction.target as Record<string, unknown>).urlTemplate).toBe(
+        `${SITE_URL}/#/search?q={search_term_string}`,
+      )
       expect(potentialAction['query-input']).toBe('required name=search_term_string')
     })
   })

--- a/src/utils/__tests__/toast.test.ts
+++ b/src/utils/__tests__/toast.test.ts
@@ -3,7 +3,11 @@ import { toast } from 'react-hot-toast'
 import { toastSuccess, toastError, toastInfo, TOAST_DEFAULT_OPTIONS } from '../toast'
 
 vi.mock('react-hot-toast', () => {
-  const toastMock: any = vi.fn()
+  const toastMock = vi.fn() as unknown as {
+    (message: string, options?: import('react-hot-toast').ToastOptions): string
+    success: import('vitest').Mock
+    error: import('vitest').Mock
+  }
   toastMock.success = vi.fn()
   toastMock.error = vi.fn()
   return {


### PR DESCRIPTION
Hunter Session 28: Fixed 3 errors by removing `any` type casting across test files and replacing them with stricter TypeScript checks (e.g. `unknown` and `ReturnType`). The build, lint, format and tests pass successfully.

---
*PR created automatically by Jules for task [2416651177416929505](https://jules.google.com/task/2416651177416929505) started by @saint2706*