### PR TITLE
📚 Docs: Fix broken links across markdown lessons

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -105,3 +105,8 @@ Added complete and well-formatted JSDoc to the following exported components, fu
   - Ran validation, linting, tests, and build—all passed successfully.
 - Added JSDoc comments to exported React components (, , , , ) based on  audit.
 - Added JSDoc comments to exported React components based on scripts audit.
+
+## 2026-04-28
+- Checked for missing JSDocs/TSDocs in src/ (none found).
+- Ran markdown-link-check to identify broken links in content/lessons.
+- Fixed several broken links across various markdown files including a16z.com, nngroup.com, austinhenley.com, agi.money, cloudoptimizer.com, realpython.com, aif360.mybluemix.net, huggingface.co, and leetcode.com.

--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Phase_Overview.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Phase_Overview.md
@@ -57,7 +57,7 @@ You learned the art of functions—encapsulating logic into reusable blocks. Com
 
 ### Practice Platforms
 
-- [LeetCode Easy Problems](https://leetcode.com/problemset/?difficulty=EASY) — Algorithm practice
+- [LeetCode Easy Problems](https://leetcode.com/problemset/all/) — Algorithm practice
 - [HackerRank Python Track](https://www.hackerrank.com/domains/python) — Skill certification path
 - [Exercism Python](https://exercism.org/tracks/python) — Mentored code exercises
 

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Phase_Overview.md
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Phase_Overview.md
@@ -700,7 +700,7 @@ You've completed **Phase 5: Advanced ML & Deep Learning**!
 
 ### Official Documentation
 
-- [Hugging Face Transformers](https://huggingface.co/docs/transformers)
+- [Hugging Face Transformers](https://huggingface.co/docs/transformers/index)
 - [PyTorch Geometric](https://pytorch-geometric.readthedocs.io)
 - [MLflow](https://mlflow.org/docs/latest/index.html)
 - [XGBoost](https://xgboost.readthedocs.io)

--- a/content/lessons/Phase_10_Generative_AI_LLM_Engineering/Day_118_AI_Product_Design/README.md
+++ b/content/lessons/Phase_10_Generative_AI_LLM_Engineering/Day_118_AI_Product_Design/README.md
@@ -387,11 +387,11 @@ Feedback from production users serves several purposes: (1) **Model monitoring**
 
 ## Further Reading
 
-- [The State of AI Product Design — a16z](https://a16z.com/ai-product-design/)
-- [Designing with AI in Mind — Nielsen Norman Group](https://www.nngroup.com/articles/ai-thinking-new/)
-- [Boring AI: How to Ship AI Features That Actually Work](https://austinhenley.com/blog/boringai.html)
+- [The State of AI Product Design — a16z](https://a16z.com/2023/11/16/ai-product-design/)
+- [Designing with AI in Mind — Nielsen Norman Group](https://www.nngroup.com/articles/ai-tools-productivity/)
+- [Boring AI: How to Ship AI Features That Actually Work](https://austinhenley.com/blog/designingboringai.html)
 - [Google PAIR — People + AI Research](https://pair.withgoogle.com/guidebook/)
-- [AI UX Patterns Library — Human-AI Interaction Patterns](https://www.agi.money/)
+- [AI UX Patterns Library — Human-AI Interaction Patterns](https://www.shapeofai.com/rules)
 
 ---
 

--- a/content/lessons/Phase_10_Generative_AI_LLM_Engineering/Day_120_Capstone_AI_Data_Assistant/README.md
+++ b/content/lessons/Phase_10_Generative_AI_LLM_Engineering/Day_120_Capstone_AI_Data_Assistant/README.md
@@ -715,7 +715,7 @@ Open-ended — key considerations for a strong answer: (1) **Prompt Engineering 
 
 - [Full LangChain RAG Tutorial — Harrison Chase](https://python.langchain.com/docs/tutorials/rag/)
 - [Building Production RAG Applications — LlamaIndex](https://docs.llamaindex.ai/en/stable/optimizing/production_rag/)
-- [Real Python — Building a CLI Chatbot](https://realpython.com/build-a-chatbot-python-cheat-sheet/)
+- [Real Python — Building a CLI Chatbot](https://realpython.com/build-a-python-chatbot/)
 - [Anthropic's Guide to Building Effective Agents](https://www.anthropic.com/research/building-effective-agents)
 
 ---

--- a/content/lessons/Phase_10_Generative_AI_LLM_Engineering/Phase_Overview.md
+++ b/content/lessons/Phase_10_Generative_AI_LLM_Engineering/Phase_Overview.md
@@ -421,7 +421,7 @@ This is the phase that closes the gap between where most MBA graduates are (talk
 - [Unsloth](https://github.com/unslothai/unsloth) — Fast LoRA/QLoRA fine-tuning
 - [instructor](https://github.com/jxnl/instructor) — Structured LLM outputs with Pydantic
 - [LangSmith](https://docs.smith.langchain.com/) — LLM tracing and evaluation
-- [AIF360](https://aif360.mybluemix.net/) — AI Fairness 360
+- [AIF360](https://aif360.res.ibm.com/) — AI Fairness 360
 
 ### Books
 

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_121_Cloud_Fundamentals/README.md
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_121_Cloud_Fundamentals/README.md
@@ -314,7 +314,7 @@ On-demand: pay by the hour/second with no commitment, full flexibility. Reserved
 - [AWS Well-Architected Framework](https://aws.amazon.com/architecture/well-architected/) — 6 pillars of cloud architecture
 - [GCP Cloud Architecture Center](https://cloud.google.com/architecture) — Reference architectures for data platforms
 - [FinOps Foundation](https://www.finops.org/) — Cloud financial management best practices
-- [Cloud Comparison Tool](https://cloudoptimizer.com/) — Side-by-side service comparison
+- [Cloud Comparison Tool](https://comparecloud.in/) — Side-by-side service comparison
 
 ---
 


### PR DESCRIPTION
Fixed broken URLs across markdown files in `content/lessons/` identified by `markdown-link-check`, replacing them with working versions. Updated `.jules/docs-progress.md` with an action summary.

---
*PR created automatically by Jules for task [18234987772983014249](https://jules.google.com/task/18234987772983014249) started by @saint2706*