### PR TITLE
⚡ Bolt: [Performance] Defer search index preloading

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,5 @@
 - 2026-04-12 UTC - ⚡ Bolt | Micro-optimized computeRankingBoost score accumulation loop and totalLearningMs reducer to prevent V8 closure allocations from causing main-thread stuttering during active user sessions. Tested via npm run analyze:report and Vitest.
 
 - **highlightText**: Memoized the `RegExp` in `searchHighlight.tsx` to prevent redundant compilations on every search render, improving overall performance for search result rendering.
+- Used `requestIdleCallback` with a fallback to `setTimeout` to defer heavy operations like `preloadSearchIndex` during initial render, lowering main thread blocking and improving interaction times.
+- Ran project test suite and LHCI checks, validating improvements while addressing specific Chrome interstitial issues that occur in sandbox environments.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,11 @@ export default function App() {
 
   useEffect(() => {
     // ⚡ Bolt: Preload search index in background to eliminate input delay when user starts a search
-    preloadSearchIndex()
+    if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
+      window.requestIdleCallback(() => preloadSearchIndex(), { timeout: 2000 })
+    } else {
+      setTimeout(() => preloadSearchIndex(), 500)
+    }
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
⚡ Bolt optimization to improve application startup performance.

This change defers the `preloadSearchIndex` function call in the main `App` component so that it runs when the browser main thread is idle, rather than immediately on mount. This reduces the Total Blocking Time (TBT) and improves the Interaction to Next Paint (INP) metric, making the app more responsive initially while still preloading the search index in the background.

Linting, type checking, tests, and build have all passed cleanly.

---
*PR created automatically by Jules for task [17539080513842137363](https://jules.google.com/task/17539080513842137363) started by @saint2706*