### PR TITLE
🎨 Picasso: [UX improvement] Add focus-visible states to buttons

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -61,3 +61,4 @@ Learned that missing aria labels for decorative emojis in React can be fixed by 
 **Changes Made:**
 - Added specific `aria-label` attributes to buttons in `ErrorBoundary`, `MasteryCheck`, `CaseStudies`, `ProgressDashboard`, `Review`, and `Lesson` components to provide better context for screen readers, especially where button text changes dynamically or relies on visual cues.
 **Learning:** When adding ARIA labels, ensure they dynamically reflect the current state of the button if its function or text changes (e.g., 'Hide Answer' vs 'Show Answer'). Avoid redundantly placing ARIA labels if the button already has perfectly descriptive static text, though doing so does not actively harm accessibility.
+Added focus-visible outlines to sidebar close, navbar hamburger, and navbar search clear buttons for better keyboard accessibility.

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -80,7 +80,7 @@ export default function Navbar({ onToggleSidebar, sidebarOpen }: NavbarProps) {
         <div className="navbar-row-left">
           <button
             type="button"
-            className="navbar-hamburger"
+            className="navbar-hamburger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
             onClick={onToggleSidebar}
             aria-label="Toggle sidebar menu"
             title="Toggle sidebar"
@@ -124,7 +124,7 @@ export default function Navbar({ onToggleSidebar, sidebarOpen }: NavbarProps) {
             {query ? (
               <button
                 type="button"
-                className="navbar-search-clear"
+                className="navbar-search-clear focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
                 onClick={handleClear}
                 aria-label="Clear search"
                 title="Clear search"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -131,7 +131,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
           </Link>
           <button
             type="button"
-            className="sidebar-close"
+            className="sidebar-close focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
             onClick={onClose}
             aria-label="Close sidebar"
             aria-expanded={isOpen}


### PR DESCRIPTION
Added standard `focus-visible` Tailwind classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`) to key navigational icon buttons (`navbar-hamburger`, `navbar-search-clear`, `sidebar-close`). This ensures keyboard users can clearly see which element has focus, improving accessibility (WCAG AA compliance) without impacting the visual design for mouse users.

---
*PR created automatically by Jules for task [12956194754424246294](https://jules.google.com/task/12956194754424246294) started by @saint2706*