### PR TITLE
🧘 Buddha: [SEO] Add image property to WebSite JSON-LD schema

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -169,3 +169,4 @@ This scroll records the harmonization of the `Coding-For-MBA` codebase for human
 
 **Changes:**
 -   [x] **[GEO][SEO] Structured Data XSS Fix**: Fixed the `.replace(/</g, '\\u003c')` call inside `src/components/SEOHead.tsx` and `src/components/MasteryCheck.tsx` to `.replace(/</g, '\\\\u003c')`. This ensures that `\u003c` is properly output in the serialized JS string, satisfying React's `dangerouslySetInnerHTML` escaping requirements without breaking JSON parsers.
+- Added image to WebSite schema

--- a/src/utils/seoSchemas.ts
+++ b/src/utils/seoSchemas.ts
@@ -39,6 +39,7 @@ export function buildWebSiteSchema(): Record<string, unknown> {
     name: SITE_NAME,
     url: `${SITE_URL}/`,
     description: DEFAULT_DESCRIPTION,
+    image: `${SITE_URL}/og-image.png`,
     potentialAction: {
       '@type': 'SearchAction',
       target: {


### PR DESCRIPTION
🧘 Buddha: [SEO] Add image property to WebSite JSON-LD schema

As requested by the Buddha persona rules for SEO optimization, I've added the missing `image` property to the `WebSite` JSON-LD structured data schema to improve the site's semantic understanding by search engines and AI agents.

Changes:
- Added `image` property to `buildWebSiteSchema` in `src/utils/seoSchemas.ts`.
- Logged the improvement in `.jules/buddha-scroll.md`.

---
*PR created automatically by Jules for task [2856173940381522283](https://jules.google.com/task/2856173940381522283) started by @saint2706*