### PR TITLE
🔍 Hunter: Fixed 4 errors - Replaced explicit any types in tests

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -167,3 +167,10 @@
 - **Fixed:** Replaced `let mockRunPython: any`, `let resizeCallback: any`, `let intersectionCallback: any`, and `constructor(callback: any)` with explicitly correct types in `src/components/__tests__/PythonRunner.test.tsx` and `src/components/__tests__/TableOfContents.test.tsx`.
 - **Fixed:** Replaced `(props: any)` with `(props: { isLesson?: boolean })` in `src/__tests__/App.test.tsx` mock.
 - **Verified:** Build, lint, and tests pass successfully without any type errors.
+
+## Session 29
+- **Fixed:** Replaced `as any` type casting with proper type assertions (`as Record<string, unknown>`) in `src/utils/__tests__/seoSchemas.test.ts`.
+- **Fixed:** Replaced `(state: any) => any` with `(state: unknown) => unknown` in `src/context/__tests__/ThemeProvider.test.tsx` to fix strict typing.
+- **Fixed:** Replaced `props: any` with `props: Record<string, unknown>` in `src/components/__tests__/MarkdownRenderer.test.tsx` for various component mocks.
+- **Fixed:** Replaced `toastMock: any = vi.fn()` with a properly structured object using `Object.assign` in `src/utils/__tests__/toast.test.ts`.
+- **Verified:** Build, lint, and tests pass successfully without any type errors.

--- a/src/components/__tests__/MarkdownRenderer.test.tsx
+++ b/src/components/__tests__/MarkdownRenderer.test.tsx
@@ -5,26 +5,26 @@ import { createRoot, Root } from 'react-dom/client'
 import MarkdownRenderer from '../MarkdownRenderer'
 
 vi.mock('../CodePlayground', () => ({
-  default: function MockCodePlayground(props: any) {
-    return <div data-testid="code-playground">{props.initialCode}</div>
+  default: function MockCodePlayground(props: Record<string, unknown>) {
+    return <div data-testid="code-playground">{props.initialCode as React.ReactNode}</div>
   },
 }))
 
 vi.mock('../ExerciseWidget', () => ({
-  default: function MockExerciseWidget(props: any) {
+  default: function MockExerciseWidget(props: Record<string, unknown>) {
     return (
-      <div data-testid="exercise-widget" data-title={props.title}>
-        {props.goal}
+      <div data-testid="exercise-widget" data-title={props.title as string}>
+        {props.goal as React.ReactNode}
       </div>
     )
   },
 }))
 
 vi.mock('../MasteryCheck', () => ({
-  default: function MockMasteryCheck(props: any) {
+  default: function MockMasteryCheck(props: Record<string, unknown>) {
     return (
-      <div data-testid="mastery-check" data-title={props.title}>
-        {props.questionText}
+      <div data-testid="mastery-check" data-title={props.title as string}>
+        {props.questionText as React.ReactNode}
       </div>
     )
   },

--- a/src/context/__tests__/ThemeProvider.test.tsx
+++ b/src/context/__tests__/ThemeProvider.test.tsx
@@ -26,7 +26,7 @@ describe('ThemeProvider', () => {
     }
 
     vi.mocked(userPreferencesStore.useUserPreferencesStore).mockImplementation(((
-      selector?: (state: any) => any,
+      selector?: (state: unknown) => unknown,
     ) => {
       if (selector)
         return selector(

--- a/src/utils/__tests__/seoSchemas.test.ts
+++ b/src/utils/__tests__/seoSchemas.test.ts
@@ -51,10 +51,12 @@ describe('seoSchemas', () => {
         description: expect.any(String),
       })
 
-      const potentialAction = schema.potentialAction as Record<string, any>
+      const potentialAction = schema.potentialAction as Record<string, unknown>
       expect(potentialAction).toBeDefined()
       expect(potentialAction['@type']).toBe('SearchAction')
-      expect(potentialAction.target.urlTemplate).toBe(`${SITE_URL}/#/search?q={search_term_string}`)
+      expect((potentialAction.target as Record<string, unknown>).urlTemplate).toBe(
+        `${SITE_URL}/#/search?q={search_term_string}`,
+      )
       expect(potentialAction['query-input']).toBe('required name=search_term_string')
     })
   })

--- a/src/utils/__tests__/toast.test.ts
+++ b/src/utils/__tests__/toast.test.ts
@@ -3,9 +3,10 @@ import { toast } from 'react-hot-toast'
 import { toastSuccess, toastError, toastInfo, TOAST_DEFAULT_OPTIONS } from '../toast'
 
 vi.mock('react-hot-toast', () => {
-  const toastMock: any = vi.fn()
-  toastMock.success = vi.fn()
-  toastMock.error = vi.fn()
+  const toastMock = Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+  })
   return {
     toast: toastMock,
   }


### PR DESCRIPTION
I acted as Hunter 🔍 to find and fix remaining `any` type casting issues in our test files which caused strict TypeScript checking to complain.

In this session, I fixed:
1. `src/context/__tests__/ThemeProvider.test.tsx` (`(state: any) => any`)
2. `src/components/__tests__/MarkdownRenderer.test.tsx` (`props: any` on mocks)
3. `src/utils/__tests__/toast.test.ts` (`const toastMock: any = vi.fn()`)
4. `src/utils/__tests__/seoSchemas.test.ts` (`as Record<string, any>`)

The build, tests, and formatting checks now pass cleanly.

---
*PR created automatically by Jules for task [3075455074493506213](https://jules.google.com/task/3075455074493506213) started by @saint2706*