### PR TITLE
🎨 Picasso: Accessibility improvements for Tabs and Reveals

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -46,3 +46,11 @@ Learned that missing aria labels for decorative emojis in React can be fixed by 
 >> 2026-04-07 - Added standard focus-visible styles to interactive button elements across the application to improve keyboard accessibility.
 * **ExerciseWidget**: Added an explicit `ariaLabel` to the `CopyButton` to improve context for screen reader users when copying solutions.
 - Added focus-visible accessibility classes to all custom interactive elements (buttons) across pages.
+
+## Case Studies Page
+- Added aria-controls to link the Case Studies and Projects tabs to the main cs-panel tab panel grid.
+- Linked the detailed view Expand/Collapse button to its content motion.div using aria-controls.
+- Replaced text-based arrows with aria-hidden spans on the expand button so screen readers don't read "Black up-pointing triangle".
+
+## Review Page
+- Wrapped the answer reveal section in an aria-live="polite" region so screen readers announce it when revealed.

--- a/src/pages/CaseStudies.tsx
+++ b/src/pages/CaseStudies.tsx
@@ -92,6 +92,7 @@ export default function CaseStudies() {
         <button
           type="button"
           role="tab"
+          aria-controls="cs-panel"
           aria-selected={activeTab === 'case-studies'}
           className={`cs-tab focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${activeTab === 'case-studies' ? 'cs-tab--active' : ''}`}
           onClick={() => {
@@ -104,6 +105,7 @@ export default function CaseStudies() {
         <button
           type="button"
           role="tab"
+          aria-controls="cs-panel"
           aria-selected={activeTab === 'projects'}
           className={`cs-tab focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${activeTab === 'projects' ? 'cs-tab--active' : ''}`}
           onClick={() => {
@@ -138,7 +140,7 @@ export default function CaseStudies() {
       </p>
 
       {/* Cards */}
-      <motion.div className="cs-grid" layout>
+      <motion.div id="cs-panel" role="tabpanel" className="cs-grid" layout>
         {filtered.map((item) => {
           const normDiff = normalizeDifficulty(item.difficulty)
           const diff = difficultyConfig[normDiff] ?? {
@@ -180,14 +182,17 @@ export default function CaseStudies() {
                   type="button"
                   className="cs-card__expand-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
                   aria-expanded={isExpanded}
+                  aria-controls={`cs-content-${item.slug}`}
                   onClick={() => toggleExpand(item.slug)}
                 >
-                  {isExpanded ? '▲ Hide details' : '▼ View details'}
+                  <span aria-hidden="true">{isExpanded ? '▲' : '▼'}</span>{' '}
+                  {isExpanded ? 'Hide details' : 'View details'}
                 </button>
               </div>
 
               {isExpanded && (
                 <motion.div
+                  id={`cs-content-${item.slug}`}
                   className="cs-card__content"
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -123,27 +123,29 @@ export default function Review() {
           <h2>{currentCard.prompt}</h2>
           <p className="review-card-lesson">From: {currentCard.lessonTitle}</p>
 
-          {showAnswer ? (
-            <div className="review-answer">
-              <strong>Answer guide:</strong>
-              <p>{currentCard.answer}</p>
-            </div>
-          ) : (
-            <>
-              <button
-                type="button"
-                className="review-answer-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
-                onClick={() => setShowAnswer(true)}
-              >
-                Show Answer
-              </button>
-              <p className="review-keyboard-hint">
-                <small>
-                  Press <kbd>Space</kbd> or <kbd>Enter</kbd> to reveal
-                </small>
-              </p>
-            </>
-          )}
+          <div aria-live="polite">
+            {showAnswer ? (
+              <div className="review-answer">
+                <strong>Answer guide:</strong>
+                <p>{currentCard.answer}</p>
+              </div>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className="review-answer-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                  onClick={() => setShowAnswer(true)}
+                >
+                  Show Answer
+                </button>
+                <p className="review-keyboard-hint">
+                  <small>
+                    Press <kbd>Space</kbd> or <kbd>Enter</kbd> to reveal
+                  </small>
+                </p>
+              </>
+            )}
+          </div>
 
           {showAnswer && (
             <>


### PR DESCRIPTION
This PR introduces targeted accessibility improvements across the application interface as part of the Picasso UX initiative.

**Changes:**
1. **Case Studies (`CaseStudies.tsx`)**:
   - Added `aria-controls="cs-panel"` to the 'Case Studies' and 'Projects' tabs to link them to the main tabpanel container.
   - Added `aria-controls` to the "View details" expand button to explicitly link it to the detailed content section.
   - Wrapped the decorative up/down arrows (`▲`/`▼`) inside the expand button with `<span aria-hidden="true">` to prevent screen readers from reading out unhelpful literal arrow descriptions.
2. **Review (`Review.tsx`)**:
   - Refactored the "Show Answer" reveal logic. Because the trigger button and the target content were mutually exclusive (never in the DOM together), standard `aria-controls` and `aria-expanded` attributes are invalid. The conditional rendering block was wrapped in a persistent `<div aria-live="polite">` container instead, ensuring screen readers naturally announce the flashcard answer as soon as it appears.
3. **Documentation**:
   - Appended the latest UX learnings and fixes to `.jules/picasso.md` without destroying previous history.

---
*PR created automatically by Jules for task [14624454731629535976](https://jules.google.com/task/14624454731629535976) started by @saint2706*