### PR TITLE
fix(a11y+theme): accessibility audit — readability and theme consistency

### DIFF
--- a/src/styles/content-features.css
+++ b/src/styles/content-features.css
@@ -16,15 +16,15 @@
   flex-wrap: wrap;
   margin-top: 0.75rem;
   padding: 0.625rem 0.875rem;
-  background: rgba(245, 158, 11, 0.06);
-  border: 1px solid rgba(245, 158, 11, 0.15);
+  background: color-mix(in srgb, var(--amber-500) 6%, transparent);
+  border: 1px solid color-mix(in srgb, var(--amber-500) 15%, transparent);
   border-radius: var(--radius-md);
 }
 
 .prerequisite-label {
   font-size: 0.8125rem;
   font-weight: 600;
-  color: #f59e0b;
+  color: var(--amber-500);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   white-space: nowrap;
@@ -35,21 +35,21 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0.1875rem 0.625rem;
-  background: rgba(245, 158, 11, 0.1);
-  border: 1px solid rgba(245, 158, 11, 0.2);
+  background: color-mix(in srgb, var(--amber-500) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--amber-500) 20%, transparent);
   border-radius: 100px;
   font-size: 0.8125rem;
   font-weight: 500;
-  color: #fbbf24;
+  color: var(--amber-500);
   text-decoration: none;
   transition: all var(--transition-fast);
   white-space: nowrap;
 }
 
 .prerequisite-pill:hover {
-  background: rgba(245, 158, 11, 0.18);
-  border-color: rgba(245, 158, 11, 0.4);
-  color: #fcd34d;
+  background: color-mix(in srgb, var(--amber-500) 18%, transparent);
+  border-color: color-mix(in srgb, var(--amber-500) 40%, transparent);
+  color: var(--accent-tertiary);
   transform: translateY(-1px);
 }
 
@@ -97,7 +97,7 @@
   border-color: var(--border-active);
   background: var(--bg-card-hover);
   transform: translateY(-2px);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-elevated);
 }
 
 .related-lesson-day {
@@ -138,8 +138,8 @@
 .related-tag {
   font-size: 0.8125rem;
   padding: 0.125rem 0.5rem;
-  background: rgba(67, 97, 238, 0.08);
-  border: 1px solid rgba(67, 97, 238, 0.12);
+  background: color-mix(in srgb, var(--accent-primary) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-primary) 12%, transparent);
   border-radius: 100px;
   color: var(--accent-tertiary);
 }

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -187,7 +187,7 @@
 
 .dashboard-tile-label {
   font-family: var(--font-mono);
-  font-size: 0.625rem;
+  font-size: 0.6875rem;
   font-weight: 600;
   letter-spacing: var(--tracking-wide);
   text-transform: uppercase;
@@ -334,7 +334,7 @@
   transition:
     color var(--transition-fast),
     background var(--transition-fast);
-  min-height: 36px;
+  min-height: 44px;
 }
 
 .map-list-toggle-btn:hover {
@@ -459,7 +459,7 @@
 }
 
 .phase-card-meta dt {
-  font-size: 0.5625rem;
+  font-size: 0.6875rem;
   font-weight: 600;
   letter-spacing: var(--tracking-wide);
   text-transform: uppercase;

--- a/src/styles/interactive.css
+++ b/src/styles/interactive.css
@@ -101,7 +101,7 @@
 }
 
 .python-runner__stdout {
-  color: #a7f3d0;
+  color: var(--teal-500);
 }
 
 .python-runner__stdout--empty {
@@ -110,8 +110,8 @@
 }
 
 .python-runner__error {
-  color: #fca5a5;
-  background: rgba(239, 68, 68, 0.06);
+  color: var(--ruby-500);
+  background: color-mix(in srgb, var(--ruby-500) 6%, transparent);
 }
 
 /* --- Code Playground --- */
@@ -160,7 +160,7 @@
 
 .code-playground__btn:hover {
   color: var(--text-primary);
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--bg-card-hover);
 }
 
 .code-playground__btn--confirm {
@@ -233,7 +233,7 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--accent-tertiary);
-  background: rgba(67, 97, 238, 0.04);
+  background: color-mix(in srgb, var(--accent-tertiary) 4%, transparent);
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -250,10 +250,10 @@
 /* --- Exercise Widget --- */
 .exercise-widget {
   margin: 1rem 0;
-  border: 1px solid rgba(67, 97, 238, 0.15);
+  border: 1px solid color-mix(in srgb, var(--accent-primary) 15%, transparent);
   border-radius: var(--radius-md);
   overflow: hidden;
-  background: rgba(67, 97, 238, 0.03);
+  background: color-mix(in srgb, var(--accent-primary) 3%, transparent);
 }
 
 .exercise-widget__header {
@@ -261,8 +261,8 @@
   align-items: center;
   gap: 0.4rem;
   padding: 0.5rem 0.75rem;
-  background: rgba(67, 97, 238, 0.06);
-  border-bottom: 1px solid rgba(67, 97, 238, 0.08);
+  background: color-mix(in srgb, var(--accent-primary) 6%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--accent-primary) 8%, transparent);
 }
 
 .exercise-widget__icon {
@@ -325,15 +325,15 @@
   font-family: var(--font-body);
   font-weight: 600;
   color: var(--accent-tertiary);
-  background: rgba(167, 139, 250, 0.06);
-  border: 1px solid rgba(167, 139, 250, 0.15);
+  background: color-mix(in srgb, var(--accent-tertiary) 6%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-tertiary) 15%, transparent);
   border-radius: 4px;
   cursor: pointer;
   transition: all var(--motion-duration-active-fast) var(--motion-easing-standard);
 }
 
 .exercise-widget__solution-btn:hover {
-  background: rgba(167, 139, 250, 0.12);
+  background: color-mix(in srgb, var(--accent-tertiary) 12%, transparent);
 }
 
 .exercise-widget__solution-panel {
@@ -344,15 +344,15 @@
 /* --- Mastery Check --- */
 .mastery-check {
   margin: 0.75rem 0;
-  border: 1px solid rgba(245, 158, 11, 0.15);
+  border: 1px solid color-mix(in srgb, var(--amber-500) 15%, transparent);
   border-radius: var(--radius-md);
   overflow: hidden;
-  background: rgba(245, 158, 11, 0.02);
+  background: color-mix(in srgb, var(--amber-500) 2%, transparent);
   transition: border-color var(--motion-duration-active-standard) var(--motion-easing-standard);
 }
 
 .mastery-check--revealed {
-  border-color: rgba(34, 197, 94, 0.2);
+  border-color: color-mix(in srgb, var(--teal-500) 20%, transparent);
 }
 
 .mastery-check__header {
@@ -360,8 +360,8 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
-  background: rgba(245, 158, 11, 0.04);
-  border-bottom: 1px solid rgba(245, 158, 11, 0.08);
+  background: color-mix(in srgb, var(--amber-500) 4%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--amber-500) 8%, transparent);
 }
 
 .mastery-check__badge {
@@ -372,9 +372,9 @@
   height: 24px;
   font-size: 0.625rem;
   font-weight: 800;
-  color: #fbbf24;
-  background: rgba(251, 191, 36, 0.1);
-  border: 1px solid rgba(251, 191, 36, 0.2);
+  color: var(--amber-500);
+  background: color-mix(in srgb, var(--amber-500) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--amber-500) 20%, transparent);
   border-radius: 50%;
 }
 
@@ -432,7 +432,7 @@
 }
 
 .mastery-check__answer {
-  border-top: 1px solid rgba(34, 197, 94, 0.1);
+  border-top: 1px solid color-mix(in srgb, var(--teal-500) 10%, transparent);
   animation: fadeSlideIn var(--motion-duration-active-fast) ease-out;
 }
 
@@ -442,9 +442,9 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #22c55e;
-  background: rgba(34, 197, 94, 0.04);
-  border-bottom: 1px solid rgba(34, 197, 94, 0.08);
+  color: var(--teal-500);
+  background: color-mix(in srgb, var(--teal-500) 4%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--teal-500) 8%, transparent);
 }
 
 .mastery-check__answer-body {
@@ -464,9 +464,9 @@
   font-size: 0.625rem;
   font-weight: 700;
   font-family: var(--font-body);
-  color: #22c55e;
-  background: rgba(34, 197, 94, 0.08);
-  border: 1px solid rgba(34, 197, 94, 0.2);
+  color: var(--teal-500);
+  background: color-mix(in srgb, var(--teal-500) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--teal-500) 20%, transparent);
   border-radius: 4px;
   cursor: pointer;
   transition: all var(--motion-duration-active-fast) var(--motion-easing-standard);
@@ -475,8 +475,8 @@
 }
 
 .code-block-try-btn:hover {
-  background: rgba(34, 197, 94, 0.15);
-  border-color: rgba(34, 197, 94, 0.35);
+  background: color-mix(in srgb, var(--teal-500) 15%, transparent);
+  border-color: color-mix(in srgb, var(--teal-500) 35%, transparent);
 }
 
 .code-block-inline-playground {

--- a/src/styles/lesson.css
+++ b/src/styles/lesson.css
@@ -88,7 +88,7 @@
 }
 
 .byline-item dt {
-  font-size: 0.5625rem;
+  font-size: 0.6875rem;
   font-weight: 600;
   letter-spacing: var(--tracking-wide);
   text-transform: uppercase;
@@ -246,7 +246,7 @@
 
 .lesson-nav-label {
   font-family: var(--font-mono);
-  font-size: 0.625rem;
+  font-size: 0.6875rem;
   font-weight: 600;
   letter-spacing: var(--tracking-wide);
   text-transform: uppercase;

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -231,7 +231,7 @@
   padding: 0 0.45rem;
   background: var(--surface-paper);
   font-family: var(--font-mono);
-  font-size: 0.5625rem;
+  font-size: 0.6875rem;
   font-weight: 600;
   letter-spacing: var(--tracking-wide);
   color: var(--accent-primary);
@@ -362,7 +362,7 @@
   text-align: left;
   font-family: var(--font-mono);
   font-weight: 600;
-  font-size: 0.625rem;
+  font-size: 0.6875rem;
   letter-spacing: var(--tracking-wide);
   text-transform: uppercase;
   color: var(--text-secondary);

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -93,14 +93,14 @@
 .ticker-label {
   color: var(--text-muted);
   text-transform: uppercase;
-  font-size: 0.625rem;
+  font-size: 0.6875rem;
   letter-spacing: var(--tracking-wide);
 }
 
 .ticker-blocks {
   color: var(--accent-primary);
   letter-spacing: 1px;
-  font-size: 0.625rem;
+  font-size: 0.6875rem;
   line-height: 1;
 }
 
@@ -182,8 +182,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 40px;
+  height: 40px;
   background: transparent;
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);

--- a/src/styles/progress.css
+++ b/src/styles/progress.css
@@ -68,7 +68,8 @@
 
 .progress-bar-fill {
   height: 100%;
-  background: var(--gradient-hero);
+  background-color: var(--accent-primary);
+  background-image: var(--gradient-hero);
   border-radius: 100px;
   transition: width var(--transition-slow);
   min-width: 0;

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -88,6 +88,8 @@
   color: var(--text-secondary);
   cursor: pointer;
   padding: 0.4rem;
+  min-width: 40px;
+  min-height: 40px;
   border-radius: var(--radius-sm);
   transition: all var(--transition-fast);
   flex-shrink: 0;
@@ -115,7 +117,7 @@
 .tree-section-label {
   padding: 0.625rem 1.125rem 0.4rem;
   font-family: var(--font-mono);
-  font-size: 0.625rem;
+  font-size: 0.6875rem;
   font-weight: 600;
   letter-spacing: var(--tracking-wide);
   text-transform: uppercase;

--- a/src/styles/ux-features.css
+++ b/src/styles/ux-features.css
@@ -116,7 +116,8 @@
 }
 
 .scroll-progress.lesson-progress .scroll-progress-bar {
-  background: var(--gradient-hero);
+  background-color: var(--accent-primary);
+  background-image: var(--gradient-hero);
 }
 
 /* ---------- Mobile Bottom Nav ---------- */
@@ -139,13 +140,15 @@
   flex-direction: column;
   align-items: center;
   gap: 2px;
-  padding: 6px 0;
-  font-size: 0.65rem;
+  padding: 8px 0;
+  font-size: 0.75rem;
   color: var(--text-muted);
   text-decoration: none;
   transition-duration: var(--motion-duration-active-fast);
   transition-timing-function: var(--motion-easing-standard);
   flex: 1;
+  min-height: 44px;
+  justify-content: center;
 }
 
 .mobile-nav-item svg {
@@ -211,10 +214,7 @@
 
 .content-stats-page h1 {
   font-size: 2rem;
-  background: var(--gradient-hero);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--accent-primary);
   margin-bottom: 0.25rem;
 }
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -313,6 +313,18 @@
   --reading-accent-glow: rgba(240, 128, 128, 0.08);
   --text-on-accent: #ffffff;
   --text-on-brand: #2d1510;
+  --reading-theme-bg-primary: #fff3ee;
+  --reading-theme-bg-surface: #fff8f5;
+  --reading-theme-bg-card: #fff8f5;
+  --reading-theme-bg-card-hover: #ffeee6;
+  --reading-theme-bg-code: #fde8df;
+  --reading-theme-accent-primary: #9e4c49;
+  --reading-theme-accent-secondary: #b05f55;
+  --reading-theme-accent-tertiary: #a54f3a;
+  --reading-theme-border-subtle: rgba(240, 128, 128, 0.12);
+  --reading-theme-border-card: rgba(240, 128, 128, 0.18);
+  --reading-theme-border-active: rgba(240, 128, 128, 0.42);
+  --reading-theme-accent-glow: rgba(240, 128, 128, 0.08);
 }
 
 /* --- 2. Gradient Blues (dark) --- */
@@ -358,6 +370,18 @@
   --reading-border-active: rgba(94, 96, 206, 0.26);
   --reading-accent-glow: rgba(94, 96, 206, 0.1);
   --text-on-accent: #0a1020;
+  --reading-theme-bg-primary: #090918;
+  --reading-theme-bg-surface: #0f0f24;
+  --reading-theme-bg-card: #12122a;
+  --reading-theme-bg-card-hover: #1a1a36;
+  --reading-theme-bg-code: #111128;
+  --reading-theme-accent-primary: #7b80eb;
+  --reading-theme-accent-secondary: #6930c3;
+  --reading-theme-accent-tertiary: #48bfe3;
+  --reading-theme-border-subtle: rgba(150, 160, 210, 0.1);
+  --reading-theme-border-card: rgba(150, 160, 210, 0.14);
+  --reading-theme-border-active: rgba(94, 96, 206, 0.26);
+  --reading-theme-accent-glow: rgba(94, 96, 206, 0.1);
 }
 
 /* --- 3. Neon Party (dark) --- */
@@ -403,6 +427,18 @@
   --reading-border-active: rgba(0, 204, 255, 0.35);
   --reading-accent-glow: rgba(0, 204, 255, 0.1);
   --text-on-accent: #04111a;
+  --reading-theme-bg-primary: #030308;
+  --reading-theme-bg-surface: #080818;
+  --reading-theme-bg-card: #0c0c1e;
+  --reading-theme-bg-card-hover: #121228;
+  --reading-theme-bg-code: #0a0a1c;
+  --reading-theme-accent-primary: #00ccff;
+  --reading-theme-accent-secondary: #cc00ff;
+  --reading-theme-accent-tertiary: #00ffcc;
+  --reading-theme-border-subtle: rgba(0, 204, 255, 0.1);
+  --reading-theme-border-card: rgba(0, 204, 255, 0.15);
+  --reading-theme-border-active: rgba(0, 204, 255, 0.35);
+  --reading-theme-accent-glow: rgba(0, 204, 255, 0.1);
 }
 
 /* --- 4. Deep Ocean Blue (dark) --- */
@@ -444,6 +480,18 @@
   --reading-border-active: rgba(0, 100, 102, 0.3);
   --reading-accent-glow: rgba(0, 100, 102, 0.1);
   --text-on-accent: #031217;
+  --reading-theme-bg-primary: #04090f;
+  --reading-theme-bg-surface: #0c1825;
+  --reading-theme-bg-card: #0f1e2e;
+  --reading-theme-bg-card-hover: #162638;
+  --reading-theme-bg-code: #0a1520;
+  --reading-theme-accent-primary: #42b7b3;
+  --reading-theme-accent-secondary: #3d949b;
+  --reading-theme-accent-tertiary: #48bfe3;
+  --reading-theme-border-subtle: rgba(100, 180, 185, 0.1);
+  --reading-theme-border-card: rgba(100, 180, 185, 0.14);
+  --reading-theme-border-active: rgba(0, 100, 102, 0.3);
+  --reading-theme-accent-glow: rgba(0, 100, 102, 0.1);
 }
 
 /* --- 5. Pastel Dreamland (light) --- */
@@ -490,6 +538,18 @@
   --reading-accent-glow: rgba(155, 114, 207, 0.08);
   --text-on-accent: #ffffff;
   --text-on-brand: #280e3e;
+  --reading-theme-bg-primary: #f5f0fa;
+  --reading-theme-bg-surface: #faf7fd;
+  --reading-theme-bg-card: #faf7fd;
+  --reading-theme-bg-card-hover: #ede5f7;
+  --reading-theme-bg-code: #f0eaf8;
+  --reading-theme-accent-primary: #6c4aa3;
+  --reading-theme-accent-secondary: #8b4d6a;
+  --reading-theme-accent-tertiary: #4b6f9f;
+  --reading-theme-border-subtle: rgba(155, 114, 207, 0.14);
+  --reading-theme-border-card: rgba(155, 114, 207, 0.2);
+  --reading-theme-border-active: rgba(155, 114, 207, 0.44);
+  --reading-theme-accent-glow: rgba(155, 114, 207, 0.08);
 }
 
 /* --- 6. Golden Summer Fields (light) --- */
@@ -536,6 +596,18 @@
   --reading-accent-glow: rgba(212, 163, 115, 0.08);
   --text-on-accent: #ffffff;
   --text-on-brand: #261e08;
+  --reading-theme-bg-primary: #fdf7d8;
+  --reading-theme-bg-surface: #fefae0;
+  --reading-theme-bg-card: #fefae0;
+  --reading-theme-bg-card-hover: #faedcd;
+  --reading-theme-bg-code: #f5eccc;
+  --reading-theme-accent-primary: #7f5b22;
+  --reading-theme-accent-secondary: #654a1c;
+  --reading-theme-accent-tertiary: #5d6f36;
+  --reading-theme-border-subtle: rgba(180, 140, 80, 0.14);
+  --reading-theme-border-card: rgba(180, 140, 80, 0.2);
+  --reading-theme-border-active: rgba(184, 133, 58, 0.44);
+  --reading-theme-accent-glow: rgba(212, 163, 115, 0.08);
 }
 
 /* --- 7. Light Steel (light) --- */
@@ -582,6 +654,18 @@
   --reading-accent-glow: rgba(73, 80, 87, 0.06);
   --text-on-accent: #ffffff;
   --text-on-brand: #0d1117;
+  --reading-theme-bg-primary: #f0f1f3;
+  --reading-theme-bg-surface: #f8f9fa;
+  --reading-theme-bg-card: #f8f9fa;
+  --reading-theme-bg-card-hover: #dee2e6;
+  --reading-theme-bg-code: #e9ecef;
+  --reading-theme-accent-primary: #495057;
+  --reading-theme-accent-secondary: #343a40;
+  --reading-theme-accent-tertiary: #5f6670;
+  --reading-theme-border-subtle: rgba(73, 80, 87, 0.1);
+  --reading-theme-border-card: rgba(73, 80, 87, 0.15);
+  --reading-theme-border-active: rgba(73, 80, 87, 0.36);
+  --reading-theme-accent-glow: rgba(73, 80, 87, 0.06);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary

- **Critical theming bug fixed**: All 7 non-default palette definitions were missing `--reading-theme-*` tokens, causing lesson reading mode to render with terminal-dark values regardless of which palette the user selected (peach-sorbet, gradient-blues, neon-party, deep-ocean-blue, pastel-dreamland, golden-summer-fields, light-steel).
- **Invisible content fixed**: `--gradient-hero: none` on terminal-dark made the content-stats page `h1` transparent and progress bars invisible. All three affected elements now have proper `var(--accent-primary)` fallbacks.
- **Hardcoded colors replaced**: Interactive components (exercise widgets, mastery checks, Python runner, prerequisite pills) used hardcoded `rgba(67,97,238,...)` / `rgba(245,158,11,...)` / `#a7f3d0` / `#fca5a5` values that broke on light palettes. All replaced with `color-mix(in srgb, var(--semantic-token) X%, transparent)`.
- **Minimum font size enforced**: Labels at 0.5625rem (9px) and 0.625rem (10px) across home, lesson, sidebar, markdown, and navbar bumped to 0.6875rem (11px) minimum.
- **Touch targets improved**: Mobile nav items given `min-height: 44px`, map-list toggle `min-height: 36px→44px`, hamburger and sidebar-close `36px→40px`.

## Files Changed

| File | Changes |
|------|---------|
| `variables.css` | +84 lines: `--reading-theme-*` tokens for all 7 legacy palettes |
| `interactive.css` | Hardcoded rgba → `color-mix()` with semantic tokens |
| `content-features.css` | Hardcoded amber → `var(--amber-500)` + `color-mix()` |
| `ux-features.css` | Gradient-text bug fix, scroll progress fallback, mobile nav touch target |
| `progress.css` | Progress bar fallback with `background-color` before `background-image` |
| `home.css` | Font sizes + map-list touch target |
| `lesson.css` | Font sizes |
| `sidebar.css` | Font sizes + sidebar-close touch target |
| `markdown.css` | Font sizes |
| `navbar.css` | Font sizes + hamburger size |

## Test Plan

- [ ] Switch to each of the 9 palettes and open a lesson — reading surface should match the active palette, never show dark terminal values on a light palette
- [ ] Verify content-stats page h1 is visible on terminal-dark (default)
- [ ] Verify progress bars render with accent color on terminal-dark
- [ ] Verify exercise widgets, mastery checks, and python runner output colors adapt on bone-light and peach-sorbet palettes
- [ ] Tap hamburger and mobile nav items on a touch device — all targets ≥ 40px
- [ ] Check all label text is readable (none below 11px)

https://claude.ai/code/session_01L1GUHNdeJjCJwP18DKh1uf

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1GUHNdeJjCJwP18DKh1uf)_