### PR TITLE
🎨 Picasso: [UX improvement] Add aria-label to MapListToggle buttons

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -68,3 +68,4 @@ Added focus-visible outlines to sidebar close, navbar hamburger, and navbar sear
 ## Focus-Visible for Map List Toggle
 - Added `focus-visible` styles to the `.map-list-toggle-btn` class in `src/styles/home.css`.
 - Ensures proper keyboard accessibility and visible focus indication for the toggle segmented control used to switch between lists and map views.
+Added aria-label to MapListToggle icon buttons for improved accessibility.

--- a/src/components/MapListToggle.tsx
+++ b/src/components/MapListToggle.tsx
@@ -43,6 +43,7 @@ function Toggle({ defaultActive, ariaLabel = 'Switch view', children }: TogglePr
               type="button"
               role="tab"
               aria-selected={isActive}
+              aria-label={v.props.label}
               className={`map-list-toggle-btn${isActive ? ' active' : ''}`}
               onClick={() => setActive(v.props.label)}
             >


### PR DESCRIPTION
🎨 Picasso: [UX improvement] Add aria-label to MapListToggle buttons

Adds `aria-label` to the map-list toggle buttons to improve accessibility for screen readers navigating the `MapListToggle` component. The label text is dynamically driven by the component's existing `label` prop. Recorded learnings in `.jules/picasso.md`.

---
*PR created automatically by Jules for task [2386159342323663884](https://jules.google.com/task/2386159342323663884) started by @saint2706*