### PR TITLE
🔍 Hunter: Fixed 1 errors - Fixed any type in test

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -174,3 +174,7 @@
 - **Fixed:** Replaced `props: any` with `props: Record<string, unknown>` in `src/components/__tests__/MarkdownRenderer.test.tsx` for various component mocks.
 - **Fixed:** Replaced `toastMock: any = vi.fn()` with a properly structured object using `Object.assign` in `src/utils/__tests__/toast.test.ts`.
 - **Verified:** Build, lint, and tests pass successfully without any type errors.
+
+## Session 30
+- **Fixed:** Replaced `let consoleLogSpy: any;` with `let consoleLogSpy: ReturnType<typeof vi.spyOn>;` in `scripts/__tests__/validate-content.test.ts` to fix strict typing.
+- **Verified:** Build, lint, and tests pass successfully without any type errors.

--- a/scripts/__tests__/validate-content.test.ts
+++ b/scripts/__tests__/validate-content.test.ts
@@ -111,7 +111,7 @@ This is a sample phase body with enough content to pass validation checks becaus
   })
 
   describe('runValidation', () => {
-    let consoleLogSpy: any;
+    let consoleLogSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
       consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});


### PR DESCRIPTION
Replaced `let consoleLogSpy: any;` with `let consoleLogSpy: ReturnType<typeof vi.spyOn>;` in `scripts/__tests__/validate-content.test.ts` to satisfy strict typing rules and fix the last remaining `any` type warning in the scripts. Build, lint, and tests pass.

---
*PR created automatically by Jules for task [12759441060124555074](https://jules.google.com/task/12759441060124555074) started by @saint2706*