### PR TITLE
🔍 Hunter: Fixed 1 error - strict typing for `resolveRun` in `PythonRunner.test.tsx`

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -178,3 +178,10 @@
 ## Session 30
 - **Fixed:** Replaced `let consoleLogSpy: any;` with `let consoleLogSpy: ReturnType<typeof vi.spyOn>;` in `scripts/__tests__/validate-content.test.ts` to fix strict typing.
 - **Verified:** Build, lint, and tests pass successfully without any type errors.
+
+## Session 31
+- **Fixed:** Replaced `let resolveRun: (value: any) => void` with `let resolveRun: (value: { output: string | null; error: string | null }) => void` in `src/components/__tests__/PythonRunner.test.tsx`.
+- **Verified:** Build, lint, and tests pass successfully without unhandled exceptions.
+
+## Session 32
+- **Fixed:** No issues remain for today. Build, lint, tests pass completely with full strict types.

--- a/src/components/__tests__/PythonRunner.test.tsx
+++ b/src/components/__tests__/PythonRunner.test.tsx
@@ -122,7 +122,7 @@ describe('PythonRunner', () => {
   })
 
   it('prevents multiple simultaneous executions', async () => {
-    let resolveRun: (value: any) => void
+    let resolveRun: (value: { output: string | null; error: string | null }) => void
     mockRunPython.mockReturnValue(
       new Promise((resolve) => {
         resolveRun = resolve
@@ -221,7 +221,7 @@ describe('PythonRunner', () => {
   })
 
   it('ignores stale execution results when cancelled', async () => {
-    let resolveRun: (value: any) => void
+    let resolveRun: (value: { output: string | null; error: string | null }) => void
     mockRunPython.mockReturnValue(
       new Promise((resolve) => {
         resolveRun = resolve


### PR DESCRIPTION
Replaced `any` with the specific execution output interface `{ output: string | null; error: string | null }` for the `resolveRun` function mock in `PythonRunner.test.tsx` to resolve strict typing violations and improve test safety. Update agent tracking log to reflect resolved issue.

---
*PR created automatically by Jules for task [529041983270801077](https://jules.google.com/task/529041983270801077) started by @saint2706*