### PR TITLE
🎨 Picasso: Add focus-visible styles to map-list-toggle-btn

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -64,3 +64,7 @@ Learned that missing aria labels for decorative emojis in React can be fixed by 
 Added focus-visible outlines to sidebar close, navbar hamburger, and navbar search clear buttons for better keyboard accessibility.
 
 - Added role="presentation" to the sidebar overlay to prevent screen readers from interpreting the click background layer incorrectly.
+
+## Focus-Visible for Map List Toggle
+- Added `focus-visible` styles to the `.map-list-toggle-btn` class in `src/styles/home.css`.
+- Ensures proper keyboard accessibility and visible focus indication for the toggle segmented control used to switch between lists and map views.

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -341,6 +341,11 @@
   color: var(--text-heading);
 }
 
+.map-list-toggle-btn:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
 .map-list-toggle-btn.active {
   color: var(--text-on-accent);
   background: var(--accent-primary);


### PR DESCRIPTION
This PR adds `focus-visible` styles to the `.map-list-toggle-btn` selector used for switching between "Phases" and "Map" views on the homepage curriculum section.

**Reasoning:**
The toggle button lacked visual indication of keyboard focus, creating an accessibility gap. By utilizing `:focus-visible`, an outline is cleanly provided for keyboard users matching `var(--accent-primary)`, while remaining invisible to mouse users to maintain the visual design standard.

**Before:** No visible ring when focused via the keyboard.
**After:** A 2px solid lime/accent outline surrounds the button when focused, with a 2px offset.

**Verification:**
- Visual verification screenshot attached
- Build and tests pass successfully

---
*PR created automatically by Jules for task [12448938951156319842](https://jules.google.com/task/12448938951156319842) started by @saint2706*