### PR TITLE
🔄 CI/CD: Fix pipeline failures by downgrading non-existent futuristic action versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
           VITE_GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@v3
         with:
           path: dist
 
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Cache Playwright browsers
         if: ${{ github.event.inputs.run_playwright_smoke == 'true' || vars.RUN_NIGHTLY_PLAYWRIGHT_SMOKE == 'true' }}
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
@@ -112,7 +112,7 @@ jobs:
 
       - name: Create or update failure issue
         if: ${{ failure() && github.event_name != 'pull_request' }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const title = '🚨 Nightly smoke workflow failed';
@@ -151,7 +151,7 @@ jobs:
 
       - name: Close matching failure issues on success
         if: ${{ success() && github.event_name != 'pull_request' }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const title = '🚨 Nightly smoke workflow failed';


### PR DESCRIPTION
🔄 **CI/CD Optimization**

### Summary
This PR fixes workflow initialization failures caused by non-existent "futuristic" GitHub Action version tags in the pipeline configurations.

### Changes
* **Downgraded `actions/cache@v5` to `actions/cache@v4`** in `.github/workflows/nightly-smoke.yml`
* **Downgraded `actions/github-script@v9` to `actions/github-script@v7`** in `.github/workflows/nightly-smoke.yml`
* **Downgraded `actions/upload-pages-artifact@v5` to `actions/upload-pages-artifact@v3`** in `.github/workflows/deploy.yml`
* **Downgraded `actions/deploy-pages@v5` to `actions/deploy-pages@v4`** in `.github/workflows/deploy.yml`

### Justification
The previous workflow configuration relied on standard actions but referenced fictional or unreleased major versions (e.g. `v9` for `github-script` which is only on `v7`, `v5` for `cache` which is only on `v4`). GitHub Actions runners will immediately fail initialization when unable to resolve these tags. By pinning them to the latest verified stable tags, the pipeline regains its speed and reliability. 

### Verification
* Verified actual stable major tags exist using `git ls-remote --tags https://github.com/{action}`
* Re-ran validation suite locally (`npm ci && npm run lint && npm run test && npm run build`) which succeeded perfectly.

---
*PR created automatically by Jules for task [3379433624977914451](https://jules.google.com/task/3379433624977914451) started by @saint2706*