### PR TITLE
🎨 Picasso: Add aria-labels to buttons across components

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -54,3 +54,10 @@ Learned that missing aria labels for decorative emojis in React can be fixed by 
 
 ## Review Page
 - Wrapped the answer reveal section in an aria-live="polite" region so screen readers announce it when revealed.
+
+### Button Accessibility Enhancements
+**Date:** 2026-04-16
+**Goal:** Improve accessibility by adding ARIA labels to buttons across multiple components.
+**Changes Made:**
+- Added specific `aria-label` attributes to buttons in `ErrorBoundary`, `MasteryCheck`, `CaseStudies`, `ProgressDashboard`, `Review`, and `Lesson` components to provide better context for screen readers, especially where button text changes dynamically or relies on visual cues.
+**Learning:** When adding ARIA labels, ensure they dynamically reflect the current state of the button if its function or text changes (e.g., 'Hide Answer' vs 'Show Answer'). Avoid redundantly placing ARIA labels if the button already has perfectly descriptive static text, though doing so does not actively harm accessibility.

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -60,6 +60,7 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
               type="button"
               className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
               onClick={this.handleRetry}
+              aria-label="Try again"
             >
               Try again
             </button>
@@ -67,6 +68,7 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
               type="button"
               className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
               onClick={this.handleReload}
+              aria-label="Reload page"
             >
               Reload page
             </button>

--- a/src/components/MasteryCheck.tsx
+++ b/src/components/MasteryCheck.tsx
@@ -76,6 +76,7 @@ export default function MasteryCheck({
         className={`mastery-check__check-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${revealed ? 'mastery-check__check-btn--revealed' : ''}`}
         onClick={() => setRevealed((r) => !r)}
         aria-expanded={revealed}
+        aria-label={revealed ? 'Hide Answer' : 'Show Answer'}
         {...(revealed && { 'aria-controls': answerId })}
       >
         {revealed ? (

--- a/src/pages/CaseStudies.tsx
+++ b/src/pages/CaseStudies.tsx
@@ -182,6 +182,7 @@ export default function CaseStudies() {
                   type="button"
                   className="cs-card__expand-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
                   aria-expanded={isExpanded}
+                  aria-label={isExpanded ? 'Hide details' : 'View details'}
                   aria-controls={`cs-content-${item.slug}`}
                   onClick={() => toggleExpand(item.slug)}
                 >

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -330,6 +330,7 @@ export default function Lesson() {
                 className={`lesson-complete-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${completed ? 'completed' : ''}`}
                 onClick={handleToggleComplete}
                 aria-pressed={completed}
+                aria-label={completed ? 'Mark lesson as incomplete' : 'Mark lesson as complete'}
               >
                 {completed ? '✓ Completed' : '○ Mark as Complete'}
               </button>

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -607,6 +607,7 @@ export default function ProgressDashboard() {
           type="button"
           className="progress-clear-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
           onClick={handleClearProgress}
+          aria-label="Clear all progress"
         >
           Clear All Progress
         </button>

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -135,6 +135,7 @@ export default function Review() {
                   type="button"
                   className="review-answer-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
                   onClick={() => setShowAnswer(true)}
+                  aria-label="Show Answer"
                 >
                   Show Answer
                 </button>
@@ -157,6 +158,7 @@ export default function Review() {
                     className={`review-action-btn review-${rating} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`}
                     onClick={() => handleRate(rating)}
                     title={`Shortcut: ${index + 1}`}
+                    aria-label={`Rate ${rating}`}
                   >
                     {getRatingLabel(rating)}
                   </button>


### PR DESCRIPTION
This PR improves the accessibility of interactive buttons across various components by adding contextual `aria-label` attributes.

**Changes:**
- `ErrorBoundary.tsx`: Added `aria-label` to the 'Try again' and 'Reload page' buttons.
- `MasteryCheck.tsx`: Added dynamic `aria-label` to the reveal answer toggle.
- `CaseStudies.tsx`: Added dynamic `aria-label` to the expand/collapse details button.
- `ProgressDashboard.tsx`: Added `aria-label` to the 'Clear All Progress' button.
- `Review.tsx`: Added `aria-label` to the 'Show Answer' and rating buttons.
- `Lesson.tsx`: Added dynamic `aria-label` to the 'Mark as Complete' button.

**Verification:**
- Ran `npm run lint`, `npm run test`, and `npm run build` with no regressions.
- All tests pass.

---
*PR created automatically by Jules for task [13762677600110221180](https://jules.google.com/task/13762677600110221180) started by @saint2706*