### PR TITLE
🛡️ Sentinel: Harden localStorage schema validation against array bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -119,3 +119,11 @@
 - **Fix:** Replaced the use of `Math.random().toString(36)` in `src/stores/quizStore.ts` with the standard, cryptographically secure `crypto.randomUUID()` to generate unguessable attempt IDs.
 >> * Fixed Vite vulnerabilities (Path Traversal, Arbitrary File Read) by running `npm audit fix`.
 >> * Fixed JSON-LD structured data over-escaping in `src/components/MasteryCheck.tsx` and `src/components/SEOHead.tsx` by replacing `.replace(/</g, '\\\\u003c')` with exactly `.replace(/</g, '\u003c')` to prevent literal backslashes from breaking search engine JSON parsing.
+
+## Security Fix: Hardened `localStorage` Schema Validation
+
+- **Severity:** Medium
+- **Vulnerability:** Weak schema validation when hydrating `localStorage` data in `exerciseProgress.ts` and `reviewTracker.ts`. Arrays could incorrectly pass `typeof object` checks, leading to prototype pollution or crashing application state.
+- **Fix:**
+  - Added strict Zod schema validation (`z.record(z.string(), z.array(z.string()))`) to `exerciseProgress.ts` to validate data on hydration.
+  - Hardened type guards `isReviewStateV2` and `isSchedulingState` in `reviewTracker.ts` by explicitly rejecting array payloads (`Array.isArray(value)`).

--- a/src/utils/exerciseProgress.ts
+++ b/src/utils/exerciseProgress.ts
@@ -10,6 +10,7 @@
  * - Provide a transactional update mechanism for marking exercises as done.
  */
 
+import { z } from 'zod'
 import { getStoredJson, setStoredString } from './safeStorage'
 
 const EXERCISE_PROGRESS_KEY = 'coding-for-mba-exercise-progress'
@@ -17,11 +18,13 @@ const EXERCISE_DAY_CELEBRATION_KEY = 'coding-for-mba-exercise-day-celebration'
 
 type DayExerciseMap = Record<string, string[]>
 
+const DayExerciseMapSchema = z.record(z.string(), z.array(z.string()))
+
 function getMap(key: string): DayExerciseMap {
   return getStoredJson<DayExerciseMap>(
     key,
     {},
-    (value): value is DayExerciseMap => typeof value === 'object' && value !== null,
+    (value): value is DayExerciseMap => DayExerciseMapSchema.safeParse(value).success,
   )
 }
 

--- a/src/utils/reviewTracker.ts
+++ b/src/utils/reviewTracker.ts
@@ -77,7 +77,7 @@ if (typeof window !== 'undefined' && typeof window.addEventListener === 'functio
  * @returns True if value is a valid SchedulingState
  */
 function isSchedulingState(value: unknown): value is SchedulingState {
-  if (!value || typeof value !== 'object') return false
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
   const state = value as Record<string, unknown>
   return (
     typeof state.repetitions === 'number' &&
@@ -95,11 +95,11 @@ function isSchedulingState(value: unknown): value is SchedulingState {
  * @returns True if value is a valid ReviewStateV2
  */
 function isReviewStateV2(value: unknown): value is ReviewStateV2 {
-  if (!value || typeof value !== 'object') return false
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
   const payload = value as Record<string, unknown>
   if (payload.version !== 2 || !Array.isArray(payload.cards)) return false
   return payload.cards.every((entry) => {
-    if (!entry || typeof entry !== 'object') return false
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false
     const card = entry as Record<string, unknown>
     return typeof card.id === 'string' && isSchedulingState(card.state)
   })


### PR DESCRIPTION
🛡️ Sentinel: Hardened Local Storage Schema Validation

### Vulnerability:
Weak schema validation when hydrating `localStorage` data in `exerciseProgress.ts` and `reviewTracker.ts`. Arrays could incorrectly pass `typeof value === 'object'` checks, potentially leading to prototype pollution or crashing application state if unexpected array payloads were accessed as objects.

### Fix:
1. **`exerciseProgress.ts`**: Implemented strict Zod schema validation (`z.record(z.string(), z.array(z.string()))`) to rigorously validate `localStorage` payloads on hydration rather than trusting `typeof object`.
2. **`reviewTracker.ts`**: Hardened the `isReviewStateV2` and `isSchedulingState` type guards by explicitly rejecting array payloads using `!Array.isArray(value)` alongside the object check.
3. Updated `.jules/sentinel.md` to document the security fix.

---
*PR created automatically by Jules for task [4548001288568616398](https://jules.google.com/task/4548001288568616398) started by @saint2706*