### PR TITLE
🧪 Testing: Improve coverage for SidebarPhaseGroup and dayToken

### DIFF
--- a/src/components/SidebarPhaseGroup.tsx
+++ b/src/components/SidebarPhaseGroup.tsx
@@ -187,4 +187,5 @@ function propsAreEqual(
  * @param {SidebarPhaseGroupProps} props - The component props.
  * @returns {JSX.Element} The phase group accordion block.
  */
+export { propsAreEqual }
 export default memo(SidebarPhaseGroup, propsAreEqual)

--- a/src/components/__tests__/SidebarPhaseGroup.propsAreEqual.test.tsx
+++ b/src/components/__tests__/SidebarPhaseGroup.propsAreEqual.test.tsx
@@ -4,7 +4,9 @@ import * as contentLoader from '../../utils/contentLoader'
 
 // Mock getLesson so that propsAreEqual can use it
 vi.mock('../../utils/contentLoader', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/contentLoader')>('../../utils/contentLoader')
+  const actual = await vi.importActual<typeof import('../../utils/contentLoader')>(
+    '../../utils/contentLoader',
+  )
   return {
     ...actual,
     getLesson: vi.fn(),
@@ -45,9 +47,7 @@ describe('SidebarPhaseGroup propsAreEqual optimization', () => {
 
   describe('handles currentPath changes correctly', () => {
     it('re-renders if new path is phase overview for this phase', () => {
-      expect(
-        propsAreEqual(defaultProps, { ...defaultProps, currentPath: '/phase/1' }),
-      ).toBe(false)
+      expect(propsAreEqual(defaultProps, { ...defaultProps, currentPath: '/phase/1' })).toBe(false)
     })
 
     it('re-renders if old path is phase overview for this phase', () => {
@@ -60,14 +60,18 @@ describe('SidebarPhaseGroup propsAreEqual optimization', () => {
     })
 
     it('re-renders if new path is a lesson in this phase', () => {
-      vi.mocked(contentLoader.getLesson).mockReturnValueOnce({ phase: 1 } as unknown as ReturnType<typeof contentLoader.getLesson>)
-      expect(
-        propsAreEqual(defaultProps, { ...defaultProps, currentPath: '/lesson/01' }),
-      ).toBe(false)
+      vi.mocked(contentLoader.getLesson).mockReturnValueOnce({ phase: 1 } as unknown as ReturnType<
+        typeof contentLoader.getLesson
+      >)
+      expect(propsAreEqual(defaultProps, { ...defaultProps, currentPath: '/lesson/01' })).toBe(
+        false,
+      )
     })
 
     it('re-renders if old path is a lesson in this phase', () => {
-      vi.mocked(contentLoader.getLesson).mockReturnValueOnce({ phase: 1 } as unknown as ReturnType<typeof contentLoader.getLesson>)
+      vi.mocked(contentLoader.getLesson).mockReturnValueOnce({ phase: 1 } as unknown as ReturnType<
+        typeof contentLoader.getLesson
+      >)
       expect(
         propsAreEqual(
           { ...defaultProps, currentPath: '/lesson/01' },
@@ -77,7 +81,9 @@ describe('SidebarPhaseGroup propsAreEqual optimization', () => {
     })
 
     it('does not re-render if path changes between two unrelated paths', () => {
-      vi.mocked(contentLoader.getLesson).mockReturnValue({ phase: 2 } as unknown as ReturnType<typeof contentLoader.getLesson>)
+      vi.mocked(contentLoader.getLesson).mockReturnValue({ phase: 2 } as unknown as ReturnType<
+        typeof contentLoader.getLesson
+      >)
       expect(
         propsAreEqual(
           { ...defaultProps, currentPath: '/lesson/03' },
@@ -97,9 +103,9 @@ describe('SidebarPhaseGroup propsAreEqual optimization', () => {
 
     it('handles null getLesson result gracefully', () => {
       vi.mocked(contentLoader.getLesson).mockReturnValueOnce(undefined)
-      expect(
-        propsAreEqual(defaultProps, { ...defaultProps, currentPath: '/lesson/unknown' }),
-      ).toBe(true)
+      expect(propsAreEqual(defaultProps, { ...defaultProps, currentPath: '/lesson/unknown' })).toBe(
+        true,
+      )
     })
 
     it('handles identical currentPath properly', () => {

--- a/src/components/__tests__/SidebarPhaseGroup.propsAreEqual.test.tsx
+++ b/src/components/__tests__/SidebarPhaseGroup.propsAreEqual.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest'
+import { propsAreEqual } from '../SidebarPhaseGroup'
+import * as contentLoader from '../../utils/contentLoader'
+
+// Mock getLesson so that propsAreEqual can use it
+vi.mock('../../utils/contentLoader', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/contentLoader')>('../../utils/contentLoader')
+  return {
+    ...actual,
+    getLesson: vi.fn(),
+  }
+})
+
+describe('SidebarPhaseGroup propsAreEqual optimization', () => {
+  const defaultProps = {
+    phase: { phase: 1, title: 'Phase 1', days: ['01'], content: '', path: '' },
+    isActive: false,
+    completedIdsJoined: '',
+    dueCount: 0,
+    currentPath: '/',
+    onToggle: vi.fn(),
+    onClose: vi.fn(),
+  }
+
+  it('re-renders when isActive changes', () => {
+    expect(propsAreEqual(defaultProps, { ...defaultProps, isActive: true })).toBe(false)
+  })
+
+  it('re-renders when dueCount changes', () => {
+    expect(propsAreEqual(defaultProps, { ...defaultProps, dueCount: 1 })).toBe(false)
+  })
+
+  it('re-renders when phase changes', () => {
+    expect(
+      propsAreEqual(defaultProps, {
+        ...defaultProps,
+        phase: { ...defaultProps.phase, phase: 2, title: 'Phase 2' },
+      }),
+    ).toBe(false)
+  })
+
+  it('re-renders when completedIdsJoined changes for lessons in this phase', () => {
+    expect(propsAreEqual(defaultProps, { ...defaultProps, completedIdsJoined: '1' })).toBe(false)
+  })
+
+  describe('handles currentPath changes correctly', () => {
+    it('re-renders if new path is phase overview for this phase', () => {
+      expect(
+        propsAreEqual(defaultProps, { ...defaultProps, currentPath: '/phase/1' }),
+      ).toBe(false)
+    })
+
+    it('re-renders if old path is phase overview for this phase', () => {
+      expect(
+        propsAreEqual(
+          { ...defaultProps, currentPath: '/phase/1' },
+          { ...defaultProps, currentPath: '/' },
+        ),
+      ).toBe(false)
+    })
+
+    it('re-renders if new path is a lesson in this phase', () => {
+      vi.mocked(contentLoader.getLesson).mockReturnValueOnce({ phase: 1 } as unknown as ReturnType<typeof contentLoader.getLesson>)
+      expect(
+        propsAreEqual(defaultProps, { ...defaultProps, currentPath: '/lesson/01' }),
+      ).toBe(false)
+    })
+
+    it('re-renders if old path is a lesson in this phase', () => {
+      vi.mocked(contentLoader.getLesson).mockReturnValueOnce({ phase: 1 } as unknown as ReturnType<typeof contentLoader.getLesson>)
+      expect(
+        propsAreEqual(
+          { ...defaultProps, currentPath: '/lesson/01' },
+          { ...defaultProps, currentPath: '/' },
+        ),
+      ).toBe(false)
+    })
+
+    it('does not re-render if path changes between two unrelated paths', () => {
+      vi.mocked(contentLoader.getLesson).mockReturnValue({ phase: 2 } as unknown as ReturnType<typeof contentLoader.getLesson>)
+      expect(
+        propsAreEqual(
+          { ...defaultProps, currentPath: '/lesson/03' },
+          { ...defaultProps, currentPath: '/lesson/04' },
+        ),
+      ).toBe(true)
+    })
+
+    it('does not re-render if path changes between unrelated phase overviews', () => {
+      expect(
+        propsAreEqual(
+          { ...defaultProps, currentPath: '/phase/2' },
+          { ...defaultProps, currentPath: '/phase/3' },
+        ),
+      ).toBe(true)
+    })
+
+    it('handles null getLesson result gracefully', () => {
+      vi.mocked(contentLoader.getLesson).mockReturnValueOnce(undefined)
+      expect(
+        propsAreEqual(defaultProps, { ...defaultProps, currentPath: '/lesson/unknown' }),
+      ).toBe(true)
+    })
+
+    it('handles identical currentPath properly', () => {
+      expect(
+        propsAreEqual(
+          { ...defaultProps, currentPath: '/lesson/01' },
+          { ...defaultProps, currentPath: '/lesson/01' },
+        ),
+      ).toBe(true)
+    })
+  })
+})

--- a/src/utils/__tests__/dayToken.test.ts
+++ b/src/utils/__tests__/dayToken.test.ts
@@ -22,6 +22,10 @@ describe('dayToken utilities', () => {
     expect(compareDayTokens('invalidA', 'invalidA')).toBe(0)
     expect(compareDayTokens('invalidA', 'invalidB')).toBe(-1)
     expect(compareDayTokens('invalidB', 'invalidA')).toBe(1)
+
+    // Testing case where one is valid and another is invalid
+    expect(compareDayTokens('1', 'invalid')).toBe(-1) // '1' < 'INVALID'
+    expect(compareDayTokens('invalid', '1')).toBe(1)  // 'INVALID' > '1'
   })
 
   it('normalizes and sorts alphanumeric day tokens deterministically', () => {
@@ -78,6 +82,7 @@ describe('dayToken utilities', () => {
     expect(dayTokenFromReference('invalid reference')).toBeNull()
     expect(dayTokenFromReference(null)).toBeNull()
     expect(dayTokenFromReference({})).toBeNull()
+    expect(dayTokenFromReference('Day invalid')).toBeNull()
   })
 
   it('dayTokenToProgressId handles invalid tokens and cache', () => {

--- a/src/utils/__tests__/dayToken.test.ts
+++ b/src/utils/__tests__/dayToken.test.ts
@@ -25,7 +25,7 @@ describe('dayToken utilities', () => {
 
     // Testing case where one is valid and another is invalid
     expect(compareDayTokens('1', 'invalid')).toBe(-1) // '1' < 'INVALID'
-    expect(compareDayTokens('invalid', '1')).toBe(1)  // 'INVALID' > '1'
+    expect(compareDayTokens('invalid', '1')).toBe(1) // 'INVALID' > '1'
   })
 
   it('normalizes and sorts alphanumeric day tokens deterministically', () => {


### PR DESCRIPTION
This PR addresses the user's request to improve test coverage and reliability as the "Testing" 🧪 persona. Specifically, it resolves uncovered lines in the `SidebarPhaseGroup` component and `dayToken` utility function. 

- Extracted and exported the internal `propsAreEqual` method from `SidebarPhaseGroup.tsx` to explicitly test React memoization logic.
- Implemented comprehensive edge-case assertions in `dayToken.test.ts` for invalid parameters.
- Achieved full build, linting, and testing (with coverage) success.

---
*PR created automatically by Jules for task [17212677532284577198](https://jules.google.com/task/17212677532284577198) started by @saint2706*