### PR TITLE
Docs: Documentation and JSDoc Audit

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -90,3 +90,4 @@ Added complete and well-formatted JSDoc to the following exported components, fu
   - Validated that the curriculum's Markdown content matches `docs/` and `README.md` perfectly.
   - Ensured `npm run build` and `npm run lint` pass cleanly without any build or lint errors.
 >> Fixed markdown formatting issues in docs/ARCHITECTURE.md, docs/performance-audit.md, README.md, and CONTRIBUTING.md.
+- [x] Audited markdown link checker issues and missing JSDocs, found 0 issues.


### PR DESCRIPTION
Audited the documentation for broken links and missing JSDoc comments. Found no issues. Logged the audit in `.jules/docs-progress.md`.

---
*PR created automatically by Jules for task [11352578736656069156](https://jules.google.com/task/11352578736656069156) started by @saint2706*