### PR TITLE
🔄 CI/CD: Pin valid stable GitHub Action plugin versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         node-version: [22.x]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
@@ -62,7 +62,7 @@ jobs:
         node-version: [22.x]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload unit test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: unit-test-results-${{ matrix.os }}-node-${{ matrix.node-version }}
           path: test-results/vitest-junit.xml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report-${{ matrix.os }}-node-${{ matrix.node-version }}
           path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
@@ -42,6 +42,6 @@ jobs:
         run: npm run build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/deploy-surge.yml
+++ b/.github/workflows/deploy-surge.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
@@ -34,7 +34,7 @@ jobs:
           VITE_GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@v3
         with:
           path: dist
 
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload Lighthouse report artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: lighthouse-report
           path: .lighthouseci

--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
@@ -70,14 +70,14 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Bootstrap Node workspace
         uses: ./.github/actions/node-bootstrap
 
       - name: Cache Playwright browsers
         if: ${{ github.event.inputs.run_playwright_smoke == 'true' || vars.RUN_NIGHTLY_PLAYWRIGHT_SMOKE == 'true' }}
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload Playwright HTML report
         if: ${{ failure() && (github.event.inputs.run_playwright_smoke == 'true' || vars.RUN_NIGHTLY_PLAYWRIGHT_SMOKE == 'true') }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: nightly-playwright-html-report
           path: playwright-report
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload Playwright traces
         if: ${{ failure() && (github.event.inputs.run_playwright_smoke == 'true' || vars.RUN_NIGHTLY_PLAYWRIGHT_SMOKE == 'true') }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: nightly-playwright-traces
           path: test-results
@@ -112,7 +112,7 @@ jobs:
 
       - name: Create or update failure issue
         if: ${{ failure() && github.event_name != 'pull_request' }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const title = '🚨 Nightly smoke workflow failed';
@@ -151,7 +151,7 @@ jobs:
 
       - name: Close matching failure issues on success
         if: ${{ success() && github.event_name != 'pull_request' }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const title = '🚨 Nightly smoke workflow failed';

--- a/.jules/cicd.md
+++ b/.jules/cicd.md
@@ -1,0 +1,1 @@
+- Pinned stable valid plugin action versions (e.g., actions/checkout@v4, github/codeql-action@v3) in all Github Action workflows (.github/workflows/*) fixing broken builds from v6/v7 non-existent tags


### PR DESCRIPTION
Replaces non-existent, futuristic tags (like \`actions/checkout@v6\` and
\`actions/upload-artifact@v7\`) with their actual, stable current major versions (e.g. \`v4\`). This immediately restores workflow parseability and resolves the broken CI/CD pipelines.

---
*PR created automatically by Jules for task [11502291535333388626](https://jules.google.com/task/11502291535333388626) started by @saint2706*