### PR TITLE
Add Phase 5 quiz lessons (Days 49-60C)

### DIFF
--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_49_NLP/quiz.json
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_49_NLP/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 49,
+    "questions": [
+        {
+            "id": "d49q01",
+            "type": "multiple_choice",
+            "question": "What is the key advantage of word embeddings (Word2Vec, GloVe) over one-hot encoding for representing words?",
+            "options": [
+                "Embeddings are smaller in memory since they use single integers instead of arrays",
+                "Embeddings capture semantic similarity—words with similar meanings have similar vector representations",
+                "Embeddings guarantee exact word matches during search without false positives",
+                "Embeddings remove the need for tokenization before model training"
+            ],
+            "answer": 1,
+            "explanation": "One-hot encoding treats every word as completely independent—'king' and 'queen' are as dissimilar as 'king' and 'table'. Word embeddings (Word2Vec, GloVe, fastText) learn dense vector representations from large text corpora such that semantically related words cluster together in vector space. The classic example: embedding('king') - embedding('man') + embedding('woman') ≈ embedding('queen'). This semantic geometry enables models to generalize across related words."
+        },
+        {
+            "id": "d49q02",
+            "type": "multiple_choice",
+            "question": "You need to classify 10,000 customer support tickets into 8 categories. Which preprocessing step most directly improves model performance on this task?",
+            "options": [
+                "Stemming all words to their root form (e.g., 'running' → 'run') to reduce vocabulary size",
+                "Removing all stopwords so that only rare, domain-specific words remain",
+                "Removing stop words, lowercasing, and using TF-IDF weighting to emphasize domain-specific terms",
+                "Converting all text to ASCII to remove special characters before vectorization"
+            ],
+            "answer": 2,
+            "explanation": "For text classification, the standard preprocessing pipeline is: lowercase (reduce vocabulary), remove punctuation/special chars, remove stop words (common words like 'the', 'is' add noise), then represent text with TF-IDF. TF-IDF (Term Frequency-Inverse Document Frequency) downweights words that appear in every document (useless discriminators) and upweights words that appear in few documents (strong category signals). Stemming helps but TF-IDF is the bigger win for classification."
+        },
+        {
+            "id": "d49q03",
+            "type": "multiple_choice",
+            "question": "What does Named Entity Recognition (NER) do, and why is it useful for business applications?",
+            "options": [
+                "NER classifies entire documents into predefined categories like 'positive' or 'negative'",
+                "NER identifies and classifies named entities in text (people, organizations, locations, dates), enabling structured extraction from unstructured text",
+                "NER generates new text by predicting the next word in a sequence",
+                "NER measures the similarity between two sentences using cosine distance"
+            ],
+            "answer": 1,
+            "explanation": "NER is an information extraction technique that locates and classifies named entities in text into categories like PERSON, ORG, LOCATION, DATE, MONEY, PRODUCT. Business value: extract company names from news articles for investment monitoring, pull contract dates from legal documents, identify customer mentions in support tickets, or map supplier relationships from emails. NER converts unstructured text into structured data that feeds downstream analytics pipelines."
+        },
+        {
+            "id": "d49q04",
+            "type": "multiple_choice",
+            "question": "A sentiment analysis model is 92% accurate on movie reviews but only 61% accurate on financial news. What is the most likely cause?",
+            "options": [
+                "Financial news uses longer sentences, and the model has a sequence length limit",
+                "Domain shift: words have different sentiment polarity across domains ('volatile' is negative in movies, neutral/positive in trading)",
+                "The financial dataset has more classes, making the problem inherently harder",
+                "The model was trained on too little data and is underfitting on both domains"
+            ],
+            "answer": 1,
+            "explanation": "This is domain shift—a model trained on one text distribution fails to generalize to another. Sentiment words are domain-specific: 'volatile' and 'aggressive' are negative in movie reviews but can be positive in hedge fund contexts. 'Missed expectations' is catastrophic in earnings news but mild in a film review. Solutions include: fine-tuning on target-domain data, domain adaptation, or using domain-specific pretrained models (e.g., FinBERT for financial text)."
+        },
+        {
+            "id": "d49q05",
+            "type": "multiple_choice",
+            "question": "When using a pretrained transformer model (like BERT) for a custom text classification task, what is the recommended approach?",
+            "options": [
+                "Train BERT from scratch on your custom dataset to avoid transfer learning bias",
+                "Use BERT embeddings as fixed features with a separate classifier, never updating BERT weights",
+                "Add a classification head on top of BERT and fine-tune the entire model on your labeled data with a low learning rate",
+                "Replace BERT's tokenizer with your own vocabulary before any fine-tuning"
+            ],
+            "answer": 2,
+            "explanation": "Fine-tuning the full pretrained model (with a new classification head) consistently outperforms using frozen BERT features. The key is using a very low learning rate (2e-5 to 5e-5) so you gently adjust pretrained weights rather than overwriting them—this preserves the general language understanding BERT learned from billions of tokens. Training from scratch on small custom datasets would overfit badly. Freezing BERT entirely misses the benefit of adapting representations to your domain."
+        }
+    ]
+}

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_50_MLOps/quiz.json
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_50_MLOps/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 50,
+    "questions": [
+        {
+            "id": "d50q01",
+            "type": "multiple_choice",
+            "question": "What is the primary purpose of experiment tracking in MLOps (e.g., using MLflow)?",
+            "options": [
+                "To automatically deploy the best model to production without human review",
+                "To record hyperparameters, metrics, and artifacts for each training run so experiments are reproducible and comparable",
+                "To parallelize model training across multiple GPU machines",
+                "To encrypt model weights before storing them in a model registry"
+            ],
+            "answer": 1,
+            "explanation": "Experiment tracking solves the 'notebook chaos' problem where data scientists lose track of which configuration produced which result. Tools like MLflow log: hyperparameters (learning rate, depth), metrics (accuracy, F1 over epochs), artifacts (trained model files, feature importance plots), and environment (library versions). This makes any past run reproducible, enables side-by-side comparisons, and provides an audit trail for regulated industries. Without tracking, 'which model is in production?' becomes unanswerable."
+        },
+        {
+            "id": "d50q02",
+            "type": "multiple_choice",
+            "question": "A model performs excellently in testing but degrades over 3 months in production. What MLOps practice would catch this earliest?",
+            "options": [
+                "Retraining the model on the original training data every month",
+                "Using a simpler model that is less likely to overfit",
+                "Monitoring input data distributions and model output distributions for drift against baseline statistics",
+                "Adding more features to the model to capture more real-world variation"
+            ],
+            "answer": 2,
+            "explanation": "Performance degradation over time is caused by data drift (input distribution changes) or concept drift (relationship between inputs and outputs changes). Proactive monitoring tracks statistics like mean, variance, and distribution of input features and compares them to the training baseline. Tools like Evidently AI, WhyLogs, or custom dashboards alert when distributions shift beyond a threshold—before business outcomes degrade. Retraining fixes drift only after it's detected; monitoring catches it early."
+        },
+        {
+            "id": "d50q03",
+            "type": "multiple_choice",
+            "question": "What is the role of a Model Registry in an MLOps pipeline?",
+            "options": [
+                "It trains models automatically when new data arrives",
+                "It stores and versions trained models with lifecycle stages (Staging, Production, Archived) and enables rollback to previous versions",
+                "It encrypts model weights to prevent intellectual property theft",
+                "It automatically selects the best algorithm for a given dataset"
+            ],
+            "answer": 1,
+            "explanation": "A model registry is the single source of truth for trained models. It stores model artifacts with version numbers and lifecycle metadata: a model is promoted from Staging (testing) to Production after validation, and old Production models are Archived rather than deleted. This enables safe deployment (canary releases, A/B testing), instant rollback when a new model underperforms, and compliance auditing ('which model version was making decisions on date X?'). MLflow Model Registry and SageMaker Model Registry are common tools."
+        },
+        {
+            "id": "d50q04",
+            "type": "multiple_choice",
+            "question": "What distinguishes CI/CD for ML (MLOps CI/CD) from standard software CI/CD?",
+            "options": [
+                "ML CI/CD only applies to Python code, while standard CI/CD works with any language",
+                "ML CI/CD is slower because neural networks require GPU hardware for testing",
+                "ML CI/CD must also validate data quality, retrain/re-evaluate models, and test model behavior—not just code correctness",
+                "Standard CI/CD cannot be used for ML; entirely separate tooling is required"
+            ],
+            "answer": 2,
+            "explanation": "Standard CI/CD tests code (unit tests, integration tests, type checking). ML CI/CD adds three additional pipelines: (1) Data validation—check schema, distributions, and quality of new training data before it triggers retraining; (2) Model training pipeline—automated retraining when data or code changes; (3) Model evaluation gate—the new model must beat the current production model on held-out test data before deployment. Only if all three pass does the model get promoted. This prevents 'silent failures' where code tests pass but model quality regresses."
+        },
+        {
+            "id": "d50q05",
+            "type": "multiple_choice",
+            "question": "A data scientist's model takes 4 hours to train and uses 50 GB of raw CSV files stored locally. What is the first MLOps improvement to make this production-ready?",
+            "options": [
+                "Rewrite the model in C++ for faster training",
+                "Increase the batch size to reduce training time",
+                "Version the data in a data store, containerize the training code, and parameterize hyperparameters so runs are reproducible anywhere",
+                "Switch from scikit-learn to a deep learning framework for better scalability"
+            ],
+            "answer": 2,
+            "explanation": "The fundamental MLOps problem here is reproducibility and portability. Local CSV files aren't versioned (if the data changes, old results can't be recreated) and the code won't run on another machine. The minimum viable MLOps stack: (1) Store and version data (S3/GCS/DVC) so you can point to exact training data; (2) Containerize the training job (Docker) so it runs identically anywhere; (3) Parameterize hyperparameters (config file/CLI args) so experiments are reproducible. These three steps transform a notebook script into a production-grade training pipeline."
+        }
+    ]
+}

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_51_Regularized_Models/quiz.json
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_51_Regularized_Models/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 51,
+    "questions": [
+        {
+            "id": "d51q01",
+            "type": "multiple_choice",
+            "question": "What problem does regularization solve, and how does it solve it?",
+            "options": [
+                "Underfitting — regularization adds complexity to the model so it learns more patterns",
+                "Slow training — regularization reduces the number of gradient updates needed",
+                "Overfitting — regularization adds a penalty on model weights to discourage the model from fitting training noise",
+                "Class imbalance — regularization reweights samples from minority classes during training"
+            ],
+            "answer": 2,
+            "explanation": "Regularization addresses overfitting by adding a penalty term to the loss function that grows with the magnitude of model coefficients. This discourages the model from assigning very large weights to any single feature, forcing it to use smaller, more distributed weights. Large weights are a symptom of overfitting—the model is memorizing training data patterns (including noise) rather than learning generalizable relationships. The regularization penalty shrinks weights toward zero, producing simpler, more robust models."
+        },
+        {
+            "id": "d51q02",
+            "type": "multiple_choice",
+            "question": "What is the key practical difference between Ridge (L2) and Lasso (L1) regularization?",
+            "options": [
+                "Ridge is for classification; Lasso is for regression problems only",
+                "Lasso drives some coefficients to exactly zero (feature selection), while Ridge shrinks all coefficients toward zero but rarely eliminates them",
+                "Ridge uses the squared error loss; Lasso uses absolute error loss",
+                "Lasso is computationally faster because it uses matrix operations; Ridge requires iterative optimization"
+            ],
+            "answer": 1,
+            "explanation": "Both methods shrink coefficients, but L1 (Lasso) adds a penalty proportional to the absolute value of weights, which geometrically creates corners in the feasible region—making exact zeros likely. This produces sparse solutions where many features have zero coefficients, effectively performing automatic feature selection. L2 (Ridge) adds a penalty proportional to the square of weights, which creates a smooth circular constraint that shrinks everything toward zero but almost never produces exact zeros. Rule of thumb: use Lasso when you believe only a few features matter; use Ridge when most features are relevant."
+        },
+        {
+            "id": "d51q03",
+            "type": "multiple_choice",
+            "question": "You are predicting house prices using 200 features (location, size, age, etc.). Lasso regression eliminates 180 features and keeps only 20. What does this tell you?",
+            "options": [
+                "The model is underfitting and should use Ridge instead to keep all features",
+                "Most of the 200 features are redundant or uninformative; the 20 retained features carry the predictive signal",
+                "The regularization strength is too high and should be reduced to zero",
+                "Lasso is biased toward numeric features and discarded all categorical variables incorrectly"
+            ],
+            "answer": 1,
+            "explanation": "Lasso's automatic feature selection is revealing the true signal in the data: the 20 retained features (probably location, size, bedrooms, bathrooms, etc.) explain most of the price variance, while the other 180 features are either redundant (correlated with the 20), noisy, or irrelevant. This is valuable domain insight. The remaining model is also more interpretable and less likely to overfit. The regularization strength alpha controls how aggressive the elimination is—tune it with cross-validation to find the optimal number of features."
+        },
+        {
+            "id": "d51q04",
+            "type": "multiple_choice",
+            "question": "How do you choose the optimal regularization strength (alpha) for Ridge or Lasso regression?",
+            "options": [
+                "Set alpha=1.0 as the universal default; this works well for most datasets",
+                "Choose the alpha that minimizes training loss—smaller alpha means less penalty and always better training fit",
+                "Use cross-validation (e.g., RidgeCV or LassoCV) to evaluate multiple alpha values and select the one minimizing validation error",
+                "Set alpha based on the number of features: alpha = 1 / n_features"
+            ],
+            "answer": 2,
+            "explanation": "Alpha is a hyperparameter that controls the bias-variance tradeoff: too small (near zero) → overfitting; too large → underfitting with all coefficients near zero. Cross-validation is the correct approach: for each candidate alpha, train on k-1 folds and evaluate on the held-out fold, then pick the alpha with the best average validation score. Scikit-learn's RidgeCV and LassoCV do this efficiently. Never choose alpha by minimizing training loss—that will always pick the smallest alpha (least regularization) because the penalty is destroying training fit intentionally."
+        },
+        {
+            "id": "d51q05",
+            "type": "multiple_choice",
+            "question": "When should you prefer ElasticNet over pure Lasso or Ridge regression?",
+            "options": [
+                "When your dataset has more samples than features (n >> p)",
+                "When you have groups of correlated features and want sparse solutions that can select entire groups",
+                "When your target variable is binary (classification) rather than continuous",
+                "When training time is the primary constraint and you need the fastest possible algorithm"
+            ],
+            "answer": 1,
+            "explanation": "Lasso has a known weakness with correlated features: it arbitrarily picks one feature from a group of correlated features and sets the others to zero, which can miss important signals. ElasticNet combines L1 and L2 penalties, gaining the sparsity of Lasso (zeros out irrelevant features) while the L2 component handles correlated features more gracefully—it tends to keep correlated features together or drop them together. This makes ElasticNet the preferred default when you have correlated feature groups, like in genomics (many correlated gene expressions) or financial data (correlated economic indicators)."
+        }
+    ]
+}

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_52_Ensemble_Methods/quiz.json
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_52_Ensemble_Methods/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 52,
+    "questions": [
+        {
+            "id": "d52q01",
+            "type": "multiple_choice",
+            "question": "What is the core principle that makes ensemble methods more accurate than individual models?",
+            "options": [
+                "Ensembles train faster because the work is parallelized across multiple models",
+                "Diverse models make different errors; combining them cancels out individual mistakes and reduces variance",
+                "Ensemble models use larger datasets since each sub-model sees a different data partition",
+                "Combining models always reduces bias because averaging smooths out underfitting"
+            ],
+            "answer": 1,
+            "explanation": "The ensemble principle exploits error independence: if each model makes random, uncorrelated errors, combining their predictions averages out the noise. Think of it like asking 100 people to estimate the weight of a jar of coins—the group average is more accurate than any individual. This works best when models are diverse (different algorithms, different feature subsets, different training samples). If all models make the same mistake (correlated errors), ensembling doesn't help. This is why variance reduction is the primary benefit of bagging, and boosting reduces both bias and variance."
+        },
+        {
+            "id": "d52q02",
+            "type": "multiple_choice",
+            "question": "How does a Random Forest reduce variance compared to a single decision tree?",
+            "options": [
+                "Random Forest limits tree depth more aggressively than single trees, reducing overfitting",
+                "Random Forest averages predictions from many trees trained on bootstrap samples with random feature subsets, smoothing out individual tree overfitting",
+                "Random Forest uses pruning to remove branches that don't improve test accuracy",
+                "Random Forest trains each tree on the full dataset but uses different random seeds for initialization"
+            ],
+            "answer": 1,
+            "explanation": "Single deep decision trees overfit badly—they memorize the training set. Random Forest introduces two sources of randomness to decorrelate the trees: (1) Bootstrap sampling (bagging)—each tree trains on a random sample with replacement, so each sees a different data subset; (2) Random feature subsets—at each split, only a random subset (√n_features) of features are considered, so trees diverge in their structure. Averaging 100+ different but slightly overfit trees produces predictions where individual errors cancel, dramatically reducing variance while maintaining low bias."
+        },
+        {
+            "id": "d52q03",
+            "type": "multiple_choice",
+            "question": "What is the key difference between bagging (e.g., Random Forest) and boosting (e.g., Gradient Boosting)?",
+            "options": [
+                "Bagging uses regression trees; boosting uses classification trees exclusively",
+                "Bagging trains models in parallel, each independently; boosting trains models sequentially, where each model corrects the errors of the previous one",
+                "Bagging reduces bias; boosting reduces variance",
+                "Bagging requires more hyperparameter tuning than boosting to achieve good performance"
+            ],
+            "answer": 1,
+            "explanation": "Bagging (Bootstrap Aggregating) trains base learners independently in parallel—each tree has no knowledge of the others. The combination is achieved by averaging (regression) or majority vote (classification). Boosting trains models sequentially: each new model focuses on the samples the previous models got wrong, gradually building a strong learner from many weak learners. Result: bagging primarily reduces variance (helps overfitted models), while boosting primarily reduces bias (helps underfitted models)—though gradient boosting can also reduce variance with proper regularization."
+        },
+        {
+            "id": "d52q04",
+            "type": "multiple_choice",
+            "question": "XGBoost consistently wins Kaggle competitions and outperforms plain Gradient Boosting. What key improvements does XGBoost add?",
+            "options": [
+                "XGBoost uses neural networks as base learners instead of decision trees",
+                "XGBoost adds L1/L2 regularization on tree weights, second-order gradient approximations, and hardware-optimized parallel tree construction",
+                "XGBoost automatically selects the optimal number of trees using cross-validation during training",
+                "XGBoost replaces gradient descent with a genetic algorithm for tree construction"
+            ],
+            "answer": 1,
+            "explanation": "XGBoost improves on vanilla Gradient Boosting in three critical ways: (1) Regularization—L1 and L2 penalties on leaf weights prevent overfitting that standard GBM lacks; (2) Second-order gradients—uses both gradient (first derivative) and hessian (second derivative) of the loss to find better splits faster, analogous to Newton's method vs. gradient descent; (3) System optimizations—parallel tree construction (split finding is parallelized), cache-aware algorithms, and out-of-core computation for datasets larger than RAM. Together these make XGBoost faster and more accurate than sklearn's GradientBoostingClassifier."
+        },
+        {
+            "id": "d52q05",
+            "type": "multiple_choice",
+            "question": "You have three trained models (logistic regression, Random Forest, XGBoost) with test accuracies of 85%, 91%, and 92%. How would stacking improve upon these individual models?",
+            "options": [
+                "Stacking averages the three accuracies to get 89.3%, which is a reliable ensemble estimate",
+                "Stacking trains a meta-model on the predictions of the three base models as features, learning optimal weights and capturing complementary strengths",
+                "Stacking always improves accuracy by at least 5% over the best individual model",
+                "Stacking is unnecessary here since XGBoost is already the best model"
+            ],
+            "answer": 1,
+            "explanation": "Stacking (stacked generalization) trains a meta-learner (often logistic regression or gradient boosting) that takes the out-of-fold predictions of base models as its features. Unlike simple averaging, the meta-model learns: 'when logistic regression predicts class A and XGBoost predicts class B, which one is right?' It can learn that XGBoost is reliable for certain input patterns while Random Forest is better for others. The key is using out-of-fold predictions to prevent data leakage. A well-implemented stack typically achieves 93-95% in this scenario by exploiting complementary error patterns."
+        }
+    ]
+}

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_53_Model_Tuning_and_Feature_Selection/quiz.json
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_53_Model_Tuning_and_Feature_Selection/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 53,
+    "questions": [
+        {
+            "id": "d53q01",
+            "type": "multiple_choice",
+            "question": "Why is Grid Search inefficient for tuning models with many hyperparameters, and what is a better alternative?",
+            "options": [
+                "Grid Search is inefficient because it requires sorting the hyperparameter values before searching",
+                "Grid Search evaluates every combination exhaustively, so adding one hyperparameter multiplies total evaluations; Random Search samples random combinations and finds good results with far fewer evaluations",
+                "Grid Search only works with continuous hyperparameters; it cannot handle categorical ones",
+                "Grid Search overfits to the validation set because it evaluates the same data too many times"
+            ],
+            "answer": 1,
+            "explanation": "Grid Search suffers from the curse of dimensionality: 5 hyperparameters with 10 values each = 100,000 combinations. Random Search evaluates random samples from the same space and typically finds results within 5% of Grid Search quality with ~10% of the evaluations. This is because most hyperparameter spaces are low-dimensional: only a few hyperparameters really matter, and Random Search samples those important dimensions more densely. Bergstra & Bengio (2012) proved this empirically. For expensive models, Bayesian Optimization is even better—it builds a surrogate model to predict which hyperparameters will perform best."
+        },
+        {
+            "id": "d53q02",
+            "type": "multiple_choice",
+            "question": "What is the difference between filter methods and wrapper methods for feature selection?",
+            "options": [
+                "Filter methods use statistical scores (correlation, mutual information) independent of the model; wrapper methods train the actual model on subsets to evaluate feature importance",
+                "Filter methods work only for classification; wrapper methods work for both classification and regression",
+                "Filter methods are supervised; wrapper methods are unsupervised",
+                "Filter methods remove duplicate features; wrapper methods remove irrelevant features"
+            ],
+            "answer": 0,
+            "explanation": "Filter methods compute a univariate statistical score per feature (correlation with target, chi-squared, mutual information, ANOVA F-statistic) and select top-k features. They're fast but ignore feature interactions and model-specific behavior. Wrapper methods (RFE, forward/backward selection) actually train the model and evaluate performance on subsets of features—they're model-aware but computationally expensive. Embedded methods (Lasso, feature importances from trees) perform selection as part of training. Typical workflow: filter to reduce 1000 features to 100, then use wrapper or embedded methods on the reduced set."
+        },
+        {
+            "id": "d53q03",
+            "type": "multiple_choice",
+            "question": "Recursive Feature Elimination (RFE) with a Random Forest selects 15 of your original 200 features. What should concern you before trusting this selection?",
+            "options": [
+                "RFE only works correctly with linear models; Random Forest importance can be misleading",
+                "You should be concerned about correlated features—RFE may arbitrarily keep one of a correlated group and discard others that are equally or more important",
+                "RFE with 200 features always overfits; you should use fewer starting features",
+                "The 15 features selected are always interpretable; this means the model lacks complexity"
+            ],
+            "answer": 1,
+            "explanation": "RFE and tree-based importance scores have a known issue with correlated features: when two features are highly correlated, both contain the same information, but Random Forest importance splits the credit arbitrarily. RFE may keep feature A and discard correlated feature B, even though B might be more causally meaningful or more stable in production. Before trusting the selection: check correlations among selected features, validate on a holdout set that RFE performance improves, and consider the stability of selections across bootstrap samples (stability selection)."
+        },
+        {
+            "id": "d53q04",
+            "type": "multiple_choice",
+            "question": "What is Bayesian Optimization for hyperparameter tuning, and why does it outperform Random Search for expensive models?",
+            "options": [
+                "Bayesian Optimization trains multiple models simultaneously to find the best hyperparameters faster",
+                "Bayesian Optimization builds a probabilistic surrogate model of the objective function and uses it to choose the next hyperparameter candidate most likely to improve results, rather than sampling blindly",
+                "Bayesian Optimization is a statistical test that determines which hyperparameters are significant",
+                "Bayesian Optimization applies Bayes' theorem to combine prior model knowledge with training data during fitting"
+            ],
+            "answer": 1,
+            "explanation": "Random Search and Grid Search are memoryless—each evaluation is independent of previous results. Bayesian Optimization maintains a surrogate model (typically a Gaussian Process) that predicts the likely performance for any hyperparameter configuration, given all evaluations so far. An acquisition function (e.g., Expected Improvement) selects the next point that maximizes the probability of beating the current best. This exploits past results to avoid re-evaluating bad regions and focus on promising ones. For models that take hours to train (deep learning, large GBM), this reduces total search time by 10-50×. Tools: Optuna, Hyperopt, Ray Tune."
+        },
+        {
+            "id": "d53q05",
+            "type": "multiple_choice",
+            "question": "During hyperparameter tuning, a practitioner evaluates 500 different configurations on the same validation set and picks the best. What statistical problem occurs?",
+            "options": [
+                "Gradient descent will not converge with so many hyperparameter evaluations",
+                "Multiple comparisons problem: with 500 evaluations, some configurations will appear good due to random chance; the selected model is likely overfit to the validation set",
+                "The model will memorize the validation set after 500 evaluations",
+                "Statistical significance cannot be computed with more than 100 hyperparameter combinations"
+            ],
+            "answer": 1,
+            "explanation": "This is hyperparameter overfitting (also called 'overfitting to the validation set'): with enough trials, some random combination will score well on the validation set purely by chance. The selected model's validation score is an optimistically biased estimate of true performance. Solution: use nested cross-validation (inner loop for hyperparameter selection, outer loop for performance estimation), or hold out a completely separate test set that is only evaluated once after final hyperparameter selection. Never report the validation score used for selection as your model's final performance."
+        }
+    ]
+}

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_54_Probabilistic_Modeling/quiz.json
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_54_Probabilistic_Modeling/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 54,
+    "questions": [
+        {
+            "id": "d54q01",
+            "type": "multiple_choice",
+            "question": "What is the 'naive' assumption in Naive Bayes, and why does the algorithm still work well despite this assumption often being violated?",
+            "options": [
+                "The 'naive' assumption is that all features have equal importance for classification",
+                "The 'naive' assumption is that features are conditionally independent given the class label; it works well because it only needs to estimate the relative ranking of class probabilities, not their exact values",
+                "The 'naive' assumption is that the data follows a normal (Gaussian) distribution",
+                "The 'naive' assumption is that training and test data come from the same distribution"
+            ],
+            "answer": 1,
+            "explanation": "Naive Bayes assumes all features are conditionally independent given the class—meaning knowing feature X tells you nothing extra about feature Y once you know the class. In text classification, this means 'machine' and 'learning' are treated as independent words, which is obviously false. Despite this, Naive Bayes often works because: (1) for classification, you only need the correct class to have the highest posterior probability, not accurate probabilities; (2) even correlated features often push probability in the same direction, reinforcing the right prediction. NB is fast, requires little data, and is a strong baseline for text tasks."
+        },
+        {
+            "id": "d54q02",
+            "type": "multiple_choice",
+            "question": "A logistic regression model outputs probabilities of 0.95 for positive class, but a well-calibrated model should output 0.60 for these same samples (which are actually positive 60% of the time). What does this mean?",
+            "options": [
+                "The model is overfitting because it produces probabilities too close to 1.0",
+                "The model is overconfident—its probability scores are not well-calibrated; a probability of 0.95 should correspond to 95% actual frequency, not 60%",
+                "The model's threshold should be adjusted from 0.5 to 0.7 to fix this issue",
+                "This indicates class imbalance; the model needs oversampling to produce accurate probabilities"
+            ],
+            "answer": 1,
+            "explanation": "Calibration measures whether a model's confidence matches its actual accuracy: when a calibrated model predicts 0.95, it should be right 95% of the time. This model is poorly calibrated—it says 0.95 for events that happen 60% of the time, making it overconfident. Calibration matters for risk management and decision-making (a loan model saying 95% repayment probability when true rate is 60% causes serious problems). Fix with: Platt scaling (train a logistic regression on model outputs) or isotonic regression. Evaluate with reliability diagrams and Expected Calibration Error (ECE)."
+        },
+        {
+            "id": "d54q03",
+            "type": "multiple_choice",
+            "question": "In Bayesian inference, what do the prior, likelihood, and posterior represent?",
+            "options": [
+                "Prior = training data; likelihood = model architecture; posterior = model predictions",
+                "Prior = beliefs before seeing data; likelihood = probability of data given parameters; posterior = updated beliefs after observing data (prior × likelihood, normalized)",
+                "Prior = feature distribution; likelihood = target distribution; posterior = joint distribution",
+                "Prior = model complexity penalty; likelihood = training loss; posterior = validation loss"
+            ],
+            "answer": 1,
+            "explanation": "Bayes' theorem: P(θ|data) ∝ P(data|θ) × P(θ). The prior P(θ) encodes beliefs before seeing data—e.g., 'I believe fraud rate is between 1-5% based on industry data.' The likelihood P(data|θ) is how probable the observed data is for a given parameter θ—the standard ML loss function. The posterior P(θ|data) combines both: your updated belief about θ after observing data. As data accumulates, the posterior becomes dominated by the likelihood and converges regardless of prior. Bayesian methods are powerful when data is scarce and you have domain knowledge to encode in priors."
+        },
+        {
+            "id": "d54q04",
+            "type": "multiple_choice",
+            "question": "When should you prefer a probabilistic model that outputs uncertainty estimates over a standard point-estimate model?",
+            "options": [
+                "When the dataset is large; probabilistic models scale better to big data than point-estimate models",
+                "When prediction confidence matters for decisions—e.g., a self-driving car needs to know whether it's 99% vs 60% confident before acting",
+                "When features are categorical; probabilistic models handle categorical data more naturally",
+                "Probabilistic models are always preferable since they contain strictly more information than point estimates"
+            ],
+            "answer": 1,
+            "explanation": "Uncertainty quantification is critical when the cost of wrong decisions is asymmetric or when model confidence should trigger different actions. Examples: a medical diagnosis model with 60% confidence should flag for human review; a trading model with high uncertainty should reduce position size; a robot arm should move slowly when uncertain about object position. Standard models give overconfident point estimates. Gaussian Processes, Bayesian Neural Networks, Monte Carlo Dropout, and conformal prediction all provide uncertainty bounds. The key business question: 'should my system act differently when it's uncertain?' If yes, use probabilistic models."
+        },
+        {
+            "id": "d54q05",
+            "type": "multiple_choice",
+            "question": "Which algorithm is best suited for email spam classification, and why?",
+            "options": [
+                "K-Nearest Neighbors, because spam emails cluster near similar spam emails in feature space",
+                "Naive Bayes (specifically Multinomial NB), because it naturally models word frequency distributions and works well even with small training sets",
+                "Support Vector Machine, because it finds the maximum margin between spam and legitimate emails",
+                "Gradient Boosting, because it handles class imbalance between spam and ham automatically"
+            ],
+            "answer": 1,
+            "explanation": "Multinomial Naive Bayes is the classic spam filter algorithm for good reasons: (1) Text is naturally modeled as word count distributions—MultinomialNB models exactly this; (2) Despite the independence assumption, words like 'free', 'winner', 'click here' are individually strong spam signals; (3) Computationally trivial—trains in milliseconds on millions of emails; (4) Online learning—can update the model in real-time as new spam patterns emerge; (5) Good performance with limited labeled data. Gmail uses far more sophisticated methods today, but NB was the foundation of the first commercial spam filters (SpamAssassin, etc.)."
+        }
+    ]
+}

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_55_Advanced_Unsupervised_Learning/quiz.json
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_55_Advanced_Unsupervised_Learning/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 55,
+    "questions": [
+        {
+            "id": "d55q01",
+            "type": "multiple_choice",
+            "question": "What is the key advantage of DBSCAN over K-Means for clustering?",
+            "options": [
+                "DBSCAN is faster than K-Means because it does not require computing distances between all points",
+                "DBSCAN discovers clusters of arbitrary shape and automatically identifies outliers as noise, without requiring the number of clusters to be specified in advance",
+                "DBSCAN guarantees that every point is assigned to exactly one cluster, unlike K-Means which can leave points unassigned",
+                "DBSCAN works better with high-dimensional data because it uses cosine similarity instead of Euclidean distance"
+            ],
+            "answer": 1,
+            "explanation": "K-Means assumes clusters are convex (circular/spherical) and requires you to specify k in advance—it will force every point into a cluster and struggles with non-convex shapes. DBSCAN (Density-Based Spatial Clustering of Applications with Noise) defines clusters as dense regions separated by sparse regions. This means: (1) it can find arbitrarily shaped clusters (crescents, rings, irregular blobs); (2) sparse points become 'noise' (not forced into clusters); (3) k is discovered rather than specified. DBSCAN requires tuning epsilon (neighborhood radius) and min_samples (minimum points to form a dense region)."
+        },
+        {
+            "id": "d55q02",
+            "type": "multiple_choice",
+            "question": "Your production system has 0.1% fraud transactions. You want to detect new fraud patterns without labeled data. Which technique is most appropriate?",
+            "options": [
+                "K-Means clustering with k=2 to separate fraud from legitimate transactions",
+                "PCA to reduce dimensions and then apply logistic regression on the components",
+                "Isolation Forest anomaly detection, which identifies unusual points by measuring how easily they can be isolated from the rest of the data",
+                "UMAP visualization to identify fraud clusters, then manually label them for training"
+            ],
+            "answer": 2,
+            "explanation": "Isolation Forest is designed for anomaly detection without labels. The key insight: anomalies are rare and different—they require fewer random splits in a tree to isolate them. For normal points (which are densely packed), you need many splits. The algorithm builds an ensemble of random isolation trees and scores each point by its average depth—anomalies have shorter paths. With 0.1% fraud, fraud patterns are genuinely unusual in feature space, making Isolation Forest ideal. One-Class SVM is another option but is slower and more sensitive to hyperparameters. Both are unsupervised, requiring no labeled fraud examples."
+        },
+        {
+            "id": "d55q03",
+            "type": "multiple_choice",
+            "question": "How does an autoencoder achieve dimensionality reduction, and what makes it more powerful than PCA?",
+            "options": [
+                "Autoencoders reduce dimensions by dropping features with low variance, while PCA projects onto orthogonal axes",
+                "Autoencoders compress data through a narrow bottleneck layer (encoder) and learn to reconstruct it (decoder), enabling nonlinear dimensionality reduction that PCA cannot capture",
+                "Autoencoders use supervised labels to guide compression, making them more accurate than PCA's unsupervised approach",
+                "Autoencoders are faster than PCA because neural networks compute matrix operations more efficiently"
+            ],
+            "answer": 1,
+            "explanation": "PCA finds linear projections that maximize variance—it can only capture linear relationships. An autoencoder learns encoder f: X → Z (compress to low-dimensional latent space Z) and decoder g: Z → X (reconstruct original X), optimizing reconstruction loss. Because neural networks can model nonlinear functions, autoencoders capture complex nonlinear structure in the data—e.g., the manifold structure of face images. The bottleneck forces the network to learn meaningful compressed representations. Applications: image compression, denoising (denoising autoencoders), anomaly detection (high reconstruction error = anomaly), and feature extraction for downstream tasks."
+        },
+        {
+            "id": "d55q04",
+            "type": "multiple_choice",
+            "question": "What is the purpose of t-SNE and UMAP, and why should you NOT use their outputs directly as features for machine learning?",
+            "options": [
+                "t-SNE and UMAP are feature selection methods; their outputs should not replace the original features because they only select a subset",
+                "t-SNE and UMAP are visualization tools that produce 2D/3D embeddings preserving local structure; their outputs are not suitable as ML features because they are stochastic, non-deterministic on new points, and distort global distances",
+                "t-SNE and UMAP reduce overfitting; they should not be used as features because they require labeled data to train",
+                "t-SNE and UMAP outputs cannot be used as features because neural networks cannot process 2D or 3D input"
+            ],
+            "answer": 1,
+            "explanation": "t-SNE and UMAP are manifold learning algorithms optimized for 2D/3D visualization of cluster structure. Problems with using them as ML features: (1) t-SNE is non-parametric—it cannot project new test points, only the training set; (2) Both are stochastic with random initialization, so outputs change between runs; (3) They distort global structure—distances in the 2D plot are not meaningful; (4) They discard information (high-D → 2D loses most signal). Use UMAP visualization to understand cluster structure and validate K-Means results, but use PCA, autoencoders, or original features as inputs to downstream ML models."
+        },
+        {
+            "id": "d55q05",
+            "type": "multiple_choice",
+            "question": "How do you evaluate clustering quality when you have no ground truth labels?",
+            "options": [
+                "Use accuracy by comparing cluster assignments to a random baseline",
+                "Use the Silhouette Score, which measures how similar each point is to its own cluster versus neighboring clusters, and the Davies-Bouldin Index which measures cluster compactness and separation",
+                "Split data 80/20 and compute cross-entropy loss on the held-out set",
+                "Clustering cannot be evaluated without ground truth labels; you must always label a subset of data first"
+            ],
+            "answer": 1,
+            "explanation": "Unsupervised evaluation uses internal metrics that measure cluster quality without labels. Silhouette Score: for each point, compute a = average distance to same-cluster points, b = average distance to nearest other cluster points; score = (b - a) / max(a, b). Range [-1, 1]: near 1 = well-clustered; near -1 = misassigned. Davies-Bouldin Index: ratio of within-cluster distances to between-cluster distances; lower is better. Calinski-Harabasz Score: variance between clusters / variance within clusters; higher is better. Use these to compare k values in K-Means or epsilon in DBSCAN, but always validate business relevance—metrics don't guarantee meaningful clusters."
+        }
+    ]
+}

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_56_Time_Series_and_Forecasting/quiz.json
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_56_Time_Series_and_Forecasting/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 56,
+    "questions": [
+        {
+            "id": "d56q01",
+            "type": "multiple_choice",
+            "question": "Why must a time series be stationary before fitting an ARIMA model, and how do you make it stationary?",
+            "options": [
+                "Stationarity ensures the model trains faster by reducing the number of parameters needed",
+                "ARIMA assumes constant mean, variance, and autocorrelation structure over time; non-stationary series (trending, seasonal) violate these assumptions, producing unreliable forecasts. Differencing (subtracting previous value) removes trends to achieve stationarity",
+                "Stationarity is required to use the train/test split correctly for time series data",
+                "Non-stationary series have too many missing values for ARIMA to handle"
+            ],
+            "answer": 1,
+            "explanation": "ARIMA's mathematical foundations assume the data-generating process has constant statistical properties over time. A trending series (like stock prices growing over decades) has non-constant mean; a series with increasing volatility has non-constant variance. Fitting ARIMA to non-stationary data produces spurious correlations and poor forecasts. The 'I' in ARIMA stands for Integrated: the 'd' parameter specifies how many times to difference (subtract lag-1 value) to remove trends. Seasonal differencing removes seasonal patterns. Test for stationarity with the Augmented Dickey-Fuller test."
+        },
+        {
+            "id": "d56q02",
+            "type": "multiple_choice",
+            "question": "A retail company wants to forecast daily sales for the next 90 days, accounting for weekly seasonality and a long-term growth trend. Which forecasting approach is most appropriate?",
+            "options": [
+                "ARIMA with d=1 to remove the trend, since seasonality is not important for 90-day forecasts",
+                "A simple moving average of the last 30 days, as it captures recent trends without overfitting",
+                "Facebook Prophet, which explicitly models trend + seasonality components and handles holidays and missing data without requiring stationarity",
+                "LSTM neural network, because deep learning always outperforms statistical methods for business forecasting"
+            ],
+            "answer": 2,
+            "explanation": "Prophet (by Meta/Facebook) is designed exactly for this use case: business time series with multiple seasonalities, trend changes, and holiday effects. Its decomposable model: y(t) = trend(t) + seasonality(t) + holidays(t) + error(t). Key advantages over ARIMA for this problem: (1) handles multiple seasonalities simultaneously (weekly, yearly); (2) robust to missing values and outliers; (3) interpretable components—you can visualize and explain the trend and seasonal patterns; (4) no stationarity requirement; (5) built-in uncertainty intervals. ARIMA requires separate SARIMA extensions for seasonality and is harder to tune."
+        },
+        {
+            "id": "d56q03",
+            "type": "multiple_choice",
+            "question": "Why is using a standard random train/test split WRONG for evaluating time series models?",
+            "options": [
+                "Random splits don't work for time series because the data is not normally distributed",
+                "Random splits create data leakage: future data ends up in the training set, allowing the model to learn from information it wouldn't have in production",
+                "Random splits are computationally expensive for time series data due to high memory usage",
+                "Random splits cannot evaluate seasonality patterns since they may separate training from seasonal peaks"
+            ],
+            "answer": 1,
+            "explanation": "Time series has temporal dependency—future values depend on past values. A random split might put January 2024 in the test set and February 2024 in the training set. The model 'learns' from future data it would never have seen in real deployment, inflating performance estimates. Correct evaluation: always use temporal splits—train on past data, test on future data (e.g., train on 2020-2023, test on 2024). For cross-validation, use walk-forward validation (expanding or sliding window) where each fold respects chronological order. This simulates real production conditions."
+        },
+        {
+            "id": "d56q04",
+            "type": "multiple_choice",
+            "question": "What makes LSTM networks well-suited for time series forecasting compared to traditional regression models?",
+            "options": [
+                "LSTMs are faster to train than ARIMA models, making them better for real-time forecasting",
+                "LSTMs have memory cells that maintain information across long sequences, capturing long-range dependencies and complex nonlinear patterns that ARIMA's linear structure cannot model",
+                "LSTMs do not require feature engineering since they automatically handle missing values and outliers",
+                "LSTMs produce exact point predictions without the uncertainty ranges that ARIMA produces"
+            ],
+            "answer": 1,
+            "explanation": "ARIMA models linear relationships between a small number of past lags. LSTMs (Long Short-Term Memory networks) maintain a cell state with gates (input, forget, output) that decide what to remember and what to discard across many timesteps. This enables: (1) capturing long-range dependencies (e.g., sales in Q4 influenced by Q1 decisions); (2) modeling complex nonlinear patterns (interactions between multiple time-varying factors); (3) handling multiple parallel time series (multivariate forecasting). Trade-off: LSTMs require much more data to train, are less interpretable, and take longer to train than ARIMA."
+        },
+        {
+            "id": "d56q05",
+            "type": "multiple_choice",
+            "question": "What does MAPE (Mean Absolute Percentage Error) measure, and when is it inappropriate to use?",
+            "options": [
+                "MAPE measures the correlation between forecasts and actual values; it is inappropriate when the data has seasonality",
+                "MAPE measures average forecast error as a percentage of actual values; it is inappropriate when actual values are near zero (division by zero) or when asymmetric errors (over vs under forecast) have different costs",
+                "MAPE measures the lag between forecast and actual time series; it is inappropriate for long-horizon forecasts",
+                "MAPE measures variance in forecast errors; it is inappropriate when comparing models trained on different datasets"
+            ],
+            "answer": 1,
+            "explanation": "MAPE = mean(|actual - forecast| / actual) × 100. Problems: (1) Undefined when actual = 0; very unstable when actual is near zero—a small absolute error becomes a huge percentage error. (2) Asymmetric: underforecasting by 50% (MAPE contribution: 50%) is penalized less than overforecasting by 50% (MAPE contribution: 100%). (3) Penalizes models that predict low values when actual is high more than the reverse. Use MAE when you care equally about all errors; RMSE when large errors matter more; SMAPE (Symmetric MAPE) to address asymmetry; or MASE (Mean Absolute Scaled Error) which scales by naive forecast performance."
+        }
+    ]
+}

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_57_Recommender_Systems/quiz.json
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_57_Recommender_Systems/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 57,
+    "questions": [
+        {
+            "id": "d57q01",
+            "type": "multiple_choice",
+            "question": "What is collaborative filtering, and what fundamental assumption makes it work?",
+            "options": [
+                "Collaborative filtering recommends items based on the item's content features (genre, keywords, attributes), assuming similar items should be recommended together",
+                "Collaborative filtering recommends items based on the behavior of similar users, assuming that people with similar past preferences will have similar future preferences",
+                "Collaborative filtering trains a neural network on user-item interactions to predict ratings without any user similarity computation",
+                "Collaborative filtering filters items by popularity, recommending the most interacted-with items to all users"
+            ],
+            "answer": 1,
+            "explanation": "Collaborative filtering (CF) ignores item content entirely—it only uses the matrix of user-item interactions (ratings, clicks, purchases). The core assumption: if Alice and Bob both liked movies A, B, and C, and Alice also liked D, then Bob will probably like D too. This discovers latent preferences without requiring domain knowledge about items. CF comes in two flavors: user-based CF (find similar users, recommend what they liked) and item-based CF (find items similar to what the user liked, used by Amazon's 'customers also bought'). The challenge is sparse interaction data and cold start."
+        },
+        {
+            "id": "d57q02",
+            "type": "multiple_choice",
+            "question": "Netflix wants to recommend movies to a brand new user who has just signed up and rated nothing. What is this problem called, and how is it typically solved?",
+            "options": [
+                "Sparsity problem — solve by applying matrix factorization with regularization",
+                "Cold start problem — solve by using content-based filtering or asking users to rate a few popular items to bootstrap their profile",
+                "Data leakage problem — solve by only recommending movies from the training period",
+                "Popularity bias — solve by diversifying recommendations across genres rather than defaulting to blockbusters"
+            ],
+            "answer": 1,
+            "explanation": "The cold start problem occurs when there's insufficient interaction history to generate collaborative filtering recommendations. Solutions for new users: (1) Onboarding survey—ask users to rate a few seed items (Netflix asks about favorite movies during signup); (2) Demographics-based—recommend popular items in the user's age/location segment; (3) Content-based fallback—use available signals (device type, time of day, landing page) to infer preferences; (4) Hybrid system—combine collaborative filtering with content-based methods. The cold start problem also affects new items (no ratings yet); solution: feature-based similarity to existing items."
+        },
+        {
+            "id": "d57q03",
+            "type": "multiple_choice",
+            "question": "How does Matrix Factorization (SVD, ALS) improve upon user-based collaborative filtering for large-scale recommendation systems?",
+            "options": [
+                "Matrix factorization is faster during recommendation because it replaces dot products with hash lookups",
+                "Matrix factorization decomposes the sparse user-item matrix into dense latent factor matrices, learning compact user and item embeddings that generalize to unobserved interactions and scale to millions of users",
+                "Matrix factorization automatically handles missing ratings by imputing average values before decomposition",
+                "Matrix factorization eliminates the need for negative examples during training, simplifying the data pipeline"
+            ],
+            "answer": 1,
+            "explanation": "User-based CF requires storing and searching all user-item pairs—at Netflix scale (200M users × 15K movies) this is computationally intractable. Matrix factorization decomposes the rating matrix R ≈ U × V^T where U is a (users × k) matrix and V is an (items × k) matrix, with k latent factors (e.g., k=50). Each user and item gets a dense embedding vector. Recommendation = dot product of user and item embeddings. Benefits: (1) compact storage (200M×50 + 15K×50 instead of 200M×15K); (2) captures latent preferences (e.g., an 'action-oriented' factor); (3) handles sparsity by learning generalizable representations; (4) fast lookup using approximate nearest neighbor search."
+        },
+        {
+            "id": "d57q04",
+            "type": "multiple_choice",
+            "question": "What is the difference between implicit and explicit feedback in recommender systems, and which is more common in practice?",
+            "options": [
+                "Explicit feedback is collected automatically by the system; implicit feedback requires users to actively provide ratings",
+                "Explicit feedback is direct user ratings (1-5 stars, thumbs up); implicit feedback is inferred from behavior (clicks, time spent, purchases). Implicit is far more common since most users never rate anything",
+                "Explicit feedback is more accurate because users provide intentional ratings; implicit feedback has too much noise to be useful",
+                "Explicit and implicit feedback are equivalent for collaborative filtering; the choice depends only on data collection infrastructure"
+            ],
+            "answer": 1,
+            "explanation": "Explicit feedback (star ratings, likes/dislikes) directly expresses preferences but suffers from low coverage—only ~5% of Netflix users rate watched content. Implicit feedback (play, pause, skip, rewatch, add-to-list, time spent) is collected automatically for every interaction, providing orders of magnitude more data. Challenge: implicit feedback is noisy and one-sided. A click means 'interested', but absence of a click could mean 'not interested' or 'never saw it'. ALS (Alternating Least Squares) is optimized for implicit feedback, treating interactions as confidence-weighted signals rather than ground-truth preferences. Spotify, YouTube, and TikTok rely almost entirely on implicit signals."
+        },
+        {
+            "id": "d57q05",
+            "type": "multiple_choice",
+            "question": "How do you evaluate a recommender system, and why is RMSE on held-out ratings an incomplete measure?",
+            "options": [
+                "RMSE is the gold standard for recommender systems; it is incomplete only when the rating scale is non-linear",
+                "RMSE measures rating prediction accuracy but ignores ranking quality—a system that predicts ratings accurately may still show users irrelevant items in top-k recommendations, which is what actually matters for engagement",
+                "RMSE cannot be computed for implicit feedback; this is why it is incomplete for modern recommendation systems",
+                "RMSE is incomplete because it does not account for the cold start problem in evaluation"
+            ],
+            "answer": 1,
+            "explanation": "Netflix ran a $1M prize (Netflix Prize) optimizing RMSE, then found the winning algorithm barely improved actual engagement. RMSE measures how accurately you predict a user's rating for an item they've already rated—but what users actually experience is the ranking of items shown to them. Better metrics: Precision@K (what fraction of top-K recommended items are relevant?), Recall@K (what fraction of relevant items appear in top-K?), NDCG (Normalized Discounted Cumulative Gain—rewards relevant items appearing higher in the list), and MRR (Mean Reciprocal Rank—how high is the first relevant item?). Online A/B testing of click-through rate and session time is the ultimate evaluation."
+        }
+    ]
+}

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_58_Transformers_and_Attention/quiz.json
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_58_Transformers_and_Attention/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 58,
+    "questions": [
+        {
+            "id": "d58q01",
+            "type": "multiple_choice",
+            "question": "What problem with RNNs did the attention mechanism solve, and how does it work?",
+            "options": [
+                "RNNs could not process batches of text; attention enables parallel processing of entire sequences",
+                "RNNs compressed entire sequences into a single fixed-size vector, losing information for long sequences; attention lets the model directly access any position in the input sequence when generating each output token",
+                "RNNs were unable to handle multiple languages; attention mechanisms learn language-specific representations",
+                "RNNs required labeled data for training; attention enables unsupervised pre-training on raw text"
+            ],
+            "answer": 1,
+            "explanation": "The bottleneck problem: RNNs encode the entire input sequence into a single context vector, which must contain all information needed for generation. For long sequences (e.g., translating a 100-word sentence), early information gets compressed out. Bahdanau attention (2014) solved this: when generating output word t, the model computes a weighted sum of ALL input encoder states, with weights (attention scores) indicating which input positions are most relevant. For 'bank' in 'I deposited money at the bank', high attention on 'money' and 'deposited' disambiguates meaning. This 'direct access' to any input position was transformative for NLP."
+        },
+        {
+            "id": "d58q02",
+            "type": "multiple_choice",
+            "question": "What is self-attention in the Transformer architecture, and why is it powerful?",
+            "options": [
+                "Self-attention is attention applied to the model's own parameters to select which weights to activate",
+                "Self-attention computes relationships between all pairs of positions within a single sequence simultaneously, allowing each token to gather context from every other token in one parallel operation",
+                "Self-attention is a regularization technique where the model attends to its own previous predictions to reduce repetition",
+                "Self-attention refers to the transformer attending to previous layers rather than the input sequence"
+            ],
+            "answer": 1,
+            "explanation": "In self-attention, each token in a sequence queries all other tokens to find relevant context. For each position, three vectors are computed: Query (what am I looking for?), Key (what do I contain?), Value (what do I output?). Attention score = softmax(Q × K^T / √d_k) × V. This allows 'The animal didn't cross the street because it was too tired'—when processing 'it', self-attention attends strongly to 'animal' rather than 'street'. The power: (1) captures long-range dependencies in one step (vs RNNs requiring many steps); (2) fully parallelizable (vs sequential RNN processing); (3) multi-head attention runs multiple attention operations in parallel, capturing diverse relationship types."
+        },
+        {
+            "id": "d58q03",
+            "type": "multiple_choice",
+            "question": "What is the key difference between BERT and GPT in terms of architecture and use cases?",
+            "options": [
+                "BERT uses convolutional layers; GPT uses recurrent layers",
+                "BERT is a bidirectional encoder that reads context from both directions (good for understanding tasks like classification, NER); GPT is a unidirectional decoder that generates text left-to-right (good for generation tasks)",
+                "BERT is larger than GPT and therefore more accurate on all NLP tasks",
+                "BERT uses supervised pre-training; GPT uses unsupervised pre-training"
+            ],
+            "answer": 1,
+            "explanation": "The transformer has two components: an encoder (reads entire sequence bidirectionally) and a decoder (generates tokens left-to-right, can only attend to previous tokens). BERT uses only the encoder stack—pre-trained with Masked Language Modeling (predict randomly masked words) using both left and right context. This makes BERT excellent at understanding: text classification, NER, question answering (given a passage, find the answer span). GPT uses only the decoder stack—pre-trained with next-token prediction. This makes GPT excellent at generation: summarization, translation, creative writing, chatbots. BERT-like models dominate understanding benchmarks; GPT-like models power ChatGPT and similar services."
+        },
+        {
+            "id": "d58q04",
+            "type": "multiple_choice",
+            "question": "Why do transformer models use positional encoding, and what would happen without it?",
+            "options": [
+                "Positional encoding increases the model's memory efficiency by reducing the attention matrix size",
+                "Self-attention is permutation-invariant—it treats input as a set, not a sequence. Positional encoding injects sequence order information so the model knows word positions; without it, 'dog bites man' and 'man bites dog' would produce identical representations",
+                "Positional encoding compresses the sequence length to fit within the model's maximum context window",
+                "Positional encoding replaces tokenization by directly encoding word positions in the vocabulary"
+            ],
+            "answer": 1,
+            "explanation": "Unlike RNNs that inherently process sequences step-by-step, self-attention computes all pairs of token relationships simultaneously—treating the sequence as an unordered set. Without positional information, the attention mechanism cannot distinguish 'The cat sat on the mat' from 'The mat sat on the cat.' Positional encodings are added to token embeddings to inject position information. Original Transformers use sinusoidal encodings (fixed mathematical functions of position). Modern models use learned positional embeddings (BERT, GPT) or relative position encodings (RoPE in LLaMA). The model learns to use this positional signal to understand sequential structure."
+        },
+        {
+            "id": "d58q05",
+            "type": "multiple_choice",
+            "question": "Your company wants to build a custom customer support chatbot using transformer models. Which approach is most cost-effective?",
+            "options": [
+                "Train a transformer from scratch on your customer support tickets to get domain-specific performance",
+                "Fine-tune a pretrained model (e.g., BERT or a small GPT variant) on your labeled support data, leveraging existing language knowledge and requiring far less data and compute than training from scratch",
+                "Use GPT-4 directly via API without any fine-tuning, since large models always outperform fine-tuned small models",
+                "Use only keyword matching and rule-based responses, as transformers are too complex for production customer support"
+            ],
+            "answer": 1,
+            "explanation": "Training a transformer from scratch requires billions of tokens and millions in compute—impractical for most companies. Fine-tuning leverages transfer learning: the pretrained model already understands grammar, semantics, and world knowledge from training on internet-scale text. Fine-tuning on domain-specific data (customer support tickets) with a classification or generation head adapts this knowledge to your specific use case, typically requiring 1K-100K examples rather than billions. For classification (intent detection, routing): fine-tune BERT variants. For generation (response drafting): fine-tune GPT variants or instruction-tune an open-source model. RAG (retrieval-augmented generation) is another option for knowledge-heavy support."
+        }
+    ]
+}

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_59_Generative_Models/quiz.json
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_59_Generative_Models/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 59,
+    "questions": [
+        {
+            "id": "d59q01",
+            "type": "multiple_choice",
+            "question": "What are the two components of a GAN (Generative Adversarial Network) and how do they interact during training?",
+            "options": [
+                "Encoder and Decoder: the encoder compresses real images and the decoder reconstructs them with added noise",
+                "Generator and Discriminator: the Generator creates fake samples to fool the Discriminator; the Discriminator learns to distinguish real from fake; they compete in a minimax game that drives the Generator to produce increasingly realistic outputs",
+                "Policy and Value networks: the Policy generates new images and the Value network scores their quality against a reward signal",
+                "Teacher and Student networks: the Teacher generates examples and the Student learns to replicate them through knowledge distillation"
+            ],
+            "answer": 1,
+            "explanation": "GAN training is a two-player minimax game. The Generator G takes random noise z and produces fake data G(z). The Discriminator D tries to output 1 for real data and 0 for fake data. They are trained adversarially: D is updated to maximize classification accuracy (real vs fake); G is updated to maximize D's error rate (make fakes that fool D). At Nash equilibrium, G produces samples indistinguishable from real data, and D outputs 0.5 for everything (cannot tell the difference). This adversarial pressure drives the Generator to produce high-quality outputs that must fool a continually improving critic."
+        },
+        {
+            "id": "d59q02",
+            "type": "multiple_choice",
+            "question": "What is mode collapse in GAN training, and why is it a problem?",
+            "options": [
+                "Mode collapse occurs when the Discriminator becomes too accurate, blocking any gradient signal to the Generator",
+                "Mode collapse occurs when the Generator learns to produce only a narrow subset of outputs (e.g., only one face style) that reliably fool the Discriminator, rather than capturing the full diversity of the training distribution",
+                "Mode collapse refers to the training loss collapsing to zero, indicating the model has memorized the training set",
+                "Mode collapse occurs when the learning rate is too high, causing gradient oscillations that destabilize training"
+            ],
+            "answer": 1,
+            "explanation": "Mode collapse is the most common GAN failure mode: the Generator finds a small set of outputs that reliably fool the current Discriminator and stops exploring. For a face generation task, this might mean producing variations of a single face type rather than diverse faces. The Discriminator then updates to reject this narrow range, forcing the Generator to switch to another narrow range, cycling repeatedly. Solutions include: Wasserstein GAN (WGAN) with gradient penalty, which provides better training signal; mini-batch discrimination; conditioning (cGAN); and diverse loss functions. Detecting mode collapse: measure FID (Fréchet Inception Distance) or manually inspect generated sample diversity."
+        },
+        {
+            "id": "d59q03",
+            "type": "multiple_choice",
+            "question": "How does a Variational Autoencoder (VAE) differ from a standard autoencoder, and what makes it suitable for generation?",
+            "options": [
+                "VAEs use a deeper encoder than standard autoencoders, giving them more capacity for complex distributions",
+                "VAEs encode inputs as probability distributions (mean and variance) over latent space rather than fixed points, enabling smooth interpolation and sampling of new data by drawing from the learned distribution",
+                "VAEs use adversarial training during encoding, similar to GANs, to produce higher quality reconstructions",
+                "VAEs are faster than standard autoencoders because they use variational dropout to skip unnecessary computations"
+            ],
+            "answer": 1,
+            "explanation": "Standard autoencoders map inputs to fixed latent points—the latent space has no structure, making random sampling produce garbage. VAEs encode each input as a distribution: N(μ, σ²) over the latent space. The KL divergence loss term regularizes the latent space toward N(0, 1), forcing it to be organized and continuous. The reparameterization trick enables backpropagation through sampling (z = μ + σ × ε, where ε ~ N(0,1)). Result: interpolating between two latent vectors produces semantically meaningful intermediate samples; sampling from N(0,1) generates new, diverse, realistic-looking data. VAEs produce blurrier images than GANs but have more stable training and structured latent spaces."
+        },
+        {
+            "id": "d59q04",
+            "type": "multiple_choice",
+            "question": "How do diffusion models (like those powering Stable Diffusion and DALL-E) generate images?",
+            "options": [
+                "Diffusion models generate images by progressively upsampling random noise using convolutional filters until a full-resolution image is obtained",
+                "Diffusion models learn to reverse a noise-adding process: they are trained to predict and remove noise at each step, so at inference time they start from pure noise and iteratively denoise it into a coherent image",
+                "Diffusion models use two competing networks (similar to GANs) where one adds noise and the other removes it until equilibrium",
+                "Diffusion models copy patches from training images and blend them using learned attention weights to construct new images"
+            ],
+            "answer": 1,
+            "explanation": "Diffusion models work in two phases. Forward process (training): gradually add Gaussian noise to a training image over T steps until it becomes pure noise—this requires no learning. Reverse process (the learned part): train a neural network (U-Net) to predict and remove the noise added at each step, given the noisy image and current timestep. At inference: start with pure Gaussian noise and run the learned denoising model T times (typically 50-1000 steps), progressively revealing a coherent image. Conditioning on text prompts (CLIP embeddings) steers the denoising toward specific content. Stable Diffusion operates in a compressed latent space for efficiency (Latent Diffusion Models)."
+        },
+        {
+            "id": "d59q05",
+            "type": "multiple_choice",
+            "question": "What metric is commonly used to evaluate the quality of generated images, and what does it measure?",
+            "options": [
+                "BLEU score, which measures n-gram overlap between generated and reference images",
+                "Fréchet Inception Distance (FID), which measures the statistical distance between the distribution of generated images and real images in the feature space of a pretrained InceptionV3 network",
+                "Mean Squared Error (MSE) between pixel values of generated and real images",
+                "Accuracy of a separate classifier trained to distinguish generated from real images"
+            ],
+            "answer": 1,
+            "explanation": "FID is the standard evaluation metric for generative image models. Process: (1) Extract features from real images using InceptionV3 (a pretrained classifier); (2) Extract features from generated images using the same network; (3) Fit a multivariate Gaussian to each feature distribution; (4) Compute the Fréchet distance between the two Gaussians. Lower FID = generated images are closer to real image statistics in terms of both quality and diversity. FID captures both fidelity (do images look realistic?) and diversity (do they cover the variety of the real distribution?). MSE measures pixel-level similarity but not perceptual quality; a model that produces slightly blurry images gets high MSE despite looking fine to humans."
+        }
+    ]
+}

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_60B_LLM_Fine_Tuning_and_PEFT/quiz.json
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_60B_LLM_Fine_Tuning_and_PEFT/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": "60B",
+    "questions": [
+        {
+            "id": "d60Bq01",
+            "type": "multiple_choice",
+            "question": "Why does full fine-tuning of large language models (7B+ parameters) require special techniques like PEFT?",
+            "options": [
+                "Full fine-tuning causes catastrophic forgetting of all previously learned language knowledge, producing worse results than PEFT",
+                "Full fine-tuning requires updating all parameters during backpropagation, storing optimizer states for every parameter—a 7B model needs ~28GB just for the model, plus ~84GB for Adam optimizer states, exceeding most GPU memory budgets",
+                "Full fine-tuning is prohibited by most LLM license agreements, requiring the use of PEFT as a legal workaround",
+                "Full fine-tuning takes too long because GPU parallelism only works with frozen weights"
+            ],
+            "answer": 1,
+            "explanation": "Memory is the bottleneck. For a 7B parameter model in 16-bit: model weights = 14GB. Adam optimizer stores momentum and variance for every parameter: 2 × 14GB = 28GB. Gradients: 14GB. Total: ~56GB minimum. Most GPUs are 24-40GB. PEFT methods like LoRA solve this by only adding and training a tiny number of additional parameters (0.1-1% of total) while keeping the original model frozen. The base model stays fixed; only the small adapters are updated. This reduces trainable parameters from 7B to perhaps 5M, slashing optimizer memory from 28GB to <100MB."
+        },
+        {
+            "id": "d60Bq02",
+            "type": "multiple_choice",
+            "question": "How does LoRA (Low-Rank Adaptation) reduce the number of trainable parameters?",
+            "options": [
+                "LoRA removes entire transformer layers from the model, creating a shallower fine-tuned version",
+                "LoRA decomposes weight update matrices into two smaller low-rank matrices (A and B), so instead of training a full d×d weight update, only d×r and r×d matrices are trained, where r << d",
+                "LoRA uses gradient checkpointing to avoid storing intermediate activations during fine-tuning",
+                "LoRA trains only the final classification layer while freezing all transformer layers"
+            ],
+            "answer": 1,
+            "explanation": "The key insight: weight updates during fine-tuning tend to have low intrinsic rank—you don't need a full-rank weight change. LoRA approximates the weight update ΔW ≈ B×A, where A is (r×d) and B is (d×r), with r typically 4-64. For a 4096×4096 weight matrix: full fine-tuning trains 16.7M parameters; LoRA with r=16 trains 2×4096×16 = 131K parameters—128× fewer. During inference, the LoRA weights are merged: W' = W + B×A (no added latency). Multiple LoRA adapters can coexist on the same base model, enabling cheap model specialization without maintaining full copies."
+        },
+        {
+            "id": "d60Bq03",
+            "type": "multiple_choice",
+            "question": "What does QLoRA add on top of LoRA, and what is the key tradeoff?",
+            "options": [
+                "QLoRA adds quantization-aware training to LoRA, allowing the final model to be deployed in 8-bit without accuracy loss",
+                "QLoRA loads the base model in 4-bit quantization (NF4), reducing base model memory from ~14GB to ~3.5GB for a 7B model, enabling fine-tuning on consumer GPUs; the tradeoff is slightly slower training due to quantization/dequantization overhead",
+                "QLoRA adds quality control metrics (Q stands for Quality) that automatically stop training when validation loss stops improving",
+                "QLoRA uses quantized gradients to reduce communication overhead in multi-GPU training setups"
+            ],
+            "answer": 1,
+            "explanation": "QLoRA (Dettmers et al., 2023) makes fine-tuning accessible on consumer hardware. It loads the frozen base model in 4-bit NF4 (NormalFloat4) quantization, reducing a 7B model from ~14GB (fp16) to ~3.5GB. LoRA adapters are still trained in bfloat16 for precision. Special techniques: NF4 quantization (information-theoretically optimal for normally-distributed weights), double quantization (quantize the quantization constants), and paged optimizers (handle GPU memory spikes). Result: fine-tune a 7B model on a single 24GB GPU. The minor tradeoff is ~10-20% slower training and potentially slight accuracy loss vs full fp16 LoRA."
+        },
+        {
+            "id": "d60Bq04",
+            "type": "multiple_choice",
+            "question": "Your company needs a customer service chatbot that always responds in a specific brand voice and knows your product catalog. Should you fine-tune or use RAG (Retrieval-Augmented Generation)?",
+            "options": [
+                "Fine-tune, because RAG cannot learn company-specific terminology or communication styles",
+                "RAG is always better because fine-tuning causes the model to forget general language abilities",
+                "Use RAG for frequently updated product knowledge (catalog, prices, policies) and fine-tune (or use prompt engineering) for brand voice; they are complementary, not mutually exclusive",
+                "Fine-tune exclusively, because RAG introduces retrieval latency that makes chatbots feel slow"
+            ],
+            "answer": 2,
+            "explanation": "Fine-tuning and RAG solve different problems and are best combined. Fine-tuning adjusts HOW the model behaves—tone, format, communication style, domain-specific reasoning patterns. It's ideal for: consistent brand voice, specialized response formats, technical jargon adoption. RAG adjusts WHAT the model knows—injecting current, specific, verifiable facts at query time. It's ideal for: product catalogs that change monthly, pricing that changes weekly, specific policy documents. Using RAG without fine-tuning gives accurate facts but possibly wrong tone; fine-tuning without RAG gives the right tone but outdated/hallucinated product details. The combination gives both."
+        },
+        {
+            "id": "d60Bq05",
+            "type": "multiple_choice",
+            "question": "What is catastrophic forgetting in fine-tuning, and how does PEFT help mitigate it?",
+            "options": [
+                "Catastrophic forgetting is when the model's accuracy on the fine-tuning task drops suddenly during training; PEFT prevents this by using a lower learning rate",
+                "Catastrophic forgetting is when fine-tuning overwrites pretrained general language knowledge with task-specific patterns, reducing performance on other tasks; PEFT mitigates this by keeping the original model frozen and only training small adapter layers",
+                "Catastrophic forgetting occurs when training data is shuffled randomly, causing the model to lose context; PEFT adds positional encoding to prevent this",
+                "Catastrophic forgetting is a GPU memory overflow that destroys checkpoints; PEFT prevents this by reducing checkpoint size"
+            ],
+            "answer": 1,
+            "explanation": "When you full-fine-tune an LLM on a narrow dataset (e.g., medical Q&A), gradient updates optimize for that distribution and can overwrite the general-purpose weights that encode broad world knowledge, grammar, and reasoning. The model becomes great at medical Q&A but degrades on general tasks—catastrophic forgetting. PEFT methods (LoRA, prefix tuning, adapter layers) keep the original pretrained weights completely frozen and only train small new modules. The base model's knowledge is preserved; only the adapter learns the new task. This is analogous to adding a specialized module to a general brain rather than retraining the entire brain."
+        }
+    ]
+}

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_60C_RAG_and_Vector_Databases/quiz.json
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_60C_RAG_and_Vector_Databases/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": "60C",
+    "questions": [
+        {
+            "id": "d60Cq01",
+            "type": "multiple_choice",
+            "question": "What is a vector embedding, and why does it enable semantic search?",
+            "options": [
+                "A vector embedding is a compressed binary representation of a file, used to reduce storage requirements for large document collections",
+                "A vector embedding is a dense numerical vector that represents the meaning of text such that semantically similar texts have similar vectors, enabling search by meaning rather than exact keyword matching",
+                "A vector embedding is an index structure that maps keywords to document IDs for fast retrieval",
+                "A vector embedding is a one-hot encoding of words in a fixed vocabulary, used as input to neural networks"
+            ],
+            "answer": 1,
+            "explanation": "Embedding models (sentence-transformers, OpenAI text-embedding-ada-002) convert text into dense vectors of 768-3072 dimensions. The key property: semantically similar text maps to nearby vectors in the embedding space. 'What is the cancellation policy?' and 'How do I cancel my subscription?' produce similar vectors despite sharing few words. This enables semantic search: find documents whose meaning matches the query, not just those containing the same keywords. Traditional keyword search (BM25, Elasticsearch) fails for paraphrases and synonyms; semantic search succeeds because it operates on meaning representations rather than surface text."
+        },
+        {
+            "id": "d60Cq02",
+            "type": "multiple_choice",
+            "question": "What problem does RAG (Retrieval-Augmented Generation) solve that a standalone LLM cannot?",
+            "options": [
+                "RAG makes LLMs faster by pre-computing responses for common queries",
+                "RAG solves the knowledge cutoff and hallucination problems: LLMs have static training data and can fabricate facts; RAG retrieves current, specific, verifiable documents and injects them into the prompt so the LLM grounds its response in retrieved evidence",
+                "RAG enables LLMs to understand images and audio, extending beyond text-only capabilities",
+                "RAG reduces the number of tokens an LLM needs to process by pre-summarizing documents before querying"
+            ],
+            "answer": 1,
+            "explanation": "Standalone LLMs have two fundamental limitations for enterprise use: (1) Knowledge cutoff—the model only knows what was in its training data (e.g., GPT-4 knowledge ends at a certain date; it cannot answer questions about recent events or your internal documents); (2) Hallucination—when a model doesn't know something, it confidently fabricates plausible-sounding but incorrect answers. RAG addresses both: at query time, relevant documents are retrieved from a vector database and injected into the LLM's context window. The model sees: 'Using only the following documents: [retrieved docs], answer: [question].' This grounds responses in verifiable sources and enables real-time knowledge updates without retraining."
+        },
+        {
+            "id": "d60Cq03",
+            "type": "multiple_choice",
+            "question": "What is the role of a vector database (e.g., ChromaDB, Pinecone) in a RAG pipeline?",
+            "options": [
+                "Vector databases store the LLM model weights and serve them to the generation component during inference",
+                "Vector databases store document embeddings with associated metadata and provide fast approximate nearest neighbor (ANN) search to retrieve the most semantically similar documents to a query embedding",
+                "Vector databases compress embeddings using dimensionality reduction to reduce storage requirements during retrieval",
+                "Vector databases train the embedding model incrementally as new documents are added to the knowledge base"
+            ],
+            "answer": 1,
+            "explanation": "A vector database is purpose-built for high-dimensional similarity search. Workflow: (1) Indexing—split documents into chunks, embed each chunk with an embedding model, store (embedding, text, metadata) tuples; (2) Retrieval—embed the user query, find top-k most similar stored embeddings using ANN algorithms (HNSW, IVF-Flat). Traditional databases (SQL, Elasticsearch) use exact matching or keyword search—slow and imprecise for millions of high-dimensional vectors. Vector databases use approximate algorithms optimized for this exact problem, returning top-k results in milliseconds even at million-document scale. Popular options: ChromaDB (local/open-source), Pinecone (managed), Weaviate, Qdrant, pgvector (PostgreSQL extension)."
+        },
+        {
+            "id": "d60Cq04",
+            "type": "multiple_choice",
+            "question": "Why does chunk size selection matter in a RAG pipeline, and what is the general tradeoff?",
+            "options": [
+                "Chunk size only affects storage costs; it has no impact on retrieval quality or answer accuracy",
+                "Small chunks provide more precise retrieval but may lack context; large chunks provide more context but may dilute the specific relevant content within the chunk and exceed the LLM's context window",
+                "Larger chunks are always better because they give the LLM more information to work with when generating answers",
+                "Chunk size must exactly match the embedding model's maximum token limit to avoid truncation errors"
+            ],
+            "answer": 1,
+            "explanation": "Chunking strategy is one of the most impactful RAG design decisions. Small chunks (100-200 tokens): high retrieval precision (the retrieved chunk is very relevant), but the surrounding context needed to understand the chunk may be missing—e.g., a table cell without the column headers. Large chunks (1000+ tokens): contain more context but the relevant sentence is buried in irrelevant content, reducing retrieval precision and using more of the LLM's context window. Common strategies: fixed-size with overlap (simple, decent), sentence/paragraph splitting (respects natural boundaries), hierarchical chunking (store both sentence and document embeddings), or semantic chunking (split at topic boundaries). Test different sizes with end-to-end retrieval metrics on representative queries."
+        },
+        {
+            "id": "d60Cq05",
+            "type": "multiple_choice",
+            "question": "When should you choose RAG over fine-tuning for an LLM-based application?",
+            "options": [
+                "Always choose RAG; fine-tuning is deprecated and no longer recommended for production LLM applications",
+                "Choose RAG when the knowledge changes frequently, when you need verifiable citations, or when data is too large to fine-tune on; choose fine-tuning when you need to change the model's behavior, style, or reasoning patterns on a stable dataset",
+                "Choose RAG only for question-answering tasks; fine-tuning is required for all generation tasks",
+                "Choose fine-tuning when the documents are longer than 500 tokens; RAG only works with short snippets"
+            ],
+            "answer": 1,
+            "explanation": "RAG vs. fine-tuning solve different problems. Use RAG when: knowledge changes frequently (product catalog, news, regulations—you can update the vector DB without retraining); you need citations/sources for auditability (RAG can return the exact retrieved chunks used); knowledge base is very large (millions of docs that won't fit in a context window). Use fine-tuning when: you need to change the model's behavior, tone, or output format; you want domain-specific reasoning patterns not present in the base model; performance latency is critical (no retrieval step). Often the best production systems combine both: fine-tune for behavior/style, RAG for knowledge. Prompt engineering is always the first thing to try before either approach."
+        }
+    ]
+}

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_60_Graph_and_Geometric_Learning/quiz.json
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_60_Graph_and_Geometric_Learning/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 60,
+    "questions": [
+        {
+            "id": "d60q01",
+            "type": "multiple_choice",
+            "question": "Why can't standard neural networks (MLPs, CNNs) be directly applied to graph data?",
+            "options": [
+                "Standard neural networks cannot handle numerical features; graphs require symbolic inputs",
+                "Graphs have irregular, variable-size neighborhoods with no fixed ordering—there is no grid structure for convolutions to slide over, and nodes can have different numbers of neighbors",
+                "Standard neural networks are too slow to process graphs with more than 1000 nodes",
+                "Graphs require edge labels, which standard neural networks cannot represent in their input format"
+            ],
+            "answer": 1,
+            "explanation": "CNNs work on regular grids (pixels have exactly 8 neighbors in fixed positions). Graphs are irregular: a node might have 1 neighbor or 1000, and there's no canonical ordering of neighbors. You can't define a 3×3 convolution filter on a graph. MLPs require fixed-size inputs but graphs have variable structure. Graph Neural Networks (GNNs) solve this by aggregating neighbor information in a permutation-invariant way (sum, mean, or max pooling over neighbors), so the operation works regardless of how many neighbors a node has or in what order they're listed."
+        },
+        {
+            "id": "d60q02",
+            "type": "multiple_choice",
+            "question": "What is message passing in a Graph Neural Network (GNN)?",
+            "options": [
+                "Message passing is the process of transmitting gradients through the graph during backpropagation",
+                "Message passing is the mechanism where each node gathers information from its neighbors, aggregates these messages, and updates its own representation—repeated over multiple layers to incorporate increasingly distant neighborhood information",
+                "Message passing refers to inter-process communication when training large GNNs on distributed GPU clusters",
+                "Message passing encodes edge weights into node features before the main GNN computation begins"
+            ],
+            "answer": 1,
+            "explanation": "Message passing is the core operation of GNNs: (1) Message: each neighbor j sends a message to node i, typically a function of j's current representation (and optionally edge features); (2) Aggregate: node i aggregates all received messages using a permutation-invariant function (sum, mean, max); (3) Update: node i combines its own representation with the aggregated messages to produce a new representation. After k layers, each node's representation encodes information from its k-hop neighborhood. This is analogous to convolution on graphs—each layer expands the 'receptive field' by one hop."
+        },
+        {
+            "id": "d60q03",
+            "type": "multiple_choice",
+            "question": "A pharmaceutical company wants to predict whether a new molecular compound will be toxic. Why are GNNs a natural fit for this task?",
+            "options": [
+                "GNNs are faster than traditional ML methods for tabular chemical property datasets",
+                "Molecules are naturally represented as graphs (atoms as nodes, bonds as edges), and GNNs can learn from the topological structure of molecular graphs to predict properties that depend on connectivity patterns",
+                "GNNs can process SMILES strings directly without converting molecules to graph format",
+                "GNNs are preferred because molecular data always contains missing values that GNNs handle better than other models"
+            ],
+            "answer": 1,
+            "explanation": "A molecule IS a graph: atoms are nodes (with features like atomic number, charge, hybridization) and chemical bonds are edges (with features like bond type: single/double/aromatic). Toxicity depends on structural patterns—certain functional groups, ring structures, or connectivity motifs cause toxicity. GNNs learn to recognize these patterns by propagating information along bonds (message passing) and then pooling the resulting node representations into a graph-level embedding for classification. This is far more principled than encoding molecular descriptors as a flat feature vector, which loses topological information. GNNs are now standard in computational drug discovery."
+        },
+        {
+            "id": "d60q04",
+            "type": "multiple_choice",
+            "question": "What is node classification, and give a real-world example where it applies?",
+            "options": [
+                "Node classification labels entire graphs (e.g., classifying proteins as toxic or non-toxic)",
+                "Node classification predicts a label for each individual node in a graph based on its features and graph structure—e.g., classifying whether each account in a transaction network is fraudulent based on transaction patterns with neighbors",
+                "Node classification groups similar nodes into clusters without predefined categories",
+                "Node classification assigns importance scores to nodes to identify which ones to remove from the graph"
+            ],
+            "answer": 1,
+            "explanation": "Node classification predicts a category for each node, using both node features and structural context from the graph. Classic examples: (1) Fraud detection—in a transaction graph (accounts as nodes, transactions as edges), classify each account as legitimate or fraudulent; fraudsters often cluster and share transaction patterns; (2) Citation network—classify academic papers (nodes) into research topics, using citation links as edges; (3) Social network—identify bot accounts on Twitter using connection patterns; (4) Protein function prediction—classify proteins by their function based on protein interaction networks. GNNs outperform non-graph methods because fraud patterns and topic clusters emerge from connectivity, not just node-level features."
+        },
+        {
+            "id": "d60q05",
+            "type": "multiple_choice",
+            "question": "What is the over-smoothing problem in deep GNNs, and why does it occur?",
+            "options": [
+                "Over-smoothing occurs when edge weights become too uniform after many training epochs",
+                "Over-smoothing occurs when too many message-passing layers cause all node representations to converge to similar values, losing the distinctive local features that distinguish nodes",
+                "Over-smoothing occurs when the loss function is too smooth, causing gradient vanishing during backpropagation",
+                "Over-smoothing occurs when node features are continuous rather than discrete, causing the model to predict average values"
+            ],
+            "answer": 1,
+            "explanation": "Each GNN layer aggregates a node's representation with its neighbors. After k layers, a node's representation contains information from its k-hop neighborhood. As k increases, each node's neighborhood eventually contains most of the graph—the representations of distant nodes mix and become indistinguishable from each other. This is over-smoothing: the GNN cannot distinguish between nodes that share similar multi-hop neighborhoods. Solutions: limit depth (most effective GNNs use 2-3 layers); residual connections (add skip connections to preserve original features); jumping knowledge networks; or PairNorm regularization. This is why very deep GNNs (10+ layers) rarely outperform shallow ones."
+        }
+    ]
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `quiz.json` files for all 14 lessons in Phase 05 (Advanced ML & Deep Learning), completing quiz coverage for Days 49–60C
- Each quiz follows the existing format: 5 multiple-choice questions with 4 options, a 0-indexed answer, and a detailed explanation
- Topics covered: NLP, MLOps, Regularized Models, Ensemble Methods, Model Tuning & Feature Selection, Probabilistic Modeling, Advanced Unsupervised Learning, Time Series & Forecasting, Recommender Systems, Transformers & Attention, Generative Models, Graph & Geometric Learning, LLM Fine-Tuning & PEFT, and RAG & Vector Databases

## Test plan

- [ ] Verify all 14 `quiz.json` files parse as valid JSON
- [ ] Confirm each file has exactly 5 questions with `id`, `type`, `question`, `options` (4 items), `answer` (0–3), and `explanation` fields
- [ ] Check that special day values (`"60B"`, `"60C"`) match the frontmatter in their respective `README.md` files
- [ ] Load a Phase 5 lesson in the app and confirm the quiz renders correctly via the `MasteryCheck` component

https://claude.ai/code/session_01THEFy7mZcMCHRatsgmAQpo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01THEFy7mZcMCHRatsgmAQpo)_