### PR TITLE
🧘 Buddha: [SEO] Fix semantic HTML skip in Home phase cards

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -171,3 +171,11 @@ This scroll records the harmonization of the `Coding-For-MBA` codebase for human
 -   [x] **[GEO][SEO] Structured Data XSS Fix**: Fixed the `.replace(/</g, '\\u003c')` call inside `src/components/SEOHead.tsx` and `src/components/MasteryCheck.tsx` to `.replace(/</g, '\\\\u003c')`. This ensures that `\u003c` is properly output in the serialized JS string, satisfying React's `dangerouslySetInnerHTML` escaping requirements without breaking JSON parsers.
 - Added image to WebSite schema
 - [GEO] Fixed JSON-LD escaping in SEOHead and MasteryCheck.
+
+### [Date: 2026-04-16] - Semantic HTML Optimization
+
+**Priority Areas:**
+1.  **SEO (Visibility)**: Semantic HTML hierarchy.
+
+**Changes:**
+-   [x] **[SEO] Semantic HTML Fixes**: Converted `<h3>` tags to `<h2>` in `src/pages/Home.tsx` inside the phase cards to prevent skipped heading levels and maintain strict semantic HTML hierarchy.

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -73,7 +73,7 @@ export default function Home() {
               <div className="phase-card-icon">{icon}</div>
               <div className="phase-card-title">
                 <div className="phase-num">Phase {phase.phase}</div>
-                <h3>{phase.title}</h3>
+                <h2>{phase.title}</h2>
               </div>
             </div>
             <div className="phase-card-meta">


### PR DESCRIPTION
This PR fixes a semantic HTML issue in `src/pages/Home.tsx` where phase card titles were using `<h3>` directly after an `<h1>`, resulting in skipped heading levels. The phase card titles are now correctly rendered as `<h2>` elements to maintain proper document outline hierarchy.

### Priority Areas Addressed
- **SEO (Visibility)**: Fixed skipped heading levels to ensure perfect semantic HTML mapping, directly aligning with the `Buddha` persona's SEO focus.

### Changes
- Changed `<h3>` to `<h2>` in `src/pages/Home.tsx` inside the phase cards.
- Verified validation suites (linting, tests, build, and content validation script) pass without errors.
- Added record to `.jules/buddha-scroll.md`.

---
*PR created automatically by Jules for task [8778841047907232593](https://jules.google.com/task/8778841047907232593) started by @saint2706*