### PR TITLE
⚡ Bolt: Memoize SearchPalette results mapping

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,4 @@
 - **highlightText**: Memoized the `RegExp` in `searchHighlight.tsx` to prevent redundant compilations on every search render, improving overall performance for search result rendering.
 - Used `requestIdleCallback` with a fallback to `setTimeout` to defer heavy operations like `preloadSearchIndex` during initial render, lowering main thread blocking and improving interaction times.
 - Ran project test suite and LHCI checks, validating improvements while addressing specific Chrome interstitial issues that occur in sandbox environments.
+- ⚡ **SearchPalette Component Memoization:** Wrapped search result map operations within a `useMemo` block inside `SearchPalette.tsx` to prevent expensive re-renders and React node generation on every keystroke until the debounced query is processed. Extracted `getSnippet` into a `useCallback` to prevent breaking the memoization dependencies.

--- a/src/components/SearchPalette.tsx
+++ b/src/components/SearchPalette.tsx
@@ -173,7 +173,10 @@ export default function SearchPalette({ isOpen, onClose }: SearchPaletteProps) {
           <div className="search-result-header">
             <span className="search-result-day">Day {result.item.day}</span>
             <span className="search-result-title">{result.item.title}</span>
-            <span className="search-result-badge" style={{ color: diff.color, background: diff.bg }}>
+            <span
+              className="search-result-badge"
+              style={{ color: diff.color, background: diff.bg }}
+            >
               {diff.label}
             </span>
           </div>

--- a/src/components/SearchPalette.tsx
+++ b/src/components/SearchPalette.tsx
@@ -147,10 +147,50 @@ export default function SearchPalette({ isOpen, onClose }: SearchPaletteProps) {
    * @param result - Search result to extract snippet from
    * @returns Formatted text snippet with ellipses
    */
-  function getSnippet(result: SearchResult): string {
-    const plain = result.item.plainContent || result.item.content
-    return getSearchSnippet(plain, debouncedQuery, 120)
-  }
+  const getSnippet = useCallback(
+    (result: SearchResult): string => {
+      const plain = result.item.plainContent || result.item.content
+      return getSearchSnippet(plain, debouncedQuery, 120)
+    },
+    [debouncedQuery],
+  )
+
+  // ⚡ Bolt: Memoize the search results mapping to prevent recalculation
+  // on every keystroke when debouncedQuery hasn't updated yet.
+  const renderedResults = useMemo(() => {
+    return results.map((result, index) => {
+      const diff =
+        difficultyConfig[result.item.difficulty || 'beginner'] || difficultyConfig.beginner!
+      return (
+        <div
+          key={result.item.day}
+          id={`search-result-${index}`}
+          className={`search-result-item ${index === activeIndex ? 'active' : ''}`}
+          onClick={() => navigateToResult(result)}
+          role="option"
+          aria-selected={index === activeIndex}
+        >
+          <div className="search-result-header">
+            <span className="search-result-day">Day {result.item.day}</span>
+            <span className="search-result-title">{result.item.title}</span>
+            <span className="search-result-badge" style={{ color: diff.color, background: diff.bg }}>
+              {diff.label}
+            </span>
+          </div>
+          <div className="search-result-snippet">{getSnippet(result)}</div>
+          {result.item.tags && result.item.tags.length > 0 && (
+            <div className="search-result-tags">
+              {result.item.tags.slice(0, 4).map((tag) => (
+                <span key={tag} className="search-result-tag">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )
+    })
+  }, [results, activeIndex, navigateToResult, getSnippet])
 
   if (!isOpen) return null
 
@@ -213,41 +253,7 @@ export default function SearchPalette({ isOpen, onClose }: SearchPaletteProps) {
 
         {results.length > 0 && (
           <div className="search-results" id="search-results" ref={listRef} role="listbox">
-            {results.map((result, index) => {
-              const diff =
-                difficultyConfig[result.item.difficulty || 'beginner'] || difficultyConfig.beginner!
-              return (
-                <div
-                  key={result.item.day}
-                  id={`search-result-${index}`}
-                  className={`search-result-item ${index === activeIndex ? 'active' : ''}`}
-                  onClick={() => navigateToResult(result)}
-                  role="option"
-                  aria-selected={index === activeIndex}
-                >
-                  <div className="search-result-header">
-                    <span className="search-result-day">Day {result.item.day}</span>
-                    <span className="search-result-title">{result.item.title}</span>
-                    <span
-                      className="search-result-badge"
-                      style={{ color: diff.color, background: diff.bg }}
-                    >
-                      {diff.label}
-                    </span>
-                  </div>
-                  <div className="search-result-snippet">{getSnippet(result)}</div>
-                  {result.item.tags && result.item.tags.length > 0 && (
-                    <div className="search-result-tags">
-                      {result.item.tags.slice(0, 4).map((tag) => (
-                        <span key={tag} className="search-result-tag">
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )
-            })}
+            {renderedResults}
           </div>
         )}
 


### PR DESCRIPTION
⚡ **SearchPalette Component Memoization:** Wrapped search result map operations within a `useMemo` block inside `SearchPalette.tsx` to prevent expensive re-renders and React node generation on every keystroke until the debounced query is processed. Extracted `getSnippet` into a `useCallback` to prevent breaking the memoization dependencies.

---
*PR created automatically by Jules for task [3830349931065779097](https://jules.google.com/task/3830349931065779097) started by @saint2706*