### PR TITLE
Add Phase 4 quizzes for all 14 days (Days 37–48)

### DIFF
--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_37B_Probability_and_Statistics_for_ML/quiz.json
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_37B_Probability_and_Statistics_for_ML/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": "37B",
+    "questions": [
+        {
+            "id": "d37Bq01",
+            "type": "multiple_choice",
+            "question": "In Bayes' theorem — P(H|E) = P(E|H) × P(H) / P(E) — an email spam classifier computes P(spam | 'free'). If P(spam)=0.20, P('free'|spam)=0.40, and P('free'|ham)=0.02, what is P(spam | 'free') approximately?",
+            "options": [
+                "20% — the prior probability of spam",
+                "40% — the likelihood of seeing 'free' in spam",
+                "82% — the updated posterior probability after observing the word",
+                "60% — the complement of P('free'|ham)"
+            ],
+            "answer": 2,
+            "explanation": "P('free') = 0.20×0.40 + 0.80×0.02 = 0.096. P(spam|'free') = (0.40 × 0.20) / 0.096 ≈ 0.833. Bayes' theorem updates the prior (20% spam) with the evidence (word 'free' is 20× more likely in spam than ham) to produce the posterior (~83%). This is exactly how Naive Bayes classifiers work."
+        },
+        {
+            "id": "d37Bq02",
+            "type": "multiple_choice",
+            "question": "A call center receives an average of 12 customer calls per hour. Which distribution models the probability of receiving exactly 15 calls in a given hour?",
+            "options": [
+                "Normal distribution with μ=12",
+                "Binomial distribution with n=15 and p=0.8",
+                "Poisson distribution with λ=12",
+                "Uniform distribution between 0 and 24"
+            ],
+            "answer": 2,
+            "explanation": "The Poisson distribution models the count of rare, independent events per unit of time when the average rate (λ) is known. Call arrivals per hour with an average rate perfectly fit this: `stats.poisson(mu=12).pmf(15)`. Use Poisson for arrivals, defects, requests, or any count of events in a fixed interval."
+        },
+        {
+            "id": "d37Bq03",
+            "type": "multiple_choice",
+            "question": "Why does the Central Limit Theorem matter for k-fold cross-validation?",
+            "options": [
+                "It guarantees your model will not overfit on any individual fold",
+                "It ensures the mean accuracy across folds is approximately normally distributed, making confidence intervals and significance tests valid",
+                "It proves that k=5 always produces better estimates than k=3",
+                "It shows that accuracy will improve as you add more training data"
+            ],
+            "answer": 1,
+            "explanation": "The CLT states that the mean of many independent samples approaches a normal distribution regardless of the underlying distribution. When you average accuracy across k folds, the CLT guarantees this mean is approximately normal—even if individual fold accuracies aren't. This makes confidence intervals (mean ± z×SE) and model comparison tests statistically valid."
+        },
+        {
+            "id": "d37Bq04",
+            "type": "multiple_choice",
+            "question": "An A/B test on a new checkout page yields p-value = 0.03. A product manager says: 'There's a 97% chance the new design is better.' What is wrong with this statement?",
+            "options": [
+                "Nothing is wrong — a p-value of 0.03 means exactly a 97% probability of improvement",
+                "The correct interpretation is that, if there were truly no difference, results this extreme would occur only 3% of the time — the p-value says nothing about the probability the new design is better",
+                "The p-value threshold should be 0.01 for A/B tests, so the result is not significant",
+                "The p-value only applies to the null hypothesis, not the treatment group"
+            ],
+            "answer": 1,
+            "explanation": "A p-value of 0.03 means: 'Assuming no true difference, we'd see data this extreme 3% of the time.' It does NOT mean 'there's a 97% probability the new design is better.' That probabilistic statement requires Bayesian analysis with a prior. The correct conclusion is: we reject the null hypothesis at α=0.05. Always report effect size alongside p-value to convey practical significance."
+        },
+        {
+            "id": "d37Bq05",
+            "type": "multiple_choice",
+            "question": "You want to estimate the 95% confidence interval for average cart value without assuming the data is normally distributed. Which technique is appropriate?",
+            "options": [
+                "Use the normal distribution formula: mean ± 1.96 × std",
+                "Bootstrapping: repeatedly resample the data with replacement, compute the mean each time, and take the 2.5th–97.5th percentile of bootstrap means",
+                "Multiply the sample mean by 0.95 and 1.05 to get bounds",
+                "Use the Poisson distribution since cart values are counts"
+            ],
+            "answer": 1,
+            "explanation": "Bootstrapping makes no distributional assumptions. By resampling (with replacement) thousands of times and computing the mean each time, you build an empirical distribution of the statistic. The 2.5th and 97.5th percentiles of these bootstrap means form a non-parametric 95% CI—valid even for skewed data like cart values, which follow a log-normal distribution."
+        }
+    ]
+}

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_37C_Sklearn_Pipelines/quiz.json
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_37C_Sklearn_Pipelines/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": "37C",
+    "questions": [
+        {
+            "id": "d37Cq01",
+            "type": "multiple_choice",
+            "question": "In sklearn, a `StandardScaler` is `fit_transform`-ed on the entire dataset before the train-test split. What problem does this cause?",
+            "options": [
+                "The scaler will fail if there are missing values",
+                "Test set statistics (mean and std) leak into the scaler, causing the preprocessing to be optimistically tuned to the test data",
+                "The model will train on unscaled features and produce wrong predictions",
+                "Cross-validation scores will be lower than expected"
+            ],
+            "answer": 1,
+            "explanation": "Fitting the scaler on all data before splitting means the scaler 'sees' test statistics during training. The test set is no longer truly unseen—its mean and std influenced the preprocessing. A `Pipeline` prevents this by fitting every preprocessing step only on the training fold during cross-validation, making the test set genuinely unseen."
+        },
+        {
+            "id": "d37Cq02",
+            "type": "multiple_choice",
+            "question": "What does `ColumnTransformer` with `remainder='passthrough'` do to columns not mentioned in any transformer?",
+            "options": [
+                "It drops all unspecified columns (same as the default behavior)",
+                "It raises a ValueError for columns without a transformer",
+                "It passes unspecified columns through unchanged, including them in the output",
+                "It applies StandardScaler to unspecified columns automatically"
+            ],
+            "answer": 2,
+            "explanation": "`remainder='passthrough'` keeps all columns not listed in any transformer and appends them unchanged to the transformed output. The default `remainder='drop'` silently removes them. Use `passthrough` for binary or already-encoded features you want to preserve as-is alongside your numeric and categorical transformations."
+        },
+        {
+            "id": "d37Cq03",
+            "type": "multiple_choice",
+            "question": "You built a custom sklearn transformer `OutlierClipper`. When writing `fit()`, why must it `return self`?",
+            "options": [
+                "So sklearn can verify that the transformer ran without errors",
+                "To support method chaining: `fit_transform(X)` calls `fit(X).transform(X)`, which requires `fit()` to return the fitted object",
+                "To prevent garbage collection from deleting the fitted parameters",
+                "Because sklearn's `Pipeline` calls `fit()` twice by default"
+            ],
+            "answer": 1,
+            "explanation": "`fit_transform(X)` is implemented as `fit(X).transform(X)`. If `fit()` returned `None`, the chain `.transform(X)` would raise an `AttributeError`. Returning `self` from `fit()` is a core sklearn convention—it enables method chaining and lets `Pipeline` call `transform()` on the fitted object after `fit()` completes."
+        },
+        {
+            "id": "d37Cq04",
+            "type": "multiple_choice",
+            "question": "A `Pipeline` has steps named `'preprocessor'` and `'classifier'` (a `RandomForestClassifier`). How do you reference `n_estimators` in a `GridSearchCV` `param_grid`?",
+            "options": [
+                "{'n_estimators': [100, 200]}",
+                "{'RandomForestClassifier__n_estimators': [100, 200]}",
+                "{'classifier__n_estimators': [100, 200]}",
+                "{'classifier.n_estimators': [100, 200]}"
+            ],
+            "answer": 2,
+            "explanation": "GridSearchCV uses the `'step_name__parameter'` double-underscore syntax to reference parameters inside a Pipeline. The step name (as given to the Pipeline) is `'classifier'`, and the parameter is `n_estimators`. This syntax works at any depth: `'preprocessor__num__imputer__strategy'` can reference a nested pipeline step."
+        },
+        {
+            "id": "d37Cq05",
+            "type": "multiple_choice",
+            "question": "What is the main production benefit of serializing a trained sklearn Pipeline with `joblib.dump()`?",
+            "options": [
+                "The pipeline file is encrypted, protecting the model from unauthorized use",
+                "The entire fitted pipeline—all transformers plus the model—is saved as one file; loading it and calling `.predict()` on raw data applies all preprocessing steps automatically",
+                "Joblib compression reduces the model size to near zero",
+                "The pipeline can be converted directly to a REST API endpoint"
+            ],
+            "answer": 1,
+            "explanation": "Serializing a fitted Pipeline bundles all fitted transformers (imputer with learned medians, scaler with learned means/stds, encoder with learned categories) together with the trained model. Loading it with `joblib.load()` and calling `.predict()` on raw data automatically applies every preprocessing step in the correct order—eliminating manual reproduction of transformations and preventing the 'it worked on my laptop' failure."
+        }
+    ]
+}

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_37_Conclusion/quiz.json
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_37_Conclusion/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 37,
+    "questions": [
+        {
+            "id": "d37q01",
+            "type": "multiple_choice",
+            "question": "You have a NumPy array `a = np.array([[1], [2], [3]])` with shape (3, 1) and `b = np.array([10, 20, 30])` with shape (3,). What is the result of `a + b`?",
+            "options": [
+                "A 1D array [11, 22, 33]",
+                "A 3×3 matrix where each row of a is added to the full array b",
+                "An error because the shapes are incompatible",
+                "A 3×1 array [11, 22, 33]"
+            ],
+            "answer": 1,
+            "explanation": "NumPy broadcasting expands `a` (3, 1) and `b` (3,) to shape (3, 3). Each row of `a` is added to the entire array `b`, producing [[11, 21, 31], [12, 22, 32], [13, 23, 33]]. Broadcasting is one of NumPy's most powerful features for vectorized operations."
+        },
+        {
+            "id": "d37q02",
+            "type": "multiple_choice",
+            "question": "What is the difference between `df.groupby('department')['salary'].mean()` and `df.groupby('department')['salary'].transform('mean')`?",
+            "options": [
+                "They produce identical results; `transform` is just an alias for `mean`",
+                "`mean()` returns one value per group; `transform('mean')` returns a Series the same length as the original DataFrame with each row replaced by its group's mean",
+                "`transform` is faster than `mean()` for large DataFrames",
+                "`mean()` ignores NaN values while `transform('mean')` does not"
+            ],
+            "answer": 1,
+            "explanation": "`groupby().mean()` returns a compact result with one row per group. `transform('mean')` returns values aligned with the original index—every row gets its group's mean. This is essential for creating features like 'salary relative to department average' without losing the original row structure."
+        },
+        {
+            "id": "d37q03",
+            "type": "multiple_choice",
+            "question": "Which visualization is most appropriate for exploring the relationship between a categorical feature and a continuous target variable before building an ML model?",
+            "options": [
+                "Scatter plot with the category on the x-axis",
+                "Line chart connecting category means",
+                "Box plot (or violin plot) showing the target distribution per category",
+                "Pie chart of the category proportions"
+            ],
+            "answer": 2,
+            "explanation": "A box plot shows the median, quartiles, and outliers of the continuous target for each category—revealing whether the category is predictive. It answers 'do different categories produce different target distributions?' A scatter plot is for two continuous variables, and pie charts don't show distribution spread."
+        },
+        {
+            "id": "d37q04",
+            "type": "multiple_choice",
+            "question": "Why should you convert a low-cardinality string column (e.g., 'status' with values 'active', 'inactive', 'pending') to `category` dtype in pandas?",
+            "options": [
+                "It enables arithmetic operations on string columns",
+                "It reduces memory usage by storing integer codes instead of repeating string values, and speeds up groupby operations",
+                "It automatically one-hot encodes the column for ML models",
+                "It prevents missing values from appearing in the column"
+            ],
+            "answer": 1,
+            "explanation": "A `category` dtype stores each unique string once plus an integer code per row—instead of repeating the full string millions of times. For a column with 5 unique values across 1M rows, memory savings can be 10-50×. GroupBy and comparison operations are also faster on integer codes."
+        },
+        {
+            "id": "d37q05",
+            "type": "multiple_choice",
+            "question": "You're framing an ML problem: 'Predict which customers will churn next month.' What is X, y, and the ML type?",
+            "options": [
+                "X = churn label, y = customer features, type = unsupervised clustering",
+                "X = customer behavioral and demographic features, y = binary churn label (1=churned, 0=retained), type = supervised binary classification",
+                "X = customer features, y = churn probability as a continuous value, type = regression",
+                "X = all available data columns, y = customer ID, type = supervised regression"
+            ],
+            "answer": 1,
+            "explanation": "Churn prediction is a classic supervised binary classification problem. Features (X) include behavioral signals like login frequency, usage metrics, tenure, and plan type. The target (y) is a binary label: did the customer cancel within the prediction window? The model learns to predict this label from the features."
+        }
+    ]
+}

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_38_Linear_Algebra/quiz.json
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_38_Linear_Algebra/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 38,
+    "questions": [
+        {
+            "id": "d38q01",
+            "type": "multiple_choice",
+            "question": "Two word embedding vectors have a dot product of 0. What does this tell you about the concepts they represent?",
+            "options": [
+                "The two words are identical in meaning",
+                "The two words are antonyms",
+                "The vectors are orthogonal — the words are unrelated, with no directional alignment in embedding space",
+                "One of the vectors has zero magnitude"
+            ],
+            "answer": 2,
+            "explanation": "Geometrically, a · b = |a||b|cos(θ). A dot product of 0 (with non-zero vectors) means cos(θ) = 0, so θ = 90°—the vectors are perpendicular. In embedding space, orthogonal vectors represent unrelated concepts. This property is also used in PCA, where principal components are orthogonal to ensure they capture independent sources of variance."
+        },
+        {
+            "id": "d38q02",
+            "type": "multiple_choice",
+            "question": "Matrix A has shape (100, 50) and matrix B has shape (50, 10). What is the shape of A @ B, and what does this operation represent in a neural network context?",
+            "options": [
+                "Shape (50, 50) — combining the inner dimensions",
+                "Shape (100, 10) — transforming 100 samples from 50 features to 10 outputs",
+                "Shape (100, 50) — no change because dimensions match",
+                "This operation is invalid because the shapes are incompatible"
+            ],
+            "answer": 1,
+            "explanation": "Matrix multiplication (m×n) @ (n×p) = (m×p). Here: (100×50) @ (50×10) = (100×10). In a neural network, A represents 100 data samples with 50 features, B represents a weight matrix mapping 50 inputs to 10 neurons, and the result is 100 samples with 10 activations. Every neural network layer is fundamentally this operation plus an activation function."
+        },
+        {
+            "id": "d38q03",
+            "type": "multiple_choice",
+            "question": "In the normal equation w = (X^T X)^{-1} X^T y, why do we compute X^T X?",
+            "options": [
+                "To normalize the feature magnitudes before inversion",
+                "To create a square (n_features × n_features) matrix that can be inverted — since X itself is rectangular and cannot be inverted",
+                "To reduce computation from O(n) to O(1)",
+                "To ensure the target variable y aligns with the feature dimensions"
+            ],
+            "answer": 1,
+            "explanation": "X has shape (n_samples × n_features) and is rectangular — it cannot be inverted. X^T X has shape (n_features × n_features), which is square and can be inverted. This represents the covariance structure of the features, and inverting it 'normalizes' for correlations between features to find the optimal weights. For large datasets, use gradient descent instead — inverting large matrices is computationally expensive."
+        },
+        {
+            "id": "d38q04",
+            "type": "multiple_choice",
+            "question": "In PCA, what do eigenvalues of the covariance matrix represent?",
+            "options": [
+                "The correlation between pairs of features",
+                "The number of dimensions required to represent the data",
+                "The variance explained by each principal component — larger eigenvalue means that direction captures more spread in the data",
+                "The mean of each feature after centering"
+            ],
+            "answer": 2,
+            "explanation": "Eigenvalues measure how much variance each principal component captures. If eigenvalues are [5.2, 2.1, 0.4, 0.1], PC1 explains 5.2/7.8 = 67% of total variance, and PC1+PC2 together explain 94%. You keep components with the largest eigenvalues, retaining maximum information while reducing dimensions. This is the foundation of dimensionality reduction."
+        },
+        {
+            "id": "d38q05",
+            "type": "multiple_choice",
+            "question": "Your recommendation system represents 1 million users and 100,000 products as 100-dimensional vectors. Why is brute-force dot product similarity impractical, and what is the standard solution?",
+            "options": [
+                "Dot products can't be computed for vectors with more than 50 dimensions",
+                "Storing 100M × 100-dimensional vectors exceeds available memory, so you must reduce to 10 dimensions first",
+                "Brute-force requires trillions of operations; approximate nearest neighbor libraries like FAISS or Annoy find similar vectors in logarithmic time",
+                "The dot product is undefined for recommendation systems — use Euclidean distance instead"
+            ],
+            "answer": 2,
+            "explanation": "Finding similarities for one query against 100K products requires 100K × 100 = 10M dot product operations; doing this for 1M users simultaneously is trillions of operations. Approximate nearest neighbor (ANN) libraries like FAISS (Facebook) and Annoy (Spotify) use tree structures or hashing to find similar vectors in O(log n) time, enabling real-time recommendations at scale."
+        }
+    ]
+}

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_39_Calculus/quiz.json
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_39_Calculus/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 39,
+    "questions": [
+        {
+            "id": "d39q01",
+            "type": "multiple_choice",
+            "question": "For the loss function L(w) = (w - 3)², the derivative at w = 5 is positive. Which direction should gradient descent move w to reduce the loss?",
+            "options": [
+                "Increase w (move in the positive direction) because the slope is positive",
+                "Decrease w (move in the negative direction) because gradient descent moves opposite to the gradient",
+                "Keep w unchanged because a positive derivative means we are at a minimum",
+                "Set w = 0 to reset the optimization"
+            ],
+            "answer": 1,
+            "explanation": "A positive gradient means the function increases as w increases — so we must move in the opposite direction to go downhill. The gradient descent update rule is: w = w - learning_rate × gradient. Since gradient > 0, we subtract a positive number, decreasing w. Intuitively: if you're on the right side of a valley (slope going up to the right), you walk left to reach the bottom."
+        },
+        {
+            "id": "d39q02",
+            "type": "multiple_choice",
+            "question": "You set the learning rate to 0.9 for gradient descent on a simple quadratic loss. After several steps, the loss oscillates wildly and fails to converge. What is the most likely cause?",
+            "options": [
+                "The learning rate is too small, so convergence is very slow",
+                "The loss function has no minimum, so the algorithm keeps searching",
+                "The learning rate is too large — each step overshoots the minimum, landing on the opposite slope and oscillating or diverging",
+                "The gradient computation has a numerical precision error"
+            ],
+            "answer": 2,
+            "explanation": "A large learning rate causes steps that overshoot the minimum: you land past the bottom on the opposite slope, take another large step back, and oscillate. If large enough, the oscillations grow exponentially, causing the loss to diverge to infinity (NaN). Reduce the learning rate by 10× and check that the loss decreases monotonically."
+        },
+        {
+            "id": "d39q03",
+            "type": "multiple_choice",
+            "question": "Why is the chain rule essential for training neural networks through backpropagation?",
+            "options": [
+                "It allows the network to skip layers during the forward pass for efficiency",
+                "Neural networks are compositions of many functions (layers); the chain rule lets us compute how the final loss changes with respect to weights in any layer by multiplying derivatives through the chain",
+                "It ensures all activation functions produce outputs in the range [0, 1]",
+                "It eliminates the need to compute partial derivatives for the bias terms"
+            ],
+            "answer": 1,
+            "explanation": "Backpropagation computes ∂Loss/∂W₁ for weights in Layer 1 by applying the chain rule: (∂Loss/∂output) × (∂output/∂Layer3) × (∂Layer3/∂Layer2) × (∂Layer2/∂W₁). Each term is the local derivative at that layer. Without the chain rule, we couldn't efficiently propagate gradient signals from the output back through dozens of composed layers."
+        },
+        {
+            "id": "d39q04",
+            "type": "multiple_choice",
+            "question": "Your model's training loss becomes `NaN` after 40 iterations. What are the most likely causes and the first fix to try?",
+            "options": [
+                "The dataset is too small; collect more data and retrain",
+                "The model architecture is too shallow; add more layers",
+                "The learning rate is too high, causing exploding gradients; reduce it by 10×–100× and optionally add gradient clipping",
+                "The loss function is wrong; switch from MSE to cross-entropy"
+            ],
+            "answer": 2,
+            "explanation": "NaN loss is almost always caused by numerical overflow from an excessively large learning rate. Weights grow exponentially, producing NaN in activations or the loss computation. Fix: (1) reduce learning rate by 10–100×, (2) add gradient clipping (`np.clip(grad, -1.0, 1.0)`), (3) ensure input features are normalized. Always monitor `max(|weights|)` and `max(|gradients|)` to detect instability early."
+        },
+        {
+            "id": "d39q05",
+            "type": "multiple_choice",
+            "question": "What is the difference between Batch Gradient Descent and Mini-batch Gradient Descent, and which is the standard choice for deep learning?",
+            "options": [
+                "Batch uses the full dataset per update; Mini-batch uses small random subsets (32–128 samples). Mini-batch is standard for deep learning",
+                "Batch computes exact gradients; Mini-batch approximates them. Batch is standard because it is more accurate",
+                "Mini-batch processes one sample at a time; Batch processes all samples. They produce identical updates",
+                "Batch is for classification; Mini-batch is for regression. Choice depends on the problem type"
+            ],
+            "answer": 0,
+            "explanation": "Batch GD uses the entire dataset for each parameter update (accurate but slow for large data). Stochastic GD uses one sample (fast but noisy). Mini-batch GD — batches of 32–128 samples — is the best of both: GPU-efficient, lower memory footprint, beneficial gradient noise that helps escape local minima. It is the default for deep learning with Adam, RMSprop, and SGD optimizers."
+        }
+    ]
+}

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_40_Intro_to_ML/quiz.json
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_40_Intro_to_ML/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 40,
+    "questions": [
+        {
+            "id": "d40q01",
+            "type": "multiple_choice",
+            "question": "What is the fundamental difference between traditional programming and machine learning?",
+            "options": [
+                "Traditional programming is faster; ML is more accurate",
+                "Traditional programming provides Data + Rules → Answers; ML provides Data + Answers → Rules (the model)",
+                "ML requires more code than traditional programming to solve the same problem",
+                "Traditional programming works on text data; ML works on numeric data"
+            ],
+            "answer": 1,
+            "explanation": "In traditional programming, developers encode explicit rules (if-then logic) to transform data into answers. Machine learning inverts this: you supply data and the known answers (labels), and the algorithm discovers the rules automatically. This makes ML powerful for problems where the rules are too complex to write by hand—like spam detection, image recognition, or language understanding."
+        },
+        {
+            "id": "d40q02",
+            "type": "multiple_choice",
+            "question": "A model achieves 98% training accuracy but only 75% test accuracy. What condition is this, and what is the most direct fix?",
+            "options": [
+                "Underfitting — add more features or use a more complex model",
+                "Overfitting — the model memorized training noise; regularize, simplify the model, or get more training data",
+                "Data leakage — the test set was accidentally included in training",
+                "Class imbalance — the 2% of hard cases are dragging down test accuracy"
+            ],
+            "answer": 1,
+            "explanation": "A large gap between training and test performance (98% vs 75%) is the classic signature of overfitting: the model memorized training examples including noise rather than learning generalizable patterns. Fixes include regularization (L1/L2), reducing model complexity, early stopping, dropout (for neural networks), or collecting more training data to make memorization harder."
+        },
+        {
+            "id": "d40q03",
+            "type": "multiple_choice",
+            "question": "A fraud detection model achieves 99% accuracy on a dataset where 1% of transactions are fraudulent. Why is this metric misleading?",
+            "options": [
+                "99% accuracy is too high — the model is definitely overfitting",
+                "A model that predicts 'not fraud' for every transaction would also achieve 99% accuracy while catching zero fraud; accuracy ignores class imbalance",
+                "Fraud detection requires at least 99.9% accuracy to be production-ready",
+                "The model was likely trained on test data, inflating the accuracy"
+            ],
+            "answer": 1,
+            "explanation": "When classes are heavily imbalanced (99% negative, 1% positive), the trivial classifier that always predicts the majority class achieves 99% accuracy without being useful at all. For imbalanced problems, use Recall (how many frauds did we catch?), Precision (how many fraud alerts are real?), F1 Score, or ROC-AUC as metrics that account for class distribution."
+        },
+        {
+            "id": "d40q04",
+            "type": "multiple_choice",
+            "question": "Why use 5-fold cross-validation instead of a single 80/20 train-test split for model evaluation?",
+            "options": [
+                "Cross-validation trains 5 separate models, which can then be ensembled for better predictions",
+                "Cross-validation is faster than a single split because each fold uses less data",
+                "Cross-validation gives every sample a chance to be in the test set, reducing variance in performance estimates and producing more reliable confidence intervals",
+                "A single split is only valid for regression; classification always requires cross-validation"
+            ],
+            "answer": 2,
+            "explanation": "A single split may be lucky or unlucky depending on which samples end up in the test set. 5-fold CV uses every sample exactly once as test data (across the 5 folds) and averages the results. This dramatically reduces variance in the estimate and provides a standard deviation across folds to quantify reliability. The trade-off is 5× the computation."
+        },
+        {
+            "id": "d40q05",
+            "type": "multiple_choice",
+            "question": "For a hospital tumor screening model, which metric should be maximized, and why?",
+            "options": [
+                "Precision — because false positives (unnecessary biopsies) are more costly than missing tumors",
+                "Accuracy — because the overall correctness rate matters most in medical settings",
+                "Recall — because missing an actual tumor (false negative) is far more dangerous than an unnecessary follow-up",
+                "F1 Score — because medical models must balance precision and recall equally"
+            ],
+            "answer": 2,
+            "explanation": "In medical screening, a false negative (missed tumor) can be fatal. Recall = TP / (TP + FN) measures what fraction of actual positives you caught. Maximizing recall minimizes missed cases, even at the cost of more false alarms (which trigger additional diagnostic tests). Once a screening model flags a patient, follow-up tests with higher precision confirm the diagnosis."
+        }
+    ]
+}

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_41_Supervised_Learning_Regression/quiz.json
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_41_Supervised_Learning_Regression/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 41,
+    "questions": [
+        {
+            "id": "d41q01",
+            "type": "multiple_choice",
+            "question": "A linear regression model for house prices produces coefficients: sqft=100, bedrooms=20000, age=-500. How do you interpret the `age` coefficient of -500?",
+            "options": [
+                "The model is incorrect because negative coefficients are invalid in regression",
+                "Houses with older age tend to have lower predicted prices; each additional year reduces the predicted price by $500, holding other features constant",
+                "Age has the smallest absolute impact compared to sqft and bedrooms",
+                "The negative sign means age is negatively correlated with the residuals"
+            ],
+            "answer": 1,
+            "explanation": "Each coefficient in linear regression represents the change in the target for a one-unit increase in that feature, holding all other features constant. A coefficient of -500 for `age` means each additional year of house age reduces the predicted price by $500, all else equal. The sign and magnitude directly encode directional relationships, making linear regression highly interpretable."
+        },
+        {
+            "id": "d41q02",
+            "type": "multiple_choice",
+            "question": "Why does feature scaling (e.g., StandardScaler) matter when applying Ridge regression but generally not affect LinearRegression's predictions?",
+            "options": [
+                "LinearRegression requires features to have zero mean; Ridge requires unit variance",
+                "Ridge adds a regularization penalty proportional to coefficient magnitude; without scaling, large-scale features get unfairly penalized less than small-scale features, distorting which features are regularized",
+                "Feature scaling speeds up Ridge but has no effect on model accuracy",
+                "LinearRegression automatically normalizes features internally; Ridge does not"
+            ],
+            "answer": 1,
+            "explanation": "Ridge penalizes large coefficients: Loss = MSE + α × Σ(wᵢ²). If `sqft` ranges 800–3000 and `age` ranges 0–50, the coefficient for `age` will be much larger in raw scale to achieve the same predictive effect. Ridge would unfairly penalize `age` more. Scaling puts all features on the same scale so the regularization is applied fairly across all coefficients."
+        },
+        {
+            "id": "d41q03",
+            "type": "multiple_choice",
+            "question": "A polynomial regression model of degree 15 fits training data perfectly (R²=0.99) but performs poorly on new data (R²=0.45). A degree-2 model achieves R²=0.88 on both. What should you choose and why?",
+            "options": [
+                "Degree 15 — higher training accuracy always indicates a better model",
+                "Degree 2 — it generalizes better because it captures the true signal without memorizing noise",
+                "Degree 15 with more training data to close the gap",
+                "Average the predictions of both models for a balanced result"
+            ],
+            "answer": 1,
+            "explanation": "Degree 15 is severely overfitting: it memorized every noise fluctuation in the training set, so it fails on new data. Degree 2 captures the underlying quadratic trend without fitting noise, achieving good performance on both train and test. This is the bias-variance tradeoff — a simpler model with slightly higher bias generalizes far better than a complex model with high variance."
+        },
+        {
+            "id": "d41q04",
+            "type": "multiple_choice",
+            "question": "What is the key difference between Ridge (L2) and Lasso (L1) regularization?",
+            "options": [
+                "Ridge works for regression; Lasso works for classification",
+                "Ridge penalizes the sum of squared coefficients, shrinking all toward zero but rarely to exactly zero; Lasso penalizes absolute values and can force some coefficients to exactly zero, performing feature selection",
+                "Lasso requires more data than Ridge to work effectively",
+                "Ridge is faster to train; Lasso produces more accurate predictions"
+            ],
+            "answer": 1,
+            "explanation": "Ridge (L2) adds α × Σ(wᵢ²) to the loss, shrinking all coefficients toward zero proportionally. Lasso (L1) adds α × Σ|wᵢ|, which can push coefficients to exactly 0 — effectively removing features. Use Ridge when you believe most features are relevant; use Lasso when you suspect many features are irrelevant and want automatic feature selection."
+        },
+        {
+            "id": "d41q05",
+            "type": "multiple_choice",
+            "question": "RMSE is $25,000 for a house price model predicting values ranging from $200,000 to $800,000. R² is 0.87. How should you interpret these results?",
+            "options": [
+                "The model is useless — an error of $25,000 is too large for real estate",
+                "RMSE of $25,000 (~5% of the price range) suggests reasonable accuracy; R²=0.87 means the model explains 87% of price variance — both indicate a useful model worth deploying",
+                "R²=0.87 is below the required threshold of 0.90 for production models",
+                "RMSE and R² measure different things and cannot be interpreted together"
+            ],
+            "answer": 1,
+            "explanation": "Context matters for RMSE: $25,000 on a $200K–$800K price range is roughly ±5–12%, which is competitive with Zillow's Zestimate. R²=0.87 means 87% of price variance is explained by the model — strong for real estate given unquantified factors like renovations and neighborhood dynamics. Always interpret RMSE relative to the target scale, not in isolation."
+        }
+    ]
+}

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_42_Supervised_Learning_Classification_Part_1/quiz.json
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_42_Supervised_Learning_Classification_Part_1/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 42,
+    "questions": [
+        {
+            "id": "d42q01",
+            "type": "multiple_choice",
+            "question": "Logistic regression predicts a churn probability of 0.73 for a customer. What does this output represent, and how is a final class label determined?",
+            "options": [
+                "The model is 73% confident — this is just a confidence score, not a true probability",
+                "P(churn | features) = 0.73; a threshold (typically 0.5) is applied to convert this to a binary prediction: ≥0.5 → 'churn', <0.5 → 'stay'",
+                "The customer has been misclassified 73% of the time in training",
+                "There are 73 features predicting the outcome"
+            ],
+            "answer": 1,
+            "explanation": "Logistic regression outputs a calibrated probability P(positive class | features) using the sigmoid function. A threshold converts probabilities to class labels. The default threshold is 0.5, but for business problems you often tune it — e.g., use 0.3 for churn (act on more at-risk customers) or 0.7 for fraud (only flag high-confidence cases). `model.predict_proba(X)[:, 1]` returns these probabilities."
+        },
+        {
+            "id": "d42q02",
+            "type": "multiple_choice",
+            "question": "A confusion matrix shows: True Negatives=450, False Positives=30, False Negatives=15, True Positives=5. What is the Recall, and what does it mean for a churn detection system?",
+            "options": [
+                "Recall = 5/(5+30) = 14% — of predicted churners, 14% actually churn",
+                "Recall = 5/(5+15) = 25% — the model caught only 25% of actual churners, missing 75%",
+                "Recall = 450/(450+30) = 94% — the model correctly identified 94% of non-churners",
+                "Recall = (450+5)/500 = 91% — overall accuracy of the model"
+            ],
+            "answer": 1,
+            "explanation": "Recall = TP / (TP + FN) = 5 / (5 + 15) = 25%. This means only 1 in 4 actual churners is being identified — the model misses 75% of customers at risk. For churn prevention (where you want to intervene before customers leave), low recall is catastrophic. Lower the classification threshold or optimize for recall during training to catch more churners, even at the cost of some false alarms."
+        },
+        {
+            "id": "d42q03",
+            "type": "multiple_choice",
+            "question": "What does the ROC curve plot, and what does an AUC of 0.50 indicate about a classifier?",
+            "options": [
+                "ROC plots Precision vs Recall; AUC=0.50 means perfect discrimination",
+                "ROC plots True Positive Rate (Recall) vs False Positive Rate at varying thresholds; AUC=0.50 means the model performs no better than random guessing",
+                "ROC plots training accuracy vs test accuracy; AUC=0.50 means the model is overfit",
+                "ROC plots model confidence vs actual labels; AUC=0.50 means the model is well-calibrated"
+            ],
+            "answer": 1,
+            "explanation": "The ROC (Receiver Operating Characteristic) curve plots True Positive Rate (Recall) on the y-axis vs False Positive Rate on the x-axis at every possible classification threshold. AUC (Area Under the Curve) measures overall discrimination ability. AUC=0.50 is a random classifier (diagonal line). AUC=1.0 is perfect. AUC is threshold-independent, making it ideal for comparing models regardless of the operating threshold."
+        },
+        {
+            "id": "d42q04",
+            "type": "multiple_choice",
+            "question": "When would you prioritize Precision over Recall in a classification problem?",
+            "options": [
+                "Always — precision is universally more important than recall",
+                "When the cost of acting on false positives is high, such as blocking a legitimate bank transaction or sending an aggressive retention offer to a customer who was not going to churn",
+                "When the dataset is highly imbalanced (more negatives than positives)",
+                "When using logistic regression rather than tree-based models"
+            ],
+            "answer": 1,
+            "explanation": "Precision = TP / (TP + FP) measures 'of all positive predictions, how many were correct.' When false positives are costly — flagging innocent transactions as fraud, falsely diagnosing a disease, over-sending promotions — you want high precision. Conversely, when false negatives are costly (missing a tumor, missing a fraud case), prioritize recall. The F1 score balances both when neither dominates."
+        },
+        {
+            "id": "d42q05",
+            "type": "multiple_choice",
+            "question": "You use `stratify=y` in `train_test_split`. What does this do, and when is it important?",
+            "options": [
+                "It sorts the dataset by the target label before splitting",
+                "It ensures the class distribution in the train and test sets matches the original dataset, preventing skewed splits on imbalanced data",
+                "It applies data augmentation to the minority class in the training set",
+                "It scales the features within each class separately to preserve distribution"
+            ],
+            "answer": 1,
+            "explanation": "Without stratification, a random split on imbalanced data (e.g., 5% positive) might produce a test set with 0% or 10% positives by chance, making evaluation unreliable. `stratify=y` ensures the same class proportions appear in both train and test sets. Use it whenever your target is categorical — especially critical with class imbalance (<20% minority class)."
+        }
+    ]
+}

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_43_Supervised_Learning_Classification_Part_2/quiz.json
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_43_Supervised_Learning_Classification_Part_2/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 43,
+    "questions": [
+        {
+            "id": "d43q01",
+            "type": "multiple_choice",
+            "question": "A decision tree for loan approval splits first on `credit_score > 650`. What criterion does the algorithm use to choose this split over other possible splits?",
+            "options": [
+                "It picks the feature with the highest mean value first",
+                "It picks the split that maximizes information gain (or minimizes Gini impurity) — the split that creates the two most homogeneous subgroups",
+                "It picks the feature with the most missing values to resolve ambiguity first",
+                "It picks splits randomly and evaluates them during backpropagation"
+            ],
+            "answer": 1,
+            "explanation": "Decision trees use impurity measures (Gini impurity or Information Gain) to evaluate every possible split at every feature. The split chosen at each node is the one that produces the greatest reduction in impurity — meaning the resulting child nodes contain samples that are as 'pure' (same class) as possible. This greedy top-down process continues recursively until a stopping criterion (max depth, min samples) is reached."
+        },
+        {
+            "id": "d43q02",
+            "type": "multiple_choice",
+            "question": "A single decision tree achieves 82% accuracy and a Random Forest with 100 trees achieves 91%. Why does the ensemble outperform the single tree?",
+            "options": [
+                "The Random Forest uses a more complex loss function than a single tree",
+                "Each tree in the forest is trained on a random sample of data and random subset of features; their errors are largely uncorrelated, so averaging the votes reduces overall variance",
+                "The forest trains for 100× more epochs, giving it more time to optimize",
+                "Random Forests use gradient boosting, which is stronger than standard tree splitting"
+            ],
+            "answer": 1,
+            "explanation": "Random Forests use two sources of randomness: (1) Bootstrap sampling — each tree trains on a random sample with replacement; (2) Feature subsampling — each split considers only a random subset of features. This decorrelates the individual trees, so their errors are largely independent. When you average uncorrelated errors, they cancel out, reducing variance without increasing bias — this is the core of bagging."
+        },
+        {
+            "id": "d43q03",
+            "type": "multiple_choice",
+            "question": "In a Random Forest trained on credit data, `feature_importances_` shows: income=0.42, credit_score=0.31, debt_ratio=0.18, employment_years=0.09. What does this tell you?",
+            "options": [
+                "Income appears first in the dataset and is therefore ranked highest",
+                "Income explains 42% of the variance in the target across all 100 trees; together, income and credit score account for 73% of the model's predictive power",
+                "Debt ratio and employment years should be removed because their importance is below 0.2",
+                "Feature importances sum to less than 1.0, indicating some features were ignored"
+            ],
+            "answer": 1,
+            "explanation": "Random Forest feature importance measures the average reduction in impurity (Gini) contributed by each feature across all trees. Importances always sum to 1.0. Income (0.42) and credit_score (0.31) together drive 73% of the model's decisions. This is actionable: focus data collection on these features and consider them for business rules. Note that correlated features may have split importance between them."
+        },
+        {
+            "id": "d43q04",
+            "type": "multiple_choice",
+            "question": "When tuning `max_depth` for a decision tree, the training accuracy stays near 100% for all depths, but test accuracy peaks at depth=4 and declines for depths > 6. What is happening?",
+            "options": [
+                "The tree is underfitting at depth=4; increasing depth always improves generalization",
+                "The training data is too small for deep trees to learn anything meaningful",
+                "Deeper trees memorize training noise (overfitting); depth=4 is the sweet spot where the tree captures real patterns without fitting individual examples",
+                "Decision trees cannot generalize beyond their maximum depth"
+            ],
+            "answer": 2,
+            "explanation": "A fully grown decision tree can create one leaf per training sample, achieving 100% training accuracy but catastrophic test performance. `max_depth` controls the bias-variance tradeoff: too shallow underfits, too deep overfits. Cross-validate max_depth values (e.g., 2–20) and pick the depth that maximizes test/validation accuracy — typically 3–8 for many real-world problems."
+        },
+        {
+            "id": "d43q05",
+            "type": "multiple_choice",
+            "question": "You want to tune both `n_estimators` and `max_depth` for a Random Forest using `GridSearchCV`. Which `param_grid` is correct?",
+            "options": [
+                "{'n_estimators': [100, 200], 'max_depth': [5, 10, None]}",
+                "{'RandomForest.n_estimators': [100, 200], 'RandomForest.max_depth': [5, 10]}",
+                "{'model__n_estimators': [100, 200], 'model__max_depth': [5, 10]}",
+                "{'params': {'n_estimators': [100, 200], 'max_depth': [5, 10]}}"
+            ],
+            "answer": 0,
+            "explanation": "When tuning an estimator directly (not inside a Pipeline), you reference parameters by their name without any prefix. `GridSearchCV(RandomForestClassifier(), {'n_estimators': [100, 200], 'max_depth': [5, 10, None]}, cv=5)` will try all 6 combinations (2 n_estimators × 3 max_depth). Inside a Pipeline, you'd need the `'step_name__parameter'` syntax, e.g., `'classifier__n_estimators'`."
+        }
+    ]
+}

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_44_Unsupervised_Learning/quiz.json
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_44_Unsupervised_Learning/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 44,
+    "questions": [
+        {
+            "id": "d44q01",
+            "type": "multiple_choice",
+            "question": "What is the fundamental difference between supervised and unsupervised learning?",
+            "options": [
+                "Supervised learning is faster to train; unsupervised learning is more accurate",
+                "Supervised learning requires labeled examples (input-output pairs); unsupervised learning finds structure in unlabeled data without predefined categories",
+                "Supervised learning works on numeric data only; unsupervised learning handles all data types",
+                "Unsupervised learning uses gradient descent; supervised learning does not"
+            ],
+            "answer": 1,
+            "explanation": "Supervised learning trains on labeled data — each sample has a known target (spam/not spam, price, churn/stay). Unsupervised learning has no labels: algorithms like K-Means clustering and PCA discover hidden structure, groupings, or lower-dimensional representations in the data autonomously. Unsupervised learning is essential when labeling data is expensive or when you're exploring unknown patterns."
+        },
+        {
+            "id": "d44q02",
+            "type": "multiple_choice",
+            "question": "You run K-Means on customer data. Why must you scale the features with `StandardScaler` before clustering?",
+            "options": [
+                "K-Means requires all features to have integer values",
+                "K-Means measures Euclidean distance between points; features on large scales (e.g., annual income: 0–200,000) will dominate over small-scale features (e.g., age: 0–70), producing clusters driven entirely by the large-scale feature",
+                "StandardScaler converts categorical features to numeric values for K-Means",
+                "Scaling speeds up K-Means by reducing the number of iterations needed"
+            ],
+            "answer": 1,
+            "explanation": "K-Means assigns points to the nearest cluster center using Euclidean distance. An unscaled income feature (range 0–200,000) contributes 200,000 times more to the distance calculation than an age feature (range 0–70). Without scaling, clusters are dominated by high-magnitude features and low-magnitude features become irrelevant. StandardScaler (mean=0, std=1) puts all features on equal footing."
+        },
+        {
+            "id": "d44q03",
+            "type": "multiple_choice",
+            "question": "The elbow method plots K vs inertia for K=1 to 10. Inertia drops steeply from K=1 to K=3, then gradually from K=3 onward. What is the optimal K and why?",
+            "options": [
+                "K=1 — the lowest inertia point gives the best clustering",
+                "K=10 — more clusters always produce better segmentation",
+                "K=3 — it is the 'elbow' where adding more clusters yields diminishing returns in inertia reduction",
+                "K=5 — the standard industry default for customer segmentation"
+            ],
+            "answer": 2,
+            "explanation": "Inertia (sum of squared distances to cluster centers) always decreases as K increases — adding more clusters makes every point closer to a center. The elbow is where the rate of decrease sharply changes: at K=3, adding a 4th cluster provides little additional benefit. This suggests K=3 captures the meaningful structure. Combine with the Silhouette Score (which peaks at the optimal K) for confirmation."
+        },
+        {
+            "id": "d44q04",
+            "type": "multiple_choice",
+            "question": "PCA reduces a dataset from 50 features to 10 principal components while retaining 95% of the variance. What does this mean practically?",
+            "options": [
+                "The 40 dropped features were duplicates and contained no information",
+                "The 10 components capture 95% of the information in the original 50 features — downstream models trained on 10 components will have nearly identical performance but train 5× faster",
+                "95% of data samples can be reconstructed exactly from 10 components",
+                "PCA removed 40 noisy features and improved accuracy by 95%"
+            ],
+            "answer": 1,
+            "explanation": "Principal components are linear combinations of original features that maximize variance. The first few PCs often capture the bulk of the information because real-world features are correlated. Retaining 95% variance with 10 components means you lose only 5% of information while reducing dimensionality 5×. This speeds up training, reduces memory, and can improve model generalization by eliminating correlated noise."
+        },
+        {
+            "id": "d44q05",
+            "type": "multiple_choice",
+            "question": "The Silhouette Score for K=3 is 0.68 and for K=5 is 0.52 on the same dataset. Which K should you choose, and what does the silhouette score measure?",
+            "options": [
+                "K=5 — more clusters always represent the data better",
+                "K=3 — the Silhouette Score measures how similar each point is to its own cluster versus neighboring clusters; higher scores indicate better-defined, more separated clusters",
+                "K=3 — but only because the elbow method also suggests K=3",
+                "Neither — a Silhouette Score below 0.70 means clustering found no meaningful structure"
+            ],
+            "answer": 1,
+            "explanation": "The Silhouette Score ranges from -1 to +1. For each point, it measures (distance to nearest foreign cluster - distance to own cluster center) / max(both). A score near +1 means the point is well within its cluster and far from others. K=3 (score=0.68) produces tighter, more separated clusters than K=5 (score=0.52). Values above 0.5 generally indicate reasonable structure; above 0.7 is strong."
+        }
+    ]
+}

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_45_Feature_Engineering_and_Evaluation/quiz.json
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_45_Feature_Engineering_and_Evaluation/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 45,
+    "questions": [
+        {
+            "id": "d45q01",
+            "type": "multiple_choice",
+            "question": "A dataset has a `transaction_date` column. Which feature engineering transformation extracts the most useful signals for a purchase prediction model?",
+            "options": [
+                "Convert the date to a Unix timestamp (seconds since 1970)",
+                "Drop the date column — models can't learn from dates",
+                "Extract day_of_week, month, is_weekend, and days_since_last_purchase as separate numeric features",
+                "Use the full datetime string as a categorical feature with one-hot encoding"
+            ],
+            "answer": 2,
+            "explanation": "Raw datetime objects aren't directly usable by most ML models, and a Unix timestamp hides business-relevant patterns. Extracting components like day_of_week (weekly seasonality), month (annual seasonality), is_weekend (binary behavioral signal), and recency (days since last transaction) exposes patterns the model can learn. This is standard practice — ML can then discover that weekends drive higher conversion, for example."
+        },
+        {
+            "id": "d45q02",
+            "type": "multiple_choice",
+            "question": "A `quality` column has values 'Low', 'Medium', 'High'. Should you apply OneHotEncoding or OrdinalEncoding, and why?",
+            "options": [
+                "OneHotEncoding — always use it for string columns to avoid introducing fake numeric relationships",
+                "OrdinalEncoding — because the values have a natural order (Low < Medium < High), and encoding them as 0, 1, 2 preserves that ordering for the model",
+                "OrdinalEncoding — because tree-based models cannot use one-hot encoded features",
+                "Neither — drop the column and create a binary 'is_high_quality' feature instead"
+            ],
+            "answer": 1,
+            "explanation": "OneHotEncoding treats all categories as unordered (nominal). For truly ordered/ranked categories (ordinal data), OrdinalEncoding assigns integers that preserve the rank: Low=0, Medium=1, High=2. The model can then learn that High > Medium > Low. Using OneHotEncoding on ordinal data loses the ordering information. Use OrdinalEncoder with `categories=[['Low', 'Medium', 'High']]` to ensure the correct order."
+        },
+        {
+            "id": "d45q03",
+            "type": "multiple_choice",
+            "question": "A `StandardScaler` is fit on the full dataset (train + test combined) before the train-test split. A colleague says 'but it's just scaling, not the model.' Why is this still data leakage?",
+            "options": [
+                "It is not leakage — scaling doesn't affect model accuracy, only speed",
+                "The scaler learns the mean and standard deviation from test samples; these statistics influence how training features are normalized, so the model indirectly benefits from test data characteristics",
+                "It causes leakage only if the test set has a different distribution than the train set",
+                "It is leakage only for tree-based models, not for linear models"
+            ],
+            "answer": 1,
+            "explanation": "Data leakage means any information from the test set influences the training process. When a scaler is fit on all data, its learned mean and std include test set statistics. This means training features are normalized using information the model should never have seen. The effect is subtle but real — especially on small datasets where test outliers can shift the scaler parameters. Always fit transformers only on training data."
+        },
+        {
+            "id": "d45q04",
+            "type": "multiple_choice",
+            "question": "When should you use `StratifiedKFold` instead of standard `KFold` for cross-validation?",
+            "options": [
+                "When your features have different scales",
+                "When the target variable is continuous (regression)",
+                "When the target is categorical and class distribution is uneven — StratifiedKFold ensures each fold has the same class proportions as the full dataset",
+                "When you have more than 10,000 training samples"
+            ],
+            "answer": 2,
+            "explanation": "With imbalanced classes (e.g., 5% positive), a random KFold split might produce folds with 0% or 15% positive by chance, making some folds useless for evaluating rare-class performance. StratifiedKFold guarantees each fold maintains the original class ratio (≈5% positive in every fold), producing reliable and comparable performance estimates across folds. Always use StratifiedKFold for classification."
+        },
+        {
+            "id": "d45q05",
+            "type": "multiple_choice",
+            "question": "What is the advantage of `log_amount = np.log1p(amount)` for a right-skewed transaction amount feature?",
+            "options": [
+                "It converts the feature to a percentage, making it easier to interpret",
+                "It compresses the long right tail, making extreme values (e.g., $50,000 purchases) less dominant and bringing the distribution closer to normal, which benefits many ML models",
+                "It ensures all values are between 0 and 1, required by logistic regression",
+                "It removes negative values that would break the model"
+            ],
+            "answer": 1,
+            "explanation": "Transaction amounts are often log-normally distributed — a few very large values stretch the right tail enormously. Log-transforming compresses this tail: $10 → log(11)≈2.4, $1,000 → log(1001)≈6.9, $100,000 → log(100001)≈11.5. This prevents large amounts from dominating distance calculations and makes linear model assumptions (normally distributed errors) more plausible. `log1p` handles zero values safely: log(0+1) = 0."
+        }
+    ]
+}

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_46_Intro_to_Neural_Networks/quiz.json
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_46_Intro_to_Neural_Networks/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 46,
+    "questions": [
+        {
+            "id": "d46q01",
+            "type": "multiple_choice",
+            "question": "A single neuron computes `z = np.dot(inputs, weights) + bias` and then applies an activation function. Why is the activation function necessary?",
+            "options": [
+                "To normalize the output to the range [0, 1] for all neurons",
+                "Without activation functions, stacking multiple linear layers is equivalent to a single linear transformation — activation functions introduce non-linearity, enabling networks to learn complex patterns",
+                "To speed up computation by reducing the number of matrix multiplications",
+                "To ensure gradients don't vanish during backpropagation"
+            ],
+            "answer": 1,
+            "explanation": "A composition of linear functions is still linear: W₂(W₁x + b₁) + b₂ = (W₂W₁)x + const. No matter how many layers you stack, without activation functions the whole network collapses to a single linear transformation. Non-linear activations like ReLU, sigmoid, and tanh allow neural networks to approximate arbitrarily complex functions — this is the Universal Approximation Theorem."
+        },
+        {
+            "id": "d46q02",
+            "type": "multiple_choice",
+            "question": "For a neural network with a binary classification output, which activation function should the final layer use, and why?",
+            "options": [
+                "ReLU — because it works in both hidden and output layers",
+                "Linear — because classification outputs should be unbounded",
+                "Sigmoid — it maps any real number to (0, 1), producing a valid probability for the positive class",
+                "Softmax — required for all classification tasks"
+            ],
+            "answer": 2,
+            "explanation": "Sigmoid σ(z) = 1/(1+e^{-z}) squashes any real-valued input to (0, 1), making it a valid probability output for binary classification. The loss function `binary_crossentropy` expects probabilities in this range. Softmax is used for multi-class classification (outputs summing to 1). ReLU and linear activations are for hidden layers and regression outputs, respectively."
+        },
+        {
+            "id": "d46q03",
+            "type": "multiple_choice",
+            "question": "During training, the validation loss stops improving after epoch 15 while training loss continues to decrease. What is happening, and what technique addresses it?",
+            "options": [
+                "The learning rate is too low; increase it to allow faster convergence",
+                "The model is underfitting; add more layers to increase capacity",
+                "The model is overfitting; early stopping (halt training when validation loss stops improving) or dropout can prevent memorization of training data",
+                "The validation set is too small; split more data into validation"
+            ],
+            "answer": 2,
+            "explanation": "Training loss decreasing while validation loss plateaus or rises is the classic overfitting signature. The model memorizes training examples rather than learning generalizable patterns. Early stopping monitors validation loss and halts training at the optimal epoch. Dropout randomly deactivates neurons during training, forcing the network to learn redundant representations — both are standard regularization techniques for deep learning."
+        },
+        {
+            "id": "d46q04",
+            "type": "multiple_choice",
+            "question": "In a Keras model built with `keras.Sequential`, what does adding `layers.Dense(64, activation='relu')` create?",
+            "options": [
+                "A convolutional layer with 64 filters of size relu×relu",
+                "A fully connected layer where every input connects to each of 64 neurons, applying ReLU to each neuron's weighted sum",
+                "64 independent neural networks that vote on the output",
+                "A recurrent layer that processes 64 time steps sequentially"
+            ],
+            "answer": 1,
+            "explanation": "A `Dense` layer (also called fully connected) connects every neuron in the previous layer to each of the 64 neurons in this layer. For an input of shape (batch, n_inputs), it computes: output = ReLU(input @ W + b) where W has shape (n_inputs, 64) and b has shape (64,). The output shape is (batch, 64). This is the fundamental building block for learning complex feature representations."
+        },
+        {
+            "id": "d46q05",
+            "type": "multiple_choice",
+            "question": "A neural network is compiled with `loss='binary_crossentropy'` and `optimizer='adam'`. For regression (predicting house prices), which loss function should be used instead?",
+            "options": [
+                "binary_crossentropy — it works for all prediction tasks",
+                "categorical_crossentropy — because prices belong to categories",
+                "mean_squared_error (MSE) or mean_absolute_error (MAE) — these measure the distance between predicted and actual continuous values",
+                "hinge — the standard loss for regression problems"
+            ],
+            "answer": 2,
+            "explanation": "Binary cross-entropy is designed for binary classification (0/1 outputs). For regression, you need a loss that measures numeric distance between predictions and targets. MSE = mean((y_pred - y_true)²) penalizes large errors heavily. MAE = mean(|y_pred - y_true|) is more robust to outliers. The output layer should also use `activation='linear'` (no activation) to allow unbounded numeric predictions."
+        }
+    ]
+}

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_47_Convolutional_Neural_Networks/quiz.json
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_47_Convolutional_Neural_Networks/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 47,
+    "questions": [
+        {
+            "id": "d47q01",
+            "type": "multiple_choice",
+            "question": "A 5×5 grayscale image is convolved with a 3×3 edge detection filter. What is the size of the output feature map (without padding)?",
+            "options": [
+                "5×5 — the output preserves the input dimensions",
+                "3×3 — the output matches the filter size",
+                "3×3 — the output is (5-3+1) × (5-3+1) = 3×3",
+                "7×7 — the filter is applied beyond the image boundaries"
+            ],
+            "answer": 2,
+            "explanation": "Without padding, a convolution of an (H×W) image with a (K×K) filter produces an output of size (H-K+1) × (W-K+1). For a 5×5 image with a 3×3 filter: (5-3+1) = 3, so the output is 3×3. To preserve the original dimensions, use `padding='same'` in Keras, which pads the input with zeros so the output matches the input size."
+        },
+        {
+            "id": "d47q02",
+            "type": "multiple_choice",
+            "question": "What is the purpose of MaxPooling2D((2,2)) in a CNN architecture?",
+            "options": [
+                "It applies a 2×2 convolution filter to double the number of feature maps",
+                "It takes the maximum value in each 2×2 region, reducing spatial dimensions by half while retaining the most prominent features — reducing computation and providing spatial invariance",
+                "It normalizes pixel values to the range [0, 1] before the next layer",
+                "It adds 2×2 padding to preserve spatial dimensions after convolution"
+            ],
+            "answer": 1,
+            "explanation": "MaxPooling2D((2,2)) slides a 2×2 window over the feature map and takes the maximum value in each window, halving both height and width. A 28×28 feature map becomes 14×14. Benefits: (1) reduces computation and parameters in subsequent layers, (2) provides translation invariance — a feature detected at slightly different positions still produces the same pooled output, (3) creates a hierarchy of increasingly abstract representations."
+        },
+        {
+            "id": "d47q03",
+            "type": "multiple_choice",
+            "question": "In a CNN for MNIST digit classification, early convolutional layers learn edge detectors, middle layers detect curves and parts, and final layers detect full digit shapes. What principle does this illustrate?",
+            "options": [
+                "CNNs memorize the training images rather than learning general features",
+                "CNNs build hierarchical feature representations — low-level features (edges) combine into mid-level features (shapes) which combine into high-level concepts (objects)",
+                "Each layer specializes in a different digit class (0 through 9)",
+                "The deeper layers use larger filters to capture global patterns"
+            ],
+            "answer": 1,
+            "explanation": "CNNs learn hierarchical representations analogous to the visual cortex: Layer 1 detects oriented edges and color gradients. Layer 2 combines edges into curves, corners, and textures. Layer 3+ combines parts into object components. Final layers combine components into complete objects. This hierarchy is why deep CNNs excel at visual tasks — they progressively build more abstract and semantically meaningful representations from raw pixels."
+        },
+        {
+            "id": "d47q04",
+            "type": "multiple_choice",
+            "question": "You want to classify product images for a small e-commerce startup (only 500 labeled images). Which approach is most practical?",
+            "options": [
+                "Train a CNN from scratch for 100 epochs — more epochs compensate for small data",
+                "Use transfer learning: load a pretrained model (e.g., ResNet50 trained on ImageNet), freeze early layers, and retrain only the final classification head on your 500 images",
+                "Use a Random Forest on flattened pixel values — deep learning requires at least 10,000 samples",
+                "Use data augmentation alone — it effectively multiplies your 500 images into millions"
+            ],
+            "answer": 1,
+            "explanation": "Transfer learning reuses a model's learned feature representations from a large dataset (ImageNet, 14M+ images) for a new task. Frozen early layers already detect edges, textures, and shapes — universally useful features. You only retrain the final layers on your 500 images. This dramatically reduces overfitting risk and training time. It's the standard approach for computer vision with limited labeled data."
+        },
+        {
+            "id": "d47q05",
+            "type": "multiple_choice",
+            "question": "A CNN model processes MNIST images with input shape (28, 28, 1). What does the final dimension '1' represent, and how would it change for color images?",
+            "options": [
+                "The batch size; for color images it would be 3 to allow 3 images per batch",
+                "The number of classes; for color images it would be 3 for RGB classes",
+                "The number of channels: 1 for grayscale. Color images use 3 channels (Red, Green, Blue), so the input shape becomes (height, width, 3)",
+                "The stride of the first convolution; RGB images need stride=3"
+            ],
+            "answer": 2,
+            "explanation": "The input shape convention for CNNs is (height, width, channels). Grayscale images have 1 channel (intensity only), so shape (28, 28, 1). RGB color images have 3 channels (R, G, B), so shape (224, 224, 3) for a 224×224 image. Each convolutional filter operates across all channels simultaneously — a 3×3 filter on an RGB image actually has shape (3, 3, 3) = 27 learned weights plus a bias."
+        }
+    ]
+}

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_48_Recurrent_Neural_Networks/quiz.json
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_48_Recurrent_Neural_Networks/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 48,
+    "questions": [
+        {
+            "id": "d48q01",
+            "type": "multiple_choice",
+            "question": "What makes Recurrent Neural Networks (RNNs) fundamentally different from standard feedforward networks for sequence data?",
+            "options": [
+                "RNNs use convolutional filters instead of dense layers",
+                "RNNs maintain a hidden state that is updated at each time step, allowing information from previous inputs to influence the processing of current inputs",
+                "RNNs process the entire sequence in a single forward pass using attention",
+                "RNNs use larger weight matrices to handle variable-length inputs"
+            ],
+            "answer": 1,
+            "explanation": "An RNN cell computes: h_t = tanh(x_t × Wx + h_{t-1} × Wh + b). The hidden state h_{t-1} from the previous step is carried forward, giving the network 'memory.' This recurrent connection is what makes RNNs suitable for sequences where order and context matter — unlike feedforward networks that treat each input independently."
+        },
+        {
+            "id": "d48q02",
+            "type": "multiple_choice",
+            "question": "A Simple RNN is trained on sequences of 100 time steps but fails to learn dependencies between steps 1 and 100. What problem is this, and what architecture addresses it?",
+            "options": [
+                "Exploding gradients — use gradient clipping",
+                "Vanishing gradients — during backpropagation through 100 steps, gradient signals from early steps become exponentially small; LSTM and GRU cells use gating mechanisms to preserve long-range dependencies",
+                "Overfitting — the model needs more dropout layers",
+                "Mode collapse — the model always predicts the same output regardless of input"
+            ],
+            "answer": 1,
+            "explanation": "Backpropagation Through Time (BPTT) multiplies gradients through each time step. With 100 steps and tanh activations (derivatives < 1), gradients shrink exponentially — by step 1, the gradient is near zero. LSTM (Long Short-Term Memory) solves this with forget, input, and output gates that control what information to preserve, write, or read. The 'cell state' highway allows gradients to flow across long sequences without vanishing."
+        },
+        {
+            "id": "d48q03",
+            "type": "multiple_choice",
+            "question": "For time series prediction with an LSTM, input data has shape (samples, timesteps, features). If you have 1,000 sequences each 20 days long with 5 features per day, what is the correct input shape?",
+            "options": [
+                "(1000, 5) — samples × features, time steps are implicit",
+                "(20, 1000, 5) — time steps first, then samples, then features",
+                "(1000, 20, 5) — samples × timesteps × features",
+                "(1000, 100) — samples × (timesteps × features) flattened"
+            ],
+            "answer": 2,
+            "explanation": "Keras LSTM layers expect input shape (batch_size, timesteps, features). For 1,000 sequences of 20 days with 5 daily features, the shape is (1000, 20, 5). The LSTM processes each sequence one day at a time, updating its hidden state across 20 steps. Getting this shape right is one of the most common pain points when working with RNNs — always check `X.shape` before training."
+        },
+        {
+            "id": "d48q04",
+            "type": "multiple_choice",
+            "question": "What is the key advantage of a GRU (Gated Recurrent Unit) over an LSTM?",
+            "options": [
+                "GRU can handle longer sequences than LSTM without vanishing gradients",
+                "GRU has fewer gates (reset and update) than LSTM (forget, input, output), making it simpler, faster to train, and often achieving comparable performance with less computation",
+                "GRU processes sequences bidirectionally by default",
+                "GRU uses ReLU activation instead of tanh, preventing saturation"
+            ],
+            "answer": 1,
+            "explanation": "LSTM has 3 gating mechanisms (forget gate, input gate, output gate) and a separate cell state. GRU simplifies this to 2 gates (reset and update gates) while still addressing vanishing gradients. In practice, GRU trains faster with fewer parameters and achieves similar performance to LSTM on many tasks. Choose LSTM for complex long-range dependencies; GRU for faster prototyping or when computational efficiency matters."
+        },
+        {
+            "id": "d48q05",
+            "type": "multiple_choice",
+            "question": "Which of these problems is best suited for an LSTM model rather than a standard feedforward neural network?",
+            "options": [
+                "Predicting house prices from tabular features (square footage, bedrooms, location)",
+                "Classifying images of cats vs dogs",
+                "Forecasting daily sales for the next 30 days using the past 90 days of sales history",
+                "Clustering customers into segments based on demographic data"
+            ],
+            "answer": 2,
+            "explanation": "Sales forecasting is a sequential time series problem: each day's sales depends on recent history (trends, seasonality), and the temporal order matters. An LSTM can learn these temporal patterns by maintaining state across the 90-day input window. Feedforward networks treat all inputs independently — they would need manual feature engineering (lag features, rolling averages) to capture time dependencies. CNNs handle images; clustering is unsupervised."
+        }
+    ]
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `quiz.json` files to all 14 day directories in Phase 4 (Mathematical Foundations & ML Fundamentals)
- Each quiz contains 5 multiple-choice questions with 4 options, a zero-indexed correct answer, and a detailed explanation
- Questions are grounded in each lesson's README content and code examples

## Days covered

| Day | Topic |
|-----|-------|
| 37 | Python Review & ML Preparation |
| 37B | Probability & Statistics for ML |
| 37C | Sklearn Pipelines & ColumnTransformer |
| 38 | Linear Algebra for ML |
| 39 | Calculus & Gradient Descent |
| 40 | Introduction to Machine Learning |
| 41 | Supervised Learning: Regression |
| 42 | Supervised Learning: Classification Part 1 |
| 43 | Supervised Learning: Classification Part 2 |
| 44 | Unsupervised Learning |
| 45 | Feature Engineering and Evaluation |
| 46 | Introduction to Neural Networks |
| 47 | Convolutional Neural Networks |
| 48 | Recurrent Neural Networks |

## Test plan

- [ ] Verify all 14 `quiz.json` files parse as valid JSON
- [ ] Check each file has exactly 5 questions with `id`, `type`, `question`, `options` (4 items), `answer` (0–3), and `explanation` fields
- [ ] Confirm question IDs follow the established convention (`d37q01`, `d37Bq01`, etc.)
- [ ] Spot-check that questions match the lesson content in each day's README

https://claude.ai/code/session_01Te512RJ4DdsPZfKP3ok9TD
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Te512RJ4DdsPZfKP3ok9TD)_