### PR TITLE
🎨 Picasso: [UX improvement] Add focus-visible classes to interactive buttons

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -61,3 +61,4 @@ Learned that missing aria labels for decorative emojis in React can be fixed by 
 **Changes Made:**
 - Added specific `aria-label` attributes to buttons in `ErrorBoundary`, `MasteryCheck`, `CaseStudies`, `ProgressDashboard`, `Review`, and `Lesson` components to provide better context for screen readers, especially where button text changes dynamically or relies on visual cues.
 **Learning:** When adding ARIA labels, ensure they dynamically reflect the current state of the button if its function or text changes (e.g., 'Hide Answer' vs 'Show Answer'). Avoid redundantly placing ARIA labels if the button already has perfectly descriptive static text, though doing so does not actively harm accessibility.
+🎨 Picasso: Added focus-visible classes for keyboard accessibility to Navbar, Sidebar, and MapListToggle buttons.

--- a/src/components/MapListToggle.tsx
+++ b/src/components/MapListToggle.tsx
@@ -43,7 +43,7 @@ function Toggle({ defaultActive, ariaLabel = 'Switch view', children }: TogglePr
               type="button"
               role="tab"
               aria-selected={isActive}
-              className={`map-list-toggle-btn${isActive ? ' active' : ''}`}
+              className={`map-list-toggle-btn${isActive ? ' active' : ''} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`}
               onClick={() => setActive(v.props.label)}
             >
               {v.props.glyph && (

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -80,7 +80,7 @@ export default function Navbar({ onToggleSidebar, sidebarOpen }: NavbarProps) {
         <div className="navbar-row-left">
           <button
             type="button"
-            className="navbar-hamburger"
+            className="navbar-hamburger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
             onClick={onToggleSidebar}
             aria-label="Toggle sidebar menu"
             title="Toggle sidebar"
@@ -124,7 +124,7 @@ export default function Navbar({ onToggleSidebar, sidebarOpen }: NavbarProps) {
             {query ? (
               <button
                 type="button"
-                className="navbar-search-clear"
+                className="navbar-search-clear focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
                 onClick={handleClear}
                 aria-label="Clear search"
                 title="Clear search"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -131,7 +131,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
           </Link>
           <button
             type="button"
-            className="sidebar-close"
+            className="sidebar-close focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
             onClick={onClose}
             aria-label="Close sidebar"
             aria-expanded={isOpen}


### PR DESCRIPTION
🎨 Picasso: [UX improvement] Add focus-visible classes to interactive buttons

Adds keyboard focus-visible styling (outline and ring) to `navbar-hamburger`, `navbar-search-clear`, `sidebar-close`, and `map-list-toggle-btn` to ensure accessible keyboard navigation focus states across core UI components. Updates `.jules/picasso.md` with action log.

---
*PR created automatically by Jules for task [4351889129005438317](https://jules.google.com/task/4351889129005438317) started by @saint2706*