### PR TITLE
📚 Docs: [maintenance] Fix missing JSDocs

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -93,3 +93,5 @@ Added complete and well-formatted JSDoc to the following exported components, fu
 - [x] Added missing JSDoc comments to `src/components/Skeleton.tsx`, `src/components/CodePlayground.tsx`, `src/components/MarkdownRenderer.tsx`, `src/utils/codeSecurity.ts`, and `src/utils/reviewScheduler.ts`.
 - [x] Formatted markdown files with markdownlint.
 - [x] Verified markdown files with markdown-link-check.
+- Fixed missing JSDocs issue by removing blank lines between export blocks and JSDocs, and added missing JSDoc blocks where necessary.
+- Ran markdown link checking.

--- a/src/components/SidebarPhaseGroup.tsx
+++ b/src/components/SidebarPhaseGroup.tsx
@@ -144,6 +144,12 @@ function SidebarPhaseGroup({
   )
 }
 
+/**
+ * Custom props comparison function for memoizing SidebarPhaseGroup.
+ * @param {SidebarPhaseGroupProps} prevProps - Previous props.
+ * @param {SidebarPhaseGroupProps} nextProps - Next props.
+ * @returns {boolean} True if props are equal, false otherwise.
+ */
 function propsAreEqual(
   prevProps: Readonly<SidebarPhaseGroupProps>,
   nextProps: Readonly<SidebarPhaseGroupProps>,

--- a/src/pages/Exercises.tsx
+++ b/src/pages/Exercises.tsx
@@ -40,7 +40,6 @@ import { useQuizStore } from '../stores/quizStore'
  *
  * @returns The rendered exercises page
  */
-
 export default function Exercises() {
   const exercises = getAllExercises()
   const notebooks = getAllNotebooks()


### PR DESCRIPTION
Added missing JSDocs and cleaned up spacing to ensure proper JSDoc linking for exported variables, passing `find-missing-jsdoc.cjs`.

---
*PR created automatically by Jules for task [5727769987384748161](https://jules.google.com/task/5727769987384748161) started by @saint2706*