### PR TITLE
🛡️ Sentinel: Fix weak array type guards in stores

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,5 @@
 
 - Replacing `Math.random` with `crypto.getRandomValues` in contexts where true cryptographically secure numbers aren't needed (e.g. basic UI components and simple array selections) is security theater and can introduce crashes in Node SSR environments if `crypto` isn't imported correctly.
 - Added array validation to local storage JSON parsing (`Array.isArray()`) to prevent array prototype pollution from bypassing object checks (CWE-20).
+
+- Strengthened array type guards in local storage json parsing helpers (`src/stores/progressStore.ts`, `src/stores/learningAnalyticsStore.ts`) by explicitly checking `Array.isArray(value)`, preventing prototype pollution or logical bugs when JS evaluates `typeof []` as `'object'`.

--- a/src/stores/learningAnalyticsStore.ts
+++ b/src/stores/learningAnalyticsStore.ts
@@ -89,7 +89,7 @@ function asDayKey(date: Date): string {
 }
 
 function parsePositiveRecord(value: unknown, integerKeys = false): Record<string, number> {
-  if (!value || typeof value !== 'object') return {}
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
 
   return Object.entries(value as Record<string, unknown>).reduce<Record<string, number>>(
     (acc, [key, raw]) => {

--- a/src/stores/progressStore.ts
+++ b/src/stores/progressStore.ts
@@ -92,7 +92,7 @@ function parseValidDays(value: unknown): number[] {
 }
 
 function parseValidCompletionDates(value: unknown): Record<number, string> {
-  if (!value || typeof value !== 'object') return {}
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
 
   const entries = Object.entries(value as Record<string, unknown>)
   return entries.reduce<Record<number, string>>((acc, [rawDay, date]) => {


### PR DESCRIPTION
Fixed an input validation edge-case in local storage parsing where arrays were not explicitly excluded when a standard object/dictionary was expected, potentially causing silent runtime object traversal bugs.

---
*PR created automatically by Jules for task [7398278893068723168](https://jules.google.com/task/7398278893068723168) started by @saint2706*