### PR TITLE
🎨 Picasso: [UX improvement] Sidebar accessibility fix

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -62,3 +62,5 @@ Learned that missing aria labels for decorative emojis in React can be fixed by 
 - Added specific `aria-label` attributes to buttons in `ErrorBoundary`, `MasteryCheck`, `CaseStudies`, `ProgressDashboard`, `Review`, and `Lesson` components to provide better context for screen readers, especially where button text changes dynamically or relies on visual cues.
 **Learning:** When adding ARIA labels, ensure they dynamically reflect the current state of the button if its function or text changes (e.g., 'Hide Answer' vs 'Show Answer'). Avoid redundantly placing ARIA labels if the button already has perfectly descriptive static text, though doing so does not actively harm accessibility.
 Added focus-visible outlines to sidebar close, navbar hamburger, and navbar search clear buttons for better keyboard accessibility.
+
+- Added role="presentation" to the sidebar overlay to prevent screen readers from interpreting the click background layer incorrectly.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -112,6 +112,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
         className={`sidebar-overlay ${isOpen ? 'visible' : ''}`}
         onClick={onClose}
         aria-hidden="true"
+        role="presentation"
       />
       <aside
         id="app-sidebar"


### PR DESCRIPTION
Added `role="presentation"` to the `<div className="sidebar-overlay">` component in `Sidebar.tsx`.
This explicitly tells screen readers to ignore the overlay as a structural/semantic element while preserving its `onClick` backdrop functionality for mouse users. This avoids a common accessibility false-positive where a generic `div` is given an interactive click handler.
Logged progress in `.jules/picasso.md`.

---
*PR created automatically by Jules for task [1903130140635073340](https://jules.google.com/task/1903130140635073340) started by @saint2706*