### PR TITLE
🧘 Buddha: [SEO/GEO improvement]

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -202,3 +202,12 @@ This scroll records the harmonization of the `Coding-For-MBA` codebase for human
 **Changes:**
 - [x] **[PERF] LCP Optimization**: Replaced `fetchPriority='auto'` with `fetchPriority={undefined}` in `MarkdownRenderer.tsx` to prevent React hydration errors or DOM mismatches for non-high priority images, strictly honoring the LCP priority parameter.
 - [x] **[SEO] Semantic HTML Fixes**: Repaired heading mapping in `Home.tsx` to correctly wrap `phase.title` using `<h3>` instead of `<h2>` within the Phase card components, preserving the semantic page outline underneath the main 'The Learning Path' `<h2>`.
+
+### [Date: Current] - Sidebar Semantic HTML Refactoring
+
+**Priority Areas:**
+1.  **SEO (Visibility)**: Semantic HTML hierarchy.
+2.  **GEO (Intelligence)**: Proper markdown structure extraction.
+
+**Changes:**
+-   [x] **[SEO] Semantic HTML Fixes**: Converted `tree-section-label` from `<div>` to `<h2>` in `src/components/Sidebar.tsx` to improve semantic document outline.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -146,7 +146,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
 
         <nav className="sidebar-nav" ref={navRef}>
           <div className="tree-section">
-            <div className="tree-section-label">workspace</div>
+            <h2 className="tree-section-label">workspace</h2>
             <PrimaryItem
               to="/"
               active={location.pathname === '/'}
@@ -178,7 +178,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
           </div>
 
           <div className="tree-section">
-            <div className="tree-section-label">practice</div>
+            <h2 className="tree-section-label">practice</h2>
             <PrimaryItem
               to="/exercises"
               active={location.pathname === '/exercises'}
@@ -203,7 +203,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
           </div>
 
           <div className="tree-section">
-            <div className="tree-section-label">curriculum · {phases.length} phases</div>
+            <h2 className="tree-section-label">curriculum · {phases.length} phases</h2>
             {phases.map((phase) => (
               <SidebarPhaseGroup
                 key={phase.phase}


### PR DESCRIPTION
Converted the `div.tree-section-label` elements in `Sidebar.tsx` to `h2` elements. This change preserves the same styling via CSS classes but provides a superior semantic document outline, improving accessibility (A11Y) for screen readers and SEO/GEO indexing.

---
*PR created automatically by Jules for task [16032047389708712926](https://jules.google.com/task/16032047389708712926) started by @saint2706*