### PR TITLE
⚡ Bolt: [improvement] Cache regex in highlightText

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,3 +27,5 @@
 - **Solution**: Implemented `React.lazy` and `Suspense` for `CodePlayground`, `ExerciseWidget`, and `MasteryCheck`.
 - **Metrics/Impact**: The bundle analysis (`npm run analyze`) confirmed that the `MarkdownRenderer` chunk size decreased significantly (from ~35.6kB to ~20.3kB), and `CodePlayground`, `ExerciseWidget`, and `MasteryCheck` are now split into their own separate network chunks. This reduces the LCP and TBT on lesson pages as heavy interactive code components are only loaded when they are needed.
 - 2026-04-12 UTC - ⚡ Bolt | Micro-optimized computeRankingBoost score accumulation loop and totalLearningMs reducer to prevent V8 closure allocations from causing main-thread stuttering during active user sessions. Tested via npm run analyze:report and Vitest.
+
+- **highlightText**: Memoized the `RegExp` in `searchHighlight.tsx` to prevent redundant compilations on every search render, improving overall performance for search result rendering.

--- a/src/utils/searchHighlight.tsx
+++ b/src/utils/searchHighlight.tsx
@@ -16,6 +16,8 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
+const regexCache = new Map<string, RegExp>()
+
 /**
  * Highlights occurrences of search terms within a text string.
  *
@@ -34,7 +36,17 @@ export function highlightText(text: string, terms: string | readonly string[]): 
   const ordered = Array.from(new Set(normalized)).sort((a, b) => b.length - a.length)
 
   const pattern = ordered.map(escapeRegExp).join('|')
-  const regex = new RegExp(`(${pattern})`, 'gi')
+
+  let regex = regexCache.get(pattern)
+  if (!regex) {
+    regex = new RegExp(`(${pattern})`, 'gi')
+    // Keep cache size manageable to prevent memory leaks
+    if (regexCache.size > 100) {
+      regexCache.clear()
+    }
+    regexCache.set(pattern, regex)
+  }
+
   const parts = text.split(regex)
 
   return parts.map((part, index) =>


### PR DESCRIPTION
Added a LRU cache-like mechanism for compiled RegExps in `highlightText` to prevent redundant RegExp instantiations on every highlight call during search result renders, improving performance. Memory leaks are prevented with a size check that flushes the cache when full.

---
*PR created automatically by Jules for task [17058002130746004933](https://jules.google.com/task/17058002130746004933) started by @saint2706*