### PR TITLE
📚 Docs: Add missing JSDocs to components and utilities

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -110,3 +110,9 @@ Added complete and well-formatted JSDoc to the following exported components, fu
 - Checked for missing JSDocs/TSDocs in src/ (none found).
 - Ran markdown-link-check to identify broken links in content/lessons.
 - Fixed several broken links across various markdown files including a16z.com, nngroup.com, austinhenley.com, agi.money, cloudoptimizer.com, realpython.com, aif360.mybluemix.net, huggingface.co, and leetcode.com.
+- **[2026-04-30] Added JSDoc comments to UI components and Utils**
+  - Added missing typed JSDoc comments to `src/components/EditorialCover.tsx` for `EditorialCover`
+  - Added missing typed JSDoc comments to `src/components/MapListToggle.tsx` for `MapListToggle`
+  - Added missing typed JSDoc comments to `src/components/TerminalDashboard.tsx` for `TerminalDashboard`
+  - Added missing typed JSDoc comments to `src/utils/contentLoader.ts` for `getReadingTime`
+  - Verified `PageSkeleton` in `src/components/Skeleton.tsx` already had complete JSDoc.

--- a/src/components/EditorialCover.tsx
+++ b/src/components/EditorialCover.tsx
@@ -55,4 +55,7 @@ const EditorialCover = Object.assign(Cover, {
   Actions,
 })
 
+/**
+ * The combined EditorialCover component exposing sub-components.
+ */
 export default EditorialCover

--- a/src/components/MapListToggle.tsx
+++ b/src/components/MapListToggle.tsx
@@ -65,4 +65,7 @@ function Toggle({ defaultActive, ariaLabel = 'Switch view', children }: TogglePr
 
 const MapListToggle = Object.assign(Toggle, { View })
 
+/**
+ * The combined MapListToggle component exposing the View sub-component.
+ */
 export default MapListToggle

--- a/src/components/TerminalDashboard.tsx
+++ b/src/components/TerminalDashboard.tsx
@@ -67,4 +67,7 @@ const TerminalDashboard = Object.assign(Dashboard, {
   TileFooter,
 })
 
+/**
+ * The combined TerminalDashboard component exposing Tile, TileHeader, TileBody, and TileFooter sub-components.
+ */
 export default TerminalDashboard

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -818,6 +818,11 @@ export function getNotebook(phaseNum: string | number): ImmutableNotebook | unde
 
 const readingTimeCache = new Map<string, number>()
 
+/**
+ * Calculates the estimated reading time for a given markdown content.
+ * @param {string} content - The markdown content to calculate reading time for.
+ * @returns {number} The estimated reading time in minutes.
+ */
 export function getReadingTime(content: string): number {
   if (readingTimeCache.has(content)) {
     return readingTimeCache.get(content)!


### PR DESCRIPTION
Added missing JSDoc/TSDoc comments to exported components and functions to improve code documentation and IntelliSense, fulfilling the "Docs" persona role.

---
*PR created automatically by Jules for task [4613661516377014462](https://jules.google.com/task/4613661516377014462) started by @saint2706*