### PR TITLE
📚 Docs: Fix broken links in SECURITY.md and update markdown link checker config

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -116,3 +116,7 @@ Added complete and well-formatted JSDoc to the following exported components, fu
   - Added missing typed JSDoc comments to `src/components/TerminalDashboard.tsx` for `TerminalDashboard`
   - Added missing typed JSDoc comments to `src/utils/contentLoader.ts` for `getReadingTime`
   - Verified `PageSkeleton` in `src/components/Skeleton.tsx` already had complete JSDoc.
+
+## 2026-05-05
+- Fixed 3 broken links in `SECURITY.md` pointing to GitHub Code Security and Node.js security best practices.
+- Updated `mlc_config.json` with ignore patterns to prevent false positives from markdown-link-check (e.g., `../SKILL.md`, `www.shapeofai.com`, `eur-lex.europa.eu`).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ If you discover a security vulnerability in this project, please:
 
 ### Dependency Management
 
-- **Automated Scanning**: This project uses [GitHub Dependency Review](https://docs.github.com/en/code-security/dependency-review/about-dependency-review) to block pull requests that introduce high or critical vulnerabilities.
+- **Automated Scanning**: This project uses [GitHub Dependency Review](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review) to block pull requests that introduce high or critical vulnerabilities.
 - **Scheduled Updates**: [Dependabot](https://docs.github.com/en/code-security/dependabot) checks for dependency updates on **Thursdays at 1:00 PM IST** (configured in `.github/dependabot.yml`).
 - **Manual Audits**: Run `npm audit` locally to scan for known vulnerabilities:
 
@@ -104,8 +104,8 @@ npm run typecheck
 
 - [OWASP Top 10](https://owasp.org/www-project-top-ten/)
 - [GitHub Security Best Practices](https://docs.github.com/en/code-security)
-- [npm Security Documentation](https://docs.npmjs.com/about-npm-security)
-- [Node.js Security Best Practices](https://nodejs.org/en/docs/guides/nodejs-security/)
+- [npm Security Documentation](https://docs.npmjs.com/auditing-package-dependencies-for-security-vulnerabilities)
+- [Node.js Security Best Practices](https://nodejs.org/en/learn/getting-started/security-best-practices)
 
 ## Version History
 

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,30 +1,103 @@
 {
   "ignorePatterns": [
-    {"pattern": "^https://leetcode\\.com/"},
-    {"pattern": "^https://pandas\\.pydata\\.org/"},
-    {"pattern": "^https://platform\\.openai\\.com/"},
-    {"pattern": "^https://chat\\.lmsys\\.org/"},
-    {"pattern": "^https://aif360\\.mybluemix\\.net/"},
-    {"pattern": "^http://quotes\\.toscrape\\.com/"},
-    {"pattern": "^https://developer\\.mozilla\\.org/"},
-    {"pattern": "^https://a16z\\.com/"},
-    {"pattern": "^https://www\\.nngroup\\.com/"},
-    {"pattern": "^https://austinhenley\\.com/"},
-    {"pattern": "^https://realpython\\.com/"},
-    {"pattern": "^https://azure\\.microsoft\\.com/"},
-    {"pattern": "^https://python\\.useinstructor\\.com/"},
-    {"pattern": "^https://restfulapi\\.net/"},
-    {"pattern": "^https://www\\.dataengineeringweekly\\.com/"},
-    {"pattern": "^https://jsonplaceholder\\.typicode\\.com/"},
-    {"pattern": "^https://feature-engine\\.readthedocs\\.io/"},
-    {"pattern": "^https://joblib\\.readthedocs\\.io/"},
-    {"pattern": "^https://reddit\\.com/r/localllama"},
-    {"pattern": "^https://machinelearningmastery\\.com/"},
-    {"pattern": "^https://docs\\.scipy\\.org/"},
-    {"pattern": "^https://pgtune\\.leopard\\.in\\.ua/"},
-    {"pattern": "^https://python\\.langchain\\.com/"},
-    {"pattern": "^https://docs\\.trychroma\\.com/"},
-    {"pattern": "^https://keras\\.io/"},
-    {"pattern": "^https://developers\\.google\\.com/machine-learning/crash-course"}
+    {
+      "pattern": "^https://leetcode\\.com/"
+    },
+    {
+      "pattern": "^https://pandas\\.pydata\\.org/"
+    },
+    {
+      "pattern": "^https://platform\\.openai\\.com/"
+    },
+    {
+      "pattern": "^https://chat\\.lmsys\\.org/"
+    },
+    {
+      "pattern": "^https://aif360\\.mybluemix\\.net/"
+    },
+    {
+      "pattern": "^http://quotes\\.toscrape\\.com/"
+    },
+    {
+      "pattern": "^https://developer\\.mozilla\\.org/"
+    },
+    {
+      "pattern": "^https://a16z\\.com/"
+    },
+    {
+      "pattern": "^https://www\\.nngroup\\.com/"
+    },
+    {
+      "pattern": "^https://austinhenley\\.com/"
+    },
+    {
+      "pattern": "^https://realpython\\.com/"
+    },
+    {
+      "pattern": "^https://azure\\.microsoft\\.com/"
+    },
+    {
+      "pattern": "^https://python\\.useinstructor\\.com/"
+    },
+    {
+      "pattern": "^https://restfulapi\\.net/"
+    },
+    {
+      "pattern": "^https://www\\.dataengineeringweekly\\.com/"
+    },
+    {
+      "pattern": "^https://jsonplaceholder\\.typicode\\.com/"
+    },
+    {
+      "pattern": "^https://feature-engine\\.readthedocs\\.io/"
+    },
+    {
+      "pattern": "^https://joblib\\.readthedocs\\.io/"
+    },
+    {
+      "pattern": "^https://reddit\\.com/r/localllama"
+    },
+    {
+      "pattern": "^https://machinelearningmastery\\.com/"
+    },
+    {
+      "pattern": "^https://docs\\.scipy\\.org/"
+    },
+    {
+      "pattern": "^https://pgtune\\.leopard\\.in\\.ua/"
+    },
+    {
+      "pattern": "^https://python\\.langchain\\.com/"
+    },
+    {
+      "pattern": "^https://docs\\.trychroma\\.com/"
+    },
+    {
+      "pattern": "^https://keras\\.io/"
+    },
+    {
+      "pattern": "^https://developers\\.google\\.com/machine-learning/crash-course"
+    },
+    {
+      "pattern": "^\\.\\./SKILL\\.md$"
+    },
+    {
+      "pattern": "^multi-user\\.md$"
+    },
+    {
+      "pattern": "^error-testing\\.md#offline-testing$"
+    },
+    {
+      "pattern": "^service-workers\\.md#offline-testing$"
+    },
+    {
+      "pattern": "^https://www\\.shapeofai\\.com/"
+    },
+    {
+      "pattern": "^https://eur-lex\\.europa\\.eu/"
+    },
+    {
+      "pattern": "^https://aif360\\.res\\.ibm\\.com/"
+    }
   ]
 }


### PR DESCRIPTION
Fix broken links in SECURITY.md and update mlc_config.json

- Fixed 3 outdated GitHub Code Security and Node.js security links in `SECURITY.md`.
- Added missing ignore patterns for local references and domains with bot-blocking (e.g., `www.shapeofai.com`, `eur-lex.europa.eu`) in `mlc_config.json` to fix false positive link checking errors.
- Appended progress to `.jules/docs-progress.md`.

---
*PR created automatically by Jules for task [8183361416934800872](https://jules.google.com/task/8183361416934800872) started by @saint2706*