### PR TITLE
docs(content): add KaTeX math formulas to Phase 4 & 5 ML lessons

### DIFF
--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_37B_Probability_and_Statistics_for_ML/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_37B_Probability_and_Statistics_for_ML/README.md
@@ -54,6 +54,21 @@ Every time a model outputs a **confidence score**, it's applying probability the
 
 ### Probability Fundamentals
 
+The core vocabulary in compact form:
+
+- $P(A) \in [0, 1]$ — probability of event $A$.
+- $P(A \mid B) = \dfrac{P(A \cap B)}{P(B)}$ — conditional probability.
+- $P(A \cup B) = P(A) + P(B) - P(A \cap B)$ — union (inclusion–exclusion).
+- **Law of total probability**: $P(E) = \sum_i P(E \mid H_i) \, P(H_i)$.
+- **Bayes' theorem**: $P(H \mid E) = \dfrac{P(E \mid H) \, P(H)}{P(E)}$.
+
+The spam example below uses these directly. With $P(\text{spam}) = 0.20$, $P(\text{"free"} \mid \text{spam}) = 0.40$, and $P(\text{"free"} \mid \text{ham}) = 0.02$:
+
+$$
+P(\text{spam} \mid \text{"free"}) = \frac{P(\text{"free"} \mid \text{spam}) \, P(\text{spam})}{P(\text{"free"})} \approx 0.82
+$$
+
+
 ```python
 import numpy as np
 from scipy import stats
@@ -83,6 +98,31 @@ print(f"P(spam | contains 'free'): {p_spam_given_word:.3f}")
 ### Probability Distributions
 
 Three distributions power 80% of ML models. Know them cold.
+
+**Normal (Gaussian)** with mean $\mu$ and standard deviation $\sigma$ has density:
+
+$$
+f(x \mid \mu, \sigma) = \frac{1}{\sigma\sqrt{2\pi}} \, \exp\!\left(-\frac{(x - \mu)^2}{2\sigma^2}\right)
+$$
+
+The **z-score** rescales any value to standard-normal units:
+
+$$
+z = \frac{x - \mu}{\sigma}
+$$
+
+**Binomial** counts $k$ successes in $n$ independent Bernoulli trials with success probability $p$:
+
+$$
+P(X = k) = \binom{n}{k} p^k (1-p)^{n-k}, \qquad \mathbb{E}[X] = np, \quad \mathrm{Var}(X) = np(1-p)
+$$
+
+**Poisson** counts rare events with rate $\lambda$ per interval:
+
+$$
+P(X = k) = \frac{\lambda^k e^{-\lambda}}{k!}, \qquad \mathbb{E}[X] = \mathrm{Var}(X) = \lambda
+$$
+
 
 ```python
 # --- 1. Normal (Gaussian) Distribution ---
@@ -133,7 +173,13 @@ print(f"  P(> 15 orders — need extra staff): {1 - poisson.cdf(15):.4f}")
 
 ### The Central Limit Theorem (CLT)
 
-The CLT is the mathematical reason sampling works — and why ML validation is valid.
+The CLT is the mathematical reason sampling works — and why ML validation is valid. For i.i.d. samples $X_1, \ldots, X_n$ with mean $\mu$ and finite variance $\sigma^2$, the sample mean $\bar{X}_n = \tfrac{1}{n}\sum_{i=1}^{n} X_i$ has approximate distribution:
+
+$$
+\bar{X}_n \;\xrightarrow{\,n \to \infty\,}\; \mathcal{N}\!\left(\mu, \, \frac{\sigma^2}{n}\right)
+$$
+
+In particular, the **standard error of the mean** shrinks as $\sigma / \sqrt{n}$.
 
 ```python
 import numpy as np
@@ -175,6 +221,15 @@ print(f"\nTheoretical SE (σ/√n): ${theoretical_se:.2f}")
 ```
 
 ### Hypothesis Testing for Business Decisions
+
+For a two-proportion test comparing conversion rates $\hat{p}_C$ (control) and $\hat{p}_T$ (treatment), the pooled estimate and z-statistic are:
+
+$$
+\hat{p} = \frac{x_C + x_T}{n_C + n_T}, \qquad
+z = \frac{\hat{p}_T - \hat{p}_C}{\sqrt{\hat{p}(1 - \hat{p}) \left(\tfrac{1}{n_C} + \tfrac{1}{n_T}\right)}}
+$$
+
+A two-tailed p-value is $p = 2 \cdot \big(1 - \Phi(|z|)\big)$, where $\Phi$ is the standard-normal CDF.
 
 ```python
 from scipy import stats
@@ -355,15 +410,15 @@ print(f"95% Parametric CI: [${ci_param[0]:.2f}, ${ci_param[1]:.2f}]")
 
 ## Mastery Check
 
-**Q1**: In Bayes' theorem — P(H|E) = P(E|H)×P(H) / P(E) — what does each term represent?
+**Q1**: In Bayes' theorem $P(H \mid E) = \dfrac{P(E \mid H) \, P(H)}{P(E)}$, what does each term represent?
 <details><summary>Answer</summary>
 
-- **P(H|E)** = Posterior: updated belief after seeing evidence
-- **P(E|H)** = Likelihood: probability of observing this evidence if H is true
-- **P(H)** = Prior: belief before seeing evidence
-- **P(E)** = Marginal likelihood: normalizing constant (probability of the evidence)
+- $P(H \mid E)$ = **Posterior**: updated belief after seeing evidence
+- $P(E \mid H)$ = **Likelihood**: probability of observing this evidence if $H$ is true
+- $P(H)$ = **Prior**: belief before seeing evidence
+- $P(E)$ = **Marginal likelihood**: normalizing constant, $P(E) = \sum_{H'} P(E \mid H') P(H')$
 
-In the spam example: H = spam, E = email contains "free"
+In the spam example: $H = \text{spam}$, $E = \text{email contains "free"}$.
 </details>
 
 **Q2**: Why does the Central Limit Theorem matter for cross-validation?

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_38_Linear_Algebra/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_38_Linear_Algebra/README.md
@@ -52,7 +52,19 @@ Every neural network, every recommendation system, every computer vision model�
 
 ### Vectors: The Language of Data
 
-A vector is an ordered list of numbers. In ML, each sample in your dataset is a vector.
+A vector is an ordered list of numbers. In ML, each sample in your dataset is a vector. Formally, a vector $\mathbf{v} \in \mathbb{R}^n$ is written:
+
+$$
+\mathbf{v} = \begin{bmatrix} v_1 \\ v_2 \\ \vdots \\ v_n \end{bmatrix}
+$$
+
+The **magnitude** (or $\ell_2$-norm) of a vector measures its length:
+
+$$
+\|\mathbf{v}\|_2 = \sqrt{\sum_{i=1}^{n} v_i^2} = \sqrt{v_1^2 + v_2^2 + \cdots + v_n^2}
+$$
+
+A **unit vector** $\hat{\mathbf{v}} = \mathbf{v} / \|\mathbf{v}\|$ has length $1$ and captures only the direction of $\mathbf{v}$.
 
 ```python
 import numpy as np
@@ -91,7 +103,23 @@ print(f"Length: {np.linalg.norm(unit_a):.2f}")  # 1.0
 
 ### Dot Product: Measuring Similarity
 
-The dot product is fundamental to ML. It measures how "aligned" two vectors are.
+The dot product is fundamental to ML. It measures how "aligned" two vectors are. Algebraically:
+
+$$
+\mathbf{a} \cdot \mathbf{b} = \sum_{i=1}^{n} a_i b_i = a_1 b_1 + a_2 b_2 + \cdots + a_n b_n
+$$
+
+Geometrically it relates to the angle $\theta$ between the vectors:
+
+$$
+\mathbf{a} \cdot \mathbf{b} = \|\mathbf{a}\| \, \|\mathbf{b}\| \cos\theta
+$$
+
+The closely-related **cosine similarity** removes magnitude effects, giving a pure direction-based score in $[-1, 1]$:
+
+$$
+\text{cos\_sim}(\mathbf{a}, \mathbf{b}) = \frac{\mathbf{a} \cdot \mathbf{b}}{\|\mathbf{a}\| \, \|\mathbf{b}\|}
+$$
 
 ```python
 # Dot product: sum of element-wise products
@@ -130,7 +158,24 @@ print(f"Similarity to B: {sim_b:.4f}")
 
 ### Matrices: Data and Transformations
 
-A matrix is a 2D array. In ML, your entire dataset is a matrix.
+A matrix is a 2D array. In ML, your entire dataset is a matrix. A matrix $A \in \mathbb{R}^{m \times n}$ has $m$ rows and $n$ columns:
+
+$$
+A = \begin{bmatrix}
+a_{11} & a_{12} & \cdots & a_{1n} \\
+a_{21} & a_{22} & \cdots & a_{2n} \\
+\vdots & \vdots & \ddots & \vdots \\
+a_{m1} & a_{m2} & \cdots & a_{mn}
+\end{bmatrix}
+$$
+
+**Matrix multiplication** $C = AB$ for $A \in \mathbb{R}^{m \times n}$ and $B \in \mathbb{R}^{n \times p}$ gives $C \in \mathbb{R}^{m \times p}$ where each entry is a dot product:
+
+$$
+C_{ij} = \sum_{k=1}^{n} A_{ik} B_{kj}
+$$
+
+The inner dimensions must match (both equal to $n$); the outer dimensions form the result shape.
 
 ```python
 # Create matrices
@@ -158,7 +203,17 @@ print(f"Result:\n{C}")
 
 ### Matrix Multiplication in ML
 
-Here's why matrix multiplication matters for ML:
+Here's why matrix multiplication matters for ML. **Linear regression** uses a matrix–vector product to compute predictions for every sample at once:
+
+$$
+\hat{\mathbf{y}} = X\mathbf{w} + b
+$$
+
+A **fully-connected neural network layer** is the same operation, wrapped in a non-linear activation function $\sigma(\cdot)$:
+
+$$
+\mathbf{h} = \sigma(XW + \mathbf{b})
+$$
 
 ```python
 # Linear regression: y = Xw + b
@@ -193,6 +248,17 @@ print(f"Neural layer output shape: {output.shape}")
 
 ### Special Matrices and Operations
 
+The **identity matrix** $I_n$ acts like the number $1$ for matrices: $IA = AI = A$.
+
+The **inverse** $A^{-1}$ (when it exists) satisfies $A A^{-1} = A^{-1} A = I$. The **determinant** $\det(A)$ measures how the matrix scales volume; if $\det(A) = 0$, the matrix is **singular** and has no inverse.
+
+**Eigenvectors** $\mathbf{v}$ and **eigenvalues** $\lambda$ are the directions a transformation only stretches, never rotates:
+
+$$
+A\mathbf{v} = \lambda \mathbf{v}
+$$
+
+
 ```python
 # Identity matrix: I @ A = A @ I = A
 I = np.eye(3)  # 3x3 identity
@@ -223,13 +289,13 @@ print(f"Eigenvectors:\n{eigenvectors}")
 
 ### Linear Algebra in ML Algorithms
 
-| Algorithm             | Linear Algebra Role                             |
-| --------------------- | ----------------------------------------------- |
-| **Linear Regression** | Solve normal equation: w = (X^T X)^(-1) X^T y   |
-| **PCA**               | Eigendecomposition of covariance matrix         |
-| **Neural Networks**   | Layers are matrix multiplications + activations |
-| **SVD**               | Matrix factorization for recommendations        |
-| **Word Embeddings**   | Words as vectors; similarity via dot products   |
+| Algorithm             | Linear Algebra Role                                                |
+| --------------------- | ------------------------------------------------------------------ |
+| **Linear Regression** | Normal equation: $\mathbf{w} = (X^\top X)^{-1} X^\top \mathbf{y}$  |
+| **PCA**               | Eigendecomposition of covariance matrix $\Sigma = \frac{1}{n-1} X^\top X$ |
+| **Neural Networks**   | Layers as $\sigma(XW + \mathbf{b})$                                 |
+| **SVD**               | Factorization $A = U\Sigma V^\top$ for recommendations              |
+| **Word Embeddings**   | Words as vectors; similarity via $\mathbf{a} \cdot \mathbf{b}$      |
 
 ### When to Use Sparse Matrices
 
@@ -427,8 +493,8 @@ If the dot product of two vectors is 0, what does this tell you?
 
 **Answer:** The vectors are **orthogonal** (perpendicular).
 
-Geometrically: a · b = |a| |b| cos(θ)
-When a · b = 0 and neither vector is zero, cos(θ) = 0, meaning θ = 90°.
+Geometrically: $\mathbf{a} \cdot \mathbf{b} = \|\mathbf{a}\| \, \|\mathbf{b}\| \cos\theta$.
+When $\mathbf{a} \cdot \mathbf{b} = 0$ and neither vector is zero, $\cos\theta = 0$, so $\theta = 90°$.
 
 **In ML context:**
 
@@ -466,21 +532,21 @@ Given A with shape (100, 50) and B with shape (50, 10), what is the shape of A @
 
 ### Question 3: Why Transpose?
 
-In the normal equation w = (X^T X)^(-1) X^T y, why do we compute X^T X?
+In the normal equation $\mathbf{w} = (X^\top X)^{-1} X^\top \mathbf{y}$, why do we compute $X^\top X$?
 
 <details>
 <summary>Click for Answer</summary>
 
-**Answer:** X^T X creates a square matrix that can be inverted.
+**Answer:** $X^\top X$ creates a square matrix that can be inverted.
 
-- X has shape (n_samples × n_features)
-- X^T has shape (n_features × n_samples)
-- X^T @ X has shape (n_features × n_features) — square!
+- $X$ has shape $(n_\text{samples} \times n_\text{features})$
+- $X^\top$ has shape $(n_\text{features} \times n_\text{samples})$
+- $X^\top X$ has shape $(n_\text{features} \times n_\text{features})$ — square!
 
 **Why it works mathematically:**
-X^T X represents the covariance structure of features. The inverse "normalizes" for correlations between features, allowing us to find optimal weights.
+$X^\top X$ represents the covariance structure of features. The inverse "normalizes" for correlations between features, allowing us to find optimal weights.
 
-**Practical note:** This is called the "normal equation" because it solves ∂Loss/∂w = 0 directly, but it's slow for large n_features. Gradient descent is preferred for large problems.
+**Practical note:** This is called the "normal equation" because it solves $\partial \mathcal{L} / \partial \mathbf{w} = 0$ directly, but it's slow for large $n_\text{features}$. Gradient descent is preferred for large problems.
 
 </details>
 
@@ -561,10 +627,10 @@ D, I = index.search(query_vector.reshape(1, -1), 10)
 Today you learned:
 
 - ✅ Vectors represent data points; matrices represent datasets
-- ✅ Dot product measures vector similarity
+- ✅ Dot product $\mathbf{a} \cdot \mathbf{b}$ measures vector similarity
 - ✅ Matrix multiplication transforms and combines data
-- ✅ Linear regression uses the normal equation: w = (X^T X)^(-1) X^T y
-- ✅ PCA uses eigendecomposition to find principal directions
+- ✅ Linear regression uses the normal equation: $\mathbf{w} = (X^\top X)^{-1} X^\top \mathbf{y}$
+- ✅ PCA uses eigendecomposition $A\mathbf{v} = \lambda \mathbf{v}$ to find principal directions
 - ✅ Every ML model is built on these operations
 
 **Tomorrow**: Calculus Foundations—how gradient descent finds optimal parameters.

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_39_Calculus/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_39_Calculus/README.md
@@ -57,7 +57,13 @@ You don't need to be a calculus expert. You need to understand the *intuition*�
 
 ### Derivatives: How Things Change
 
-A derivative measures how a function's output changes when its input changes. Think of it as the "slope" at any point.
+A derivative measures how a function's output changes when its input changes. Think of it as the "slope" at any point. Formally, the derivative of $f$ at $x$ is the limit of the average rate of change as the step size shrinks to zero:
+
+$$
+f'(x) = \frac{df}{dx} = \lim_{h \to 0} \frac{f(x + h) - f(x)}{h}
+$$
+
+For $f(x) = x^2$, applying the power rule gives $f'(x) = 2x$.
 
 ```python
 import numpy as np
@@ -118,7 +124,13 @@ plt.show()
 
 ### The Key Insight: Finding Minimums
 
-**At a minimum, the derivative equals zero** (the function is flat—no slope).
+**At a minimum, the derivative equals zero** (the function is flat—no slope). Setting $f'(x) = 0$ gives a *first-order necessary condition* for an optimum:
+
+$$
+\frac{d}{dw}\,\mathcal{L}(w) = 0 \quad \Longrightarrow \quad w \text{ is a stationary point}
+$$
+
+For the loss $\mathcal{L}(w) = (w - 3)^2$, $\mathcal{L}'(w) = 2(w-3) = 0$, giving the unique minimum $w^\star = 3$.
 
 ```python
 # ML Loss function example: L(w) = (w - 3)²
@@ -145,7 +157,13 @@ print(f"Loss at w=5: {loss(5)}")  # 4
 
 ### Gradient Descent: Walking Downhill
 
-We can't always solve for the minimum analytically. **Gradient descent** finds it iteratively.
+We can't always solve for the minimum analytically. **Gradient descent** finds it iteratively by repeatedly stepping in the direction of steepest *descent* — that is, the negative gradient — scaled by a learning rate $\eta$:
+
+$$
+w_{t+1} = w_t - \eta \, \nabla_w \mathcal{L}(w_t)
+$$
+
+For our quadratic loss with $\mathcal{L}'(w) = 2(w - 3)$ and $\eta = 0.1$ starting from $w_0 = 0$, each step shrinks the gap to $w^\star = 3$ by a factor of $1 - 2\eta = 0.8$.
 
 ```python
 def gradient_descent(start, learning_rate, n_steps):
@@ -200,7 +218,18 @@ plt.show()
 
 ### Multivariate Gradients: Multiple Parameters
 
-Real ML models have many parameters. The **gradient** is a vector of partial derivatives.
+Real ML models have many parameters. The **gradient** is a vector of partial derivatives that points in the direction of steepest ascent:
+
+$$
+\nabla_{\mathbf{w}} \mathcal{L} = \begin{bmatrix}
+\dfrac{\partial \mathcal{L}}{\partial w_1} \\[4pt]
+\dfrac{\partial \mathcal{L}}{\partial w_2} \\[4pt]
+\vdots \\[4pt]
+\dfrac{\partial \mathcal{L}}{\partial w_n}
+\end{bmatrix}
+$$
+
+For $\mathcal{L}(w_1, w_2) = (w_1 - 2)^2 + (w_2 + 1)^2$, the partial derivatives are $\partial \mathcal{L} / \partial w_1 = 2(w_1 - 2)$ and $\partial \mathcal{L} / \partial w_2 = 2(w_2 + 1)$.
 
 ```python
 # Loss function with two parameters: L(w1, w2) = (w1-2)² + (w2+1)²
@@ -298,7 +327,13 @@ experiment_learning_rates([0.01, 0.1, 0.9])
 
 ### The Chain Rule: Foundation of Backpropagation
 
-When functions are composed (like neural network layers), we use the chain rule.
+When functions are composed (like neural network layers), we use the chain rule. For $y = g(f(x))$:
+
+$$
+\frac{dy}{dx} = \frac{dy}{du} \cdot \frac{du}{dx}, \quad \text{where } u = f(x)
+$$
+
+For $y = (3x + 2)^2$ with $u = 3x + 2$: $\dfrac{dy}{du} = 2u$ and $\dfrac{du}{dx} = 3$, giving $\dfrac{dy}{dx} = 6(3x + 2)$.
 
 ```python
 # If y = g(f(x)), then dy/dx = dg/df * df/dx
@@ -429,9 +464,9 @@ for epoch in range(n_epochs):
     loss = np.mean((y_pred - y) ** 2)
     loss_history.append(loss)
 
-    # Compute gradients
-    # ∂L/∂w = (2/n) * Σ(y_pred - y) * X
-    # ∂L/∂b = (2/n) * Σ(y_pred - y)
+    # Compute gradients (MSE loss):
+    #   dL/dw = (2/n) * sum((y_pred - y) * X)
+    #   dL/db = (2/n) * sum(y_pred - y)
     dw = (2 / n) * np.sum((y_pred - y) * X)
     db = (2 / n) * np.sum(y_pred - y)
 
@@ -653,17 +688,21 @@ Why is the chain rule essential for training neural networks?
 
 **Concretely:**
 
-```
-input → Layer1 → Layer2 → Layer3 → output → Loss
-```
+$$
+\mathbf{x} \;\to\; \text{Layer}_1 \;\to\; \text{Layer}_2 \;\to\; \text{Layer}_3 \;\to\; \hat{\mathbf{y}} \;\to\; \mathcal{L}
+$$
 
-To update weights in Layer1, we need ∂Loss/∂W1.
+To update weights in Layer 1, we need $\partial \mathcal{L} / \partial W_1$.
 
-Using chain rule:
+Using the chain rule:
 
-```
-∂Loss/∂W1 = ∂Loss/∂output × ∂output/∂Layer3 × ∂Layer3/∂Layer2 × ∂Layer2/∂W1
-```
+$$
+\frac{\partial \mathcal{L}}{\partial W_1}
+= \frac{\partial \mathcal{L}}{\partial \hat{\mathbf{y}}}
+\cdot \frac{\partial \hat{\mathbf{y}}}{\partial \text{Layer}_3}
+\cdot \frac{\partial \text{Layer}_3}{\partial \text{Layer}_2}
+\cdot \frac{\partial \text{Layer}_2}{\partial W_1}
+$$
 
 This is called **backpropagation**: propagating gradients backward through the network.
 
@@ -742,11 +781,11 @@ print(f"Max gradient: {np.max(np.abs(gradient))}")
 
 Today you learned:
 
-- ✅ Derivatives measure how a function changes (slope/rate of change)
-- ✅ Gradients extend derivatives to multiple variables (vector of partial derivatives)
-- ✅ Gradient descent iteratively finds minimums by walking downhill
-- ✅ Learning rate controls step size—too small is slow, too large diverges
-- ✅ The chain rule enables backpropagation through neural network layers
+- ✅ Derivatives $f'(x)$ measure how a function changes (slope/rate of change)
+- ✅ Gradients $\nabla_{\mathbf{w}} \mathcal{L}$ extend derivatives to multiple variables (vector of partial derivatives)
+- ✅ Gradient descent $w_{t+1} = w_t - \eta \nabla_w \mathcal{L}$ iteratively finds minimums by walking downhill
+- ✅ Learning rate $\eta$ controls step size—too small is slow, too large diverges
+- ✅ The chain rule $\dfrac{dy}{dx} = \dfrac{dy}{du} \dfrac{du}{dx}$ enables backpropagation through neural network layers
 - ✅ Common optimizers (Adam, RMSprop) improve on basic gradient descent
 
 **Tomorrow**: Introduction to Machine Learning—putting these mathematical foundations into practice.

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_41_Supervised_Learning_Regression/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_41_Supervised_Learning_Regression/README.md
@@ -52,7 +52,24 @@ That's regression: predicting a **continuous numerical value** based on input fe
 
 ### Linear Regression: The Foundation
 
-Linear regression finds the best straight line (or hyperplane) through your data.
+Linear regression finds the best straight line (or hyperplane) through your data. For a sample with feature vector $\mathbf{x}_i \in \mathbb{R}^p$, the prediction is:
+
+$$
+\hat{y}_i = \mathbf{w}^\top \mathbf{x}_i + b = w_1 x_{i1} + w_2 x_{i2} + \cdots + w_p x_{ip} + b
+$$
+
+The weights $\mathbf{w}$ and bias $b$ are chosen to minimize the **mean-squared-error** loss:
+
+$$
+\mathcal{L}_{\text{MSE}}(\mathbf{w}, b) = \frac{1}{n} \sum_{i=1}^{n} (y_i - \hat{y}_i)^2
+$$
+
+When written in matrix form, the closed-form solution (the *normal equation*) is:
+
+$$
+\mathbf{w}^\star = (X^\top X)^{-1} X^\top \mathbf{y}
+$$
+
 
 ```python
 import numpy as np
@@ -124,7 +141,13 @@ plt.show()
 
 ### Feature Scaling: Why It Matters
 
-Features on different scales can hurt some algorithms.
+Features on different scales can hurt some algorithms. **Standardization** maps each feature to mean zero and unit variance:
+
+$$
+x'_{ij} = \frac{x_{ij} - \mu_j}{\sigma_j}
+$$
+
+where $\mu_j$ and $\sigma_j$ are the column-wise mean and standard deviation computed on the **training set only**.
 
 ```python
 from sklearn.preprocessing import StandardScaler
@@ -158,7 +181,12 @@ for name, coef in zip(X.columns, model_scaled.coef_):
 
 ### Polynomial Regression: Capturing Non-linearity
 
-When relationships aren't straight lines:
+When relationships aren't straight lines, expand the feature into polynomial basis functions and fit a linear model in the expanded space. A degree-$d$ polynomial expansion of a single feature $x$ produces:
+
+$$
+\hat{y} = w_0 + w_1 x + w_2 x^2 + \cdots + w_d x^d
+$$
+
 
 ```python
 from sklearn.preprocessing import PolynomialFeatures
@@ -207,7 +235,21 @@ plt.show()
 
 ### Regularization: Ridge and Lasso
 
-Regularization prevents overfitting by penalizing large coefficients.
+Regularization prevents overfitting by penalizing large coefficients. Both methods minimize the MSE plus a coefficient norm:
+
+**Ridge (L2)**:
+
+$$
+\mathcal{L}_{\text{Ridge}}(\mathbf{w}) = \frac{1}{n} \sum_{i=1}^{n} (y_i - \hat{y}_i)^2 + \alpha \sum_{j=1}^{p} w_j^2 = \mathrm{MSE} + \alpha \, \|\mathbf{w}\|_2^2
+$$
+
+**Lasso (L1)**:
+
+$$
+\mathcal{L}_{\text{Lasso}}(\mathbf{w}) = \frac{1}{n} \sum_{i=1}^{n} (y_i - \hat{y}_i)^2 + \alpha \sum_{j=1}^{p} |w_j| = \mathrm{MSE} + \alpha \, \|\mathbf{w}\|_1
+$$
+
+The L1 penalty has corners at $w_j = 0$, which is why Lasso drives coefficients **exactly** to zero (automatic feature selection); the L2 penalty only shrinks them smoothly.
 
 ```python
 from sklearn.linear_model import Ridge, Lasso
@@ -301,13 +343,13 @@ print(f"Best Lasso alpha: {best_lasso_alpha:.4f}")
 
 ### Regression Metrics Explained
 
-| Metric   | Formula              | Interpretation           | Use When              |
-| -------- | -------------------- | ------------------------ | --------------------- |
-| **MAE**  | Σ\|y - ŷ\|/n         | Average absolute error   | Robust to outliers    |
-| **MSE**  | Σ(y - ŷ)²/n          | Average squared error    | Penalize large errors |
-| **RMSE** | √MSE                 | Same units as target     | Standard choice       |
-| **R²**   | 1 - SS_res/SS_tot    | Variance explained (0-1) | Compare models        |
-| **MAPE** | Σ\|y - ŷ\|/y/n × 100 | Percentage error         | Business reporting    |
+| Metric   | Formula                                                                      | Interpretation           | Use When              |
+| -------- | ---------------------------------------------------------------------------- | ------------------------ | --------------------- |
+| **MAE**  | $\dfrac{1}{n}\sum_i \lvert y_i - \hat{y}_i\rvert$                            | Average absolute error   | Robust to outliers    |
+| **MSE**  | $\dfrac{1}{n}\sum_i (y_i - \hat{y}_i)^2$                                     | Average squared error    | Penalize large errors |
+| **RMSE** | $\sqrt{\mathrm{MSE}}$                                                        | Same units as target     | Standard choice       |
+| **R²**   | $1 - \dfrac{\sum_i (y_i - \hat{y}_i)^2}{\sum_i (y_i - \bar{y})^2}$           | Variance explained (0–1) | Compare models        |
+| **MAPE** | $\dfrac{100}{n}\sum_i \left\lvert\dfrac{y_i - \hat{y}_i}{y_i}\right\rvert$   | Percentage error         | Business reporting    |
 
 ### When to Use Each Regression Type
 
@@ -773,12 +815,12 @@ Monitor the train-test gap as you tune!
 
 Today you learned:
 
-- ✅ Linear regression fits a line (or hyperplane) to predict continuous values
-- ✅ Feature scaling ensures fair treatment across features
-- ✅ Polynomial features capture non-linear relationships
-- ✅ Ridge (L2) shrinks coefficients to reduce overfitting
-- ✅ Lasso (L1) drives some coefficients to zero (feature selection)
-- ✅ RMSE and R² are standard regression metrics
-- ✅ Cross-validation helps find optimal regularization strength
+- ✅ Linear regression $\hat{y} = \mathbf{w}^\top \mathbf{x} + b$ fits a line/hyperplane to predict continuous values
+- ✅ Feature scaling $x' = (x - \mu) / \sigma$ ensures fair treatment across features
+- ✅ Polynomial features capture non-linear relationships in a linear model
+- ✅ Ridge (L2): adds $\alpha \|\mathbf{w}\|_2^2$ to shrink coefficients smoothly
+- ✅ Lasso (L1): adds $\alpha \|\mathbf{w}\|_1$ to drive some coefficients to zero (feature selection)
+- ✅ RMSE $= \sqrt{\tfrac{1}{n}\sum (y_i - \hat{y}_i)^2}$ and R² are standard regression metrics
+- ✅ Cross-validation helps find optimal regularization strength $\alpha$
 
 **Tomorrow**: Classification—predicting categories instead of numbers.

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_42_Supervised_Learning_Classification_Part_1/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_42_Supervised_Learning_Classification_Part_1/README.md
@@ -52,7 +52,31 @@ That's classification: predicting **discrete categories** from input features.
 
 ### Logistic Regression: The Fundamental Classifier
 
-Despite its name, logistic regression is for classification, not regression. It predicts probabilities.
+Despite its name, logistic regression is for classification, not regression. It predicts probabilities by passing a linear score through the **sigmoid (logistic) function**:
+
+$$
+\sigma(z) = \frac{1}{1 + e^{-z}} \in (0, 1)
+$$
+
+The model is:
+
+$$
+P(y = 1 \mid \mathbf{x}) = \sigma(\mathbf{w}^\top \mathbf{x} + b) = \frac{1}{1 + \exp\!\big(-(\mathbf{w}^\top \mathbf{x} + b)\big)}
+$$
+
+Equivalently, the **log-odds (logit)** of $y = 1$ is linear in the features:
+
+$$
+\log\!\frac{P(y=1 \mid \mathbf{x})}{P(y=0 \mid \mathbf{x})} = \mathbf{w}^\top \mathbf{x} + b
+$$
+
+Parameters are fit by minimizing the **binary cross-entropy** (a.k.a. log-loss):
+
+$$
+\mathcal{L}_{\text{BCE}}(\mathbf{w}, b) = -\frac{1}{n} \sum_{i=1}^{n} \Big[ y_i \log \hat{p}_i + (1 - y_i) \log(1 - \hat{p}_i) \Big]
+$$
+
+where $\hat{p}_i = \sigma(\mathbf{w}^\top \mathbf{x}_i + b)$.
 
 ```python
 import numpy as np
@@ -161,7 +185,25 @@ print(f"True Positives (caught churns): {TP}")
 
 ### Precision, Recall, and F1 Score
 
-Different metrics matter for different problems.
+Different metrics matter for different problems. Each is a simple ratio of confusion-matrix counts:
+
+$$
+\text{Precision} = \frac{TP}{TP + FP}, \qquad
+\text{Recall} = \frac{TP}{TP + FN}
+$$
+
+The **F1 score** is their harmonic mean — it punishes models that ignore one of the two:
+
+$$
+F_1 = 2 \cdot \frac{\text{Precision} \cdot \text{Recall}}{\text{Precision} + \text{Recall}}
+$$
+
+A more general $F_\beta$ score lets you weight recall more heavily ($\beta > 1$) when missing positives is costly:
+
+$$
+F_\beta = (1 + \beta^2) \cdot \frac{\text{Precision} \cdot \text{Recall}}{\beta^2 \cdot \text{Precision} + \text{Recall}}
+$$
+
 
 ```python
 from sklearn.metrics import precision_score, recall_score, f1_score
@@ -201,7 +243,14 @@ Recall    = TP / (TP + FN)  →  "How many positives did we catch?"
 
 ### ROC Curve and AUC
 
-The ROC curve shows performance across all possible thresholds.
+The ROC curve shows performance across all possible thresholds. It plots the **true-positive rate** against the **false-positive rate**:
+
+$$
+\text{TPR} = \frac{TP}{TP + FN} = \text{Recall}, \qquad
+\text{FPR} = \frac{FP}{FP + TN}
+$$
+
+**AUC** (area under the ROC curve) has a clean probabilistic meaning: it equals the probability that a randomly drawn positive sample is ranked higher than a randomly drawn negative one.
 
 ```python
 from sklearn.metrics import roc_curve, roc_auc_score
@@ -781,11 +830,12 @@ y_pred = (y_prob >= 0.3).astype(int)
 Today you learned:
 
 - ✅ Classification predicts categories, not numbers
-- ✅ Logistic regression outputs probabilities via sigmoid
-- ✅ Confusion matrix shows TP, TN, FP, FN
-- ✅ Precision: how accurate are positive predictions?
-- ✅ Recall: how many positives did we catch?
-- ✅ F1 Score: harmonic mean of precision and recall
+- ✅ Logistic regression outputs probabilities via the sigmoid: $\sigma(z) = 1 / (1 + e^{-z})$
+- ✅ Trained by minimizing log-loss: $\mathcal{L} = -\tfrac{1}{n}\sum [y \log \hat{p} + (1 - y) \log(1 - \hat{p})]$
+- ✅ Confusion matrix shows $TP$, $TN$, $FP$, $FN$
+- ✅ Precision $= TP / (TP + FP)$: how accurate are positive predictions?
+- ✅ Recall $= TP / (TP + FN)$: how many positives did we catch?
+- ✅ $F_1 = 2 \cdot \text{Prec} \cdot \text{Rec} / (\text{Prec} + \text{Rec})$: harmonic mean of precision and recall
 - ✅ ROC-AUC: classifier performance across all thresholds
 - ✅ Threshold tuning matches business costs
 

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_44_Unsupervised_Learning/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_44_Unsupervised_Learning/README.md
@@ -52,7 +52,18 @@ outcomes:
 
 ### K-Means Clustering
 
-K-Means groups data points into K clusters by minimizing distance to cluster centers.
+K-Means groups data points into $K$ clusters by minimizing the within-cluster sum of squared distances to the cluster centroids $\boldsymbol{\mu}_1, \ldots, \boldsymbol{\mu}_K$:
+
+$$
+\mathcal{J}(\{C_k\}, \{\boldsymbol{\mu}_k\}) = \sum_{k=1}^{K} \sum_{\mathbf{x}_i \in C_k} \|\mathbf{x}_i - \boldsymbol{\mu}_k\|_2^2
+$$
+
+The algorithm alternates two steps until convergence:
+
+1. **Assignment step** — assign each point to its nearest centroid: $C_k = \{\mathbf{x}_i : k = \arg\min_{j} \|\mathbf{x}_i - \boldsymbol{\mu}_j\|_2\}$.
+2. **Update step** — recompute each centroid as the mean of its assigned points: $\boldsymbol{\mu}_k = \dfrac{1}{|C_k|}\sum_{\mathbf{x}_i \in C_k} \mathbf{x}_i$.
+
+The objective is non-convex, so multiple random restarts (`n_init`) help avoid bad local minima. The final value of $\mathcal{J}$ is reported by sklearn as `inertia_`.
 
 ```python
 import numpy as np
@@ -104,6 +115,14 @@ plt.show()
 ```
 
 ### Finding Optimal K: The Elbow Method
+
+The **silhouette score** for a point $i$ blends how tight its cluster is with how far away the next-closest cluster is:
+
+$$
+s(i) = \frac{b(i) - a(i)}{\max\{a(i), b(i)\}} \in [-1, 1]
+$$
+
+where $a(i)$ is the average distance from $i$ to other points in *its* cluster and $b(i)$ is the average distance to points in the *nearest other* cluster. Higher is better; values near $0$ indicate overlapping clusters, negatives indicate misassignment.
 
 ```python
 # Elbow method: find the "elbow" where adding clusters has diminishing returns
@@ -181,7 +200,25 @@ plt.show()
 
 ### PCA: Dimensionality Reduction
 
-Principal Component Analysis finds directions of maximum variance.
+Principal Component Analysis finds directions of maximum variance. Given a centered data matrix $X \in \mathbb{R}^{n \times p}$ (each column has zero mean), the **sample covariance** is:
+
+$$
+\Sigma = \frac{1}{n - 1} X^\top X
+$$
+
+The principal components are the eigenvectors $\mathbf{v}_1, \ldots, \mathbf{v}_p$ of $\Sigma$, sorted by their eigenvalues $\lambda_1 \geq \lambda_2 \geq \cdots \geq \lambda_p \geq 0$:
+
+$$
+\Sigma \mathbf{v}_k = \lambda_k \mathbf{v}_k
+$$
+
+Each $\lambda_k$ is the variance captured along $\mathbf{v}_k$, so the **fraction of total variance explained** by the first $K$ components is:
+
+$$
+\text{ExplainedVar}(K) = \frac{\sum_{k=1}^{K} \lambda_k}{\sum_{j=1}^{p} \lambda_j}
+$$
+
+Projecting $\mathbf{x}_i$ onto the top-$K$ components gives a compressed representation $\mathbf{z}_i = V_K^\top \mathbf{x}_i \in \mathbb{R}^K$.
 
 ```python
 from sklearn.decomposition import PCA
@@ -833,10 +870,10 @@ profiles_normalized = profiles / overall  # Ratio to average
 Today you learned:
 
 - ✅ Unsupervised learning finds patterns without labels
-- ✅ K-Means clusters data by minimizing distance to centers
-- ✅ Elbow and Silhouette methods find optimal K
-- ✅ PCA reduces dimensions by finding principal components
-- ✅ Scale features before distance-based algorithms
+- ✅ K-Means minimizes within-cluster variance: $\mathcal{J} = \sum_k \sum_{\mathbf{x}_i \in C_k} \|\mathbf{x}_i - \boldsymbol{\mu}_k\|_2^2$
+- ✅ Elbow (inertia) and silhouette $s(i) = (b - a)/\max(a, b)$ help find optimal $K$
+- ✅ PCA finds eigenvectors of $\Sigma = \tfrac{1}{n-1}X^\top X$; eigenvalues = variance captured
+- ✅ Scale features before any distance- or variance-based algorithm
 - ✅ Cluster profiles translate results into business insights
 - ✅ Combine PCA (reduce) + K-Means (cluster) for high-dimensional data
 

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_45_Feature_Engineering_and_Evaluation/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_45_Feature_Engineering_and_Evaluation/README.md
@@ -45,6 +45,40 @@ outcomes:
 
 ## The Technical Deep Dive
 
+### Common Feature Transformations
+
+A few standard transformations cover most numerical preprocessing. Each fixes a different distributional problem:
+
+**Standardization (z-score)** — centers and rescales to mean $0$, std $1$:
+
+$$
+x'_j = \frac{x_j - \mu_j}{\sigma_j}
+$$
+
+**Min–max normalization** — squashes a feature into $[0, 1]$:
+
+$$
+x'_j = \frac{x_j - \min(x_j)}{\max(x_j) - \min(x_j)}
+$$
+
+**Robust scaling** — uses median and IQR instead, so it ignores outliers:
+
+$$
+x'_j = \frac{x_j - \text{median}(x_j)}{Q_{0.75}(x_j) - Q_{0.25}(x_j)}
+$$
+
+**Log transform** — compresses heavy right tails for skewed monetary or count data:
+
+$$
+x' = \log(1 + x)
+$$
+
+**Pearson correlation** — quantifies linear association between two features (useful for diagnosing multicollinearity):
+
+$$
+\rho_{XY} = \frac{\mathrm{Cov}(X, Y)}{\sigma_X \sigma_Y} = \frac{\sum_i (x_i - \bar{x})(y_i - \bar{y})}{\sqrt{\sum_i (x_i - \bar{x})^2} \, \sqrt{\sum_i (y_i - \bar{y})^2}} \in [-1, 1]
+$$
+
 ### Feature Creation
 
 ```python
@@ -330,6 +364,9 @@ Why use sklearn Pipeline over manual preprocessing?
 ## Summary
 
 - ✅ Feature engineering transforms raw data into model-ready signals
+- ✅ Standardize with $x' = (x - \mu)/\sigma$; normalize with $x' = (x - \min)/(\max - \min)$
+- ✅ Use $\log(1 + x)$ for right-skewed monetary/count data
+- ✅ Diagnose multicollinearity via $\rho_{XY} = \mathrm{Cov}(X, Y) / (\sigma_X \sigma_Y)$
 - ✅ Choose encoding based on categorical type (ordinal vs nominal)
 - ✅ Stratified K-Fold preserves class balance
 - ✅ Data leakage inflates scores, fails in production

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_46_Intro_to_Neural_Networks/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_46_Intro_to_Neural_Networks/README.md
@@ -49,6 +49,19 @@ outcomes:
 
 ### The Neuron: The Basic Unit
 
+A neuron computes a weighted sum of its inputs, adds a bias, and pushes the result through a non-linear activation $\sigma(\cdot)$:
+
+$$
+z = \sum_{i=1}^{n} w_i x_i + b = \mathbf{w}^\top \mathbf{x} + b, \qquad a = \sigma(z)
+$$
+
+A whole **fully-connected layer** with input $\mathbf{x} \in \mathbb{R}^{d_{\text{in}}}$, weight matrix $W \in \mathbb{R}^{d_{\text{out}} \times d_{\text{in}}}$, and bias $\mathbf{b} \in \mathbb{R}^{d_{\text{out}}}$ is just this operation in vector form:
+
+$$
+\mathbf{a} = \sigma(W \mathbf{x} + \mathbf{b})
+$$
+
+
 ```python
 import numpy as np
 
@@ -80,6 +93,27 @@ print(f"Output: {output:.3f}")
 ```
 
 ### Activation Functions
+
+Activations introduce the non-linearity that lets stacked layers represent functions a single linear layer never could. The four workhorses:
+
+$$
+\text{ReLU}(z) = \max(0, z), \qquad
+\sigma(z) = \frac{1}{1 + e^{-z}}, \qquad
+\tanh(z) = \frac{e^{z} - e^{-z}}{e^{z} + e^{-z}}
+$$
+
+For multi-class outputs, the **softmax** turns a vector of $K$ scores into a probability distribution that sums to $1$:
+
+$$
+\text{softmax}(\mathbf{z})_k = \frac{e^{z_k}}{\sum_{j=1}^{K} e^{z_j}}
+$$
+
+The corresponding loss for a one-hot target $\mathbf{y}$ is the **categorical cross-entropy**:
+
+$$
+\mathcal{L}_{\text{CE}} = -\sum_{k=1}^{K} y_k \log \hat{p}_k
+$$
+
 
 ```python
 import matplotlib.pyplot as plt
@@ -194,6 +228,36 @@ plt.show()
 ```
 
 ### Understanding Backpropagation
+
+For a network of $L$ layers, the **forward pass** computes:
+
+$$
+\mathbf{z}^{(\ell)} = W^{(\ell)} \mathbf{a}^{(\ell-1)} + \mathbf{b}^{(\ell)}, \qquad \mathbf{a}^{(\ell)} = \sigma\!\big(\mathbf{z}^{(\ell)}\big)
+$$
+
+with $\mathbf{a}^{(0)} = \mathbf{x}$ and final prediction $\hat{\mathbf{y}} = \mathbf{a}^{(L)}$.
+
+The **backward pass** uses the chain rule to compute the loss gradient w.r.t. every parameter. Define the layer error:
+
+$$
+\boldsymbol{\delta}^{(\ell)} = \frac{\partial \mathcal{L}}{\partial \mathbf{z}^{(\ell)}}
+$$
+
+Then the recursion is:
+
+$$
+\boldsymbol{\delta}^{(L)} = \nabla_{\mathbf{a}} \mathcal{L} \,\odot\, \sigma'\!\big(\mathbf{z}^{(L)}\big), \qquad
+\boldsymbol{\delta}^{(\ell)} = \big(W^{(\ell+1)}\big)^{\!\top} \boldsymbol{\delta}^{(\ell+1)} \,\odot\, \sigma'\!\big(\mathbf{z}^{(\ell)}\big)
+$$
+
+and the parameter gradients are:
+
+$$
+\frac{\partial \mathcal{L}}{\partial W^{(\ell)}} = \boldsymbol{\delta}^{(\ell)} \big(\mathbf{a}^{(\ell-1)}\big)^{\!\top}, \qquad
+\frac{\partial \mathcal{L}}{\partial \mathbf{b}^{(\ell)}} = \boldsymbol{\delta}^{(\ell)}
+$$
+
+Finally the parameters are updated by SGD: $W^{(\ell)} \leftarrow W^{(\ell)} - \eta \, \partial \mathcal{L} / \partial W^{(\ell)}$.
 
 ```python
 """
@@ -438,8 +502,9 @@ Start with 32; increase if memory allows and training is too slow.
 ## Summary
 
 - ✅ Neural networks learn by adjusting weights via backpropagation
-- ✅ Neurons compute: output = activation(weights · inputs + bias)
-- ✅ ReLU for hidden layers, sigmoid/softmax for classification output
+- ✅ A neuron computes $a = \sigma(\mathbf{w}^\top \mathbf{x} + b)$; a layer is $\mathbf{a} = \sigma(W \mathbf{x} + \mathbf{b})$
+- ✅ ReLU $\max(0, z)$ for hidden layers; sigmoid/softmax for classification output
+- ✅ Backprop recursion: $\boldsymbol{\delta}^{(\ell)} = \big(W^{(\ell+1)}\big)^\top \boldsymbol{\delta}^{(\ell+1)} \odot \sigma'(\mathbf{z}^{(\ell)})$
 - ✅ Use dropout and early stopping to prevent overfitting
 - ✅ Match loss function to task (BCE for classification, MSE for regression)
 

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_47_Convolutional_Neural_Networks/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_47_Convolutional_Neural_Networks/README.md
@@ -48,6 +48,32 @@ outcomes:
 
 ### The Convolution Operation
 
+The 2D **discrete convolution** of an input image $I$ with a kernel $K$ of shape $k_h \times k_w$ slides $K$ over $I$ and computes a weighted sum at every position. For an output pixel at $(i, j)$:
+
+$$
+S(i, j) = (I * K)(i, j) = \sum_{m=0}^{k_h - 1} \sum_{n=0}^{k_w - 1} I(i + m,\, j + n) \, K(m, n)
+$$
+
+For a colour input with $C$ channels and $F$ filters, each filter has shape $k_h \times k_w \times C$ and the layer output has $F$ channels:
+
+$$
+S_f(i, j) = \sum_{c=1}^{C} \sum_{m=0}^{k_h - 1} \sum_{n=0}^{k_w - 1} I_c(i + m,\, j + n) \, K^{(f)}_c(m, n) + b_f
+$$
+
+Given input size $H \times W$, kernel size $k$, stride $s$, and padding $p$, the **output spatial size** is:
+
+$$
+H_{\text{out}} = \left\lfloor \frac{H + 2p - k}{s} \right\rfloor + 1, \qquad
+W_{\text{out}} = \left\lfloor \frac{W + 2p - k}{s} \right\rfloor + 1
+$$
+
+A **max-pooling** layer with $p \times p$ window and stride $s$ takes the maximum over each window:
+
+$$
+\text{MaxPool}(I)(i, j) = \max_{0 \le m, n < p} I\big(s i + m,\, s j + n\big)
+$$
+
+
 ```python
 import numpy as np
 import matplotlib.pyplot as plt
@@ -427,10 +453,11 @@ Creates variations (rotated, shifted) the model hasn't seen. Prevents memorizati
 
 ## Summary
 
-- ✅ CNNs use sliding filters to detect spatial patterns
+- ✅ Convolution: $S(i, j) = \sum_{m, n} I(i + m, j + n) K(m, n)$ slides filters over the input
+- ✅ Output size: $H_{\text{out}} = \lfloor (H + 2p - k)/s \rfloor + 1$
 - ✅ Early layers detect edges, deeper layers detect objects
-- ✅ Pooling reduces dimensions and adds invariance
-- ✅ Data augmentation prevents overfitting
+- ✅ Pooling reduces dimensions and adds spatial invariance
+- ✅ Data augmentation expands effective dataset and prevents overfitting
 - ✅ Transfer learning leverages pre-trained models
 
 **Tomorrow**: Recurrent Neural Networks for sequential data.

--- a/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_48_Recurrent_Neural_Networks/README.md
+++ b/content/lessons/Phase_04_Mathematical_Foundations_ML_Fundamentals/Day_48_Recurrent_Neural_Networks/README.md
@@ -49,6 +49,17 @@ outcomes:
 
 ### The Recurrent Connection
 
+A recurrent layer maintains a hidden state $\mathbf{h}_t$ that summarizes everything seen so far. At every time step it updates the state from the new input $\mathbf{x}_t$ and the previous state $\mathbf{h}_{t-1}$:
+
+$$
+\mathbf{h}_t = \tanh\!\big(W_x \mathbf{x}_t + W_h \mathbf{h}_{t-1} + \mathbf{b}\big), \qquad
+\hat{y}_t = W_y \mathbf{h}_t + \mathbf{b}_y
+$$
+
+The same weight matrices $W_x, W_h$ are reused at every step (parameter sharing across time).
+
+The **vanishing-gradient problem** of vanilla RNNs comes from backpropagating through time: $\partial \mathbf{h}_t / \partial \mathbf{h}_0 \approx \prod_{k=1}^{t} W_h \cdot \mathrm{diag}(\tanh'(\cdot))$. When eigenvalues of $W_h$ are below $1$ this product collapses to zero exponentially fast — the network forgets long-range dependencies.
+
 ```python
 import numpy as np
 
@@ -150,6 +161,36 @@ for name, model in models.items():
 ```
 
 ### Understanding LSTM
+
+The LSTM solves vanishing gradients by adding a **cell state** $\mathbf{c}_t$ that flows through time with only additive interactions, controlled by three sigmoid **gates**. Letting $[\mathbf{h}_{t-1}, \mathbf{x}_t]$ denote the concatenation of the previous hidden state and the current input:
+
+$$
+\mathbf{f}_t = \sigma\!\big(W_f [\mathbf{h}_{t-1}, \mathbf{x}_t] + \mathbf{b}_f\big) \quad \text{(forget gate)}
+$$
+
+$$
+\mathbf{i}_t = \sigma\!\big(W_i [\mathbf{h}_{t-1}, \mathbf{x}_t] + \mathbf{b}_i\big), \qquad
+\tilde{\mathbf{c}}_t = \tanh\!\big(W_c [\mathbf{h}_{t-1}, \mathbf{x}_t] + \mathbf{b}_c\big) \quad \text{(input gate + candidate)}
+$$
+
+$$
+\mathbf{c}_t = \mathbf{f}_t \odot \mathbf{c}_{t-1} + \mathbf{i}_t \odot \tilde{\mathbf{c}}_t \quad \text{(cell state update)}
+$$
+
+$$
+\mathbf{o}_t = \sigma\!\big(W_o [\mathbf{h}_{t-1}, \mathbf{x}_t] + \mathbf{b}_o\big), \qquad
+\mathbf{h}_t = \mathbf{o}_t \odot \tanh(\mathbf{c}_t) \quad \text{(output gate + hidden state)}
+$$
+
+The forget gate $\mathbf{f}_t$ near $1$ means "remember"; near $0$ means "forget". Because $\mathbf{c}_t$ is updated additively (rather than multiplicatively), gradients can flow across hundreds of time steps without vanishing.
+
+The simpler **GRU** merges the forget and input gates into a single update gate $\mathbf{z}_t$ and uses a reset gate $\mathbf{r}_t$:
+
+$$
+\mathbf{z}_t = \sigma(W_z [\mathbf{h}_{t-1}, \mathbf{x}_t]), \quad
+\mathbf{r}_t = \sigma(W_r [\mathbf{h}_{t-1}, \mathbf{x}_t]), \quad
+\mathbf{h}_t = (1 - \mathbf{z}_t) \odot \mathbf{h}_{t-1} + \mathbf{z}_t \odot \tanh\!\big(W_h [\mathbf{r}_t \odot \mathbf{h}_{t-1}, \mathbf{x}_t]\big)
+$$
 
 ```python
 """
@@ -458,9 +499,11 @@ When choose GRU over LSTM?
 
 ## Summary
 
-- ✅ RNNs process sequences by maintaining hidden state (memory)
-- ✅ LSTM solves vanishing gradients with cell state and gates
-- ✅ GRU offers similar benefits with fewer parameters
+- ✅ RNNs maintain a hidden state: $\mathbf{h}_t = \tanh(W_x \mathbf{x}_t + W_h \mathbf{h}_{t-1} + \mathbf{b})$
+- ✅ Vanilla RNNs suffer vanishing gradients because $\partial \mathbf{h}_t / \partial \mathbf{h}_0$ involves $\prod W_h$
+- ✅ LSTMs add a cell state and three gates ($\mathbf{f}, \mathbf{i}, \mathbf{o}$) so gradients flow additively
+- ✅ Cell update: $\mathbf{c}_t = \mathbf{f}_t \odot \mathbf{c}_{t-1} + \mathbf{i}_t \odot \tilde{\mathbf{c}}_t$
+- ✅ GRU merges into update + reset gates with fewer parameters
 - ✅ Stack RNN layers for complex patterns
 - ✅ Use Bidirectional when full context is available
 - ✅ Embedding layer converts text to dense vectors

--- a/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_58_Transformers_and_Attention/README.md
+++ b/content/lessons/Phase_05_Advanced_ML_Deep_Learning/Day_58_Transformers_and_Attention/README.md
@@ -99,15 +99,40 @@ hidden_state = RNN(sentence)  # Single 512D vector
 # "sat" knows it relates to "cat" and "mat"
 ```
 
-**Attention formula:**
+**Attention formula** — the famous "scaled dot-product attention" from *Attention Is All You Need*:
 
-```
-Attention(Q, K, V) = softmax(QK^T / √d_k) × V
+$$
+\text{Attention}(Q, K, V) = \text{softmax}\!\left(\frac{Q K^\top}{\sqrt{d_k}}\right) V
+$$
 
-Q = Query: "What am I looking for?"
-K = Key: "What do I contain?"
-V = Value: "What information do I have?"
-```
+with shapes $Q \in \mathbb{R}^{n \times d_k}$, $K \in \mathbb{R}^{m \times d_k}$, $V \in \mathbb{R}^{m \times d_v}$ for $n$ query positions and $m$ key/value positions.
+
+- **Q** (query): "What am I looking for?"
+- **K** (key): "What do I contain?"
+- **V** (value): "What information do I have?"
+
+The $\sqrt{d_k}$ scaling keeps the dot products from growing too large (and pushing the softmax into a saturated, low-gradient regime) when $d_k$ is high.
+
+**Multi-head attention** runs $h$ attention heads in parallel on $d_k = d_v = d_{\text{model}} / h$ dimensional projections and concatenates the results:
+
+$$
+\text{head}_i = \text{Attention}(Q W_i^Q,\, K W_i^K,\, V W_i^V), \qquad
+\text{MHA}(Q, K, V) = \text{Concat}(\text{head}_1, \ldots, \text{head}_h) \, W^O
+$$
+
+For autoregressive ("causal") models like GPT, a triangular mask $M_{ij} = -\infty$ for $j > i$ is added inside the softmax so position $i$ cannot attend to future positions:
+
+$$
+\text{CausalAttention}(Q, K, V) = \text{softmax}\!\left(\frac{Q K^\top}{\sqrt{d_k}} + M\right) V
+$$
+
+Because the input has no inherent order, transformers add **positional encodings** — for the original sinusoidal scheme, position $\text{pos}$ and dimension $i$ get:
+
+$$
+\text{PE}(\text{pos}, 2i) = \sin\!\left(\frac{\text{pos}}{10000^{2i/d_{\text{model}}}}\right), \qquad
+\text{PE}(\text{pos}, 2i+1) = \cos\!\left(\frac{\text{pos}}{10000^{2i/d_{\text{model}}}}\right)
+$$
+
 
 **Intuitive example:**
 


### PR DESCRIPTION
## Summary

Audited every lesson across the 12 phases for math content. Found that the project already wires up `remark-math` + `rehype-katex` in `MarkdownRenderer.tsx`, but **none of the 14 Phase-4 / Phase-5 / Phase-10 ML lessons used it** — concepts like gradient descent, the normal equation, attention, or the LSTM gates were described in prose or ASCII art only. This PR fills that gap by adding rendered math notation to the 11 most foundational lessons.

Each lesson now formalizes its core ideas with proper $\LaTeX$ alongside the existing intuition and code — no content was removed, only formulas added in the right places.

### Phase 4 — Mathematical Foundations & ML Fundamentals

| Day | Math added |
| --- | --- |
| **37B** Probability & Stats | Bayes' theorem, Normal/Binomial/Poisson PMFs, $z$-score, CLT $\bar X_n \to \mathcal{N}(\mu, \sigma^2/n)$, two-proportion $z$-test |
| **38** Linear Algebra | Vectors as $\mathbb{R}^n$ column vectors, $\ell_2$-norm, dot product (algebraic + geometric), cosine similarity, matrix multiplication entries, identity / inverse / determinant, $A\mathbf{v} = \lambda \mathbf{v}$, normal equation $(X^\top X)^{-1} X^\top \mathbf{y}$ |
| **39** Calculus | Derivative as a limit, GD update $w_{t+1} = w_t - \eta \nabla \mathcal{L}$, gradient vector, chain rule, full backprop chain |
| **41** Regression | $\hat{y} = \mathbf{w}^\top \mathbf{x} + b$, MSE/RMSE/MAE/R²/MAPE formulas, polynomial expansion, Ridge $\alpha\|\mathbf{w}\|_2^2$, Lasso $\alpha\|\mathbf{w}\|_1$ |
| **42** Classification I | Sigmoid, log-odds, binary cross-entropy, Precision/Recall/F1/F-beta, TPR/FPR for ROC, AUC interpretation |
| **44** Unsupervised | K-Means objective $\sum_k \sum_{x\in C_k} \|x-\mu_k\|^2$ with E/M steps, silhouette $s(i) = (b-a)/\max(a,b)$, PCA covariance + eigendecomposition, explained-variance fraction |
| **45** Feature Engineering | Standardization, min-max, robust scaling, $\log(1+x)$, Pearson correlation $\rho_{XY}$ |
| **46** Neural Networks | Neuron $a = \sigma(\mathbf{w}^\top \mathbf{x} + b)$, full layer in matrix form, ReLU/sigmoid/tanh/softmax, categorical CE, full backprop recursion with $\boldsymbol{\delta}^{(\ell)}$ |
| **47** CNNs | 2D convolution sum, multi-channel filters, output-size formula $\lfloor (H + 2p - k)/s \rfloor + 1$, max-pooling |
| **48** RNNs | $\mathbf{h}_t = \tanh(W_x \mathbf{x}_t + W_h \mathbf{h}_{t-1} + \mathbf{b})$, vanishing-gradient explanation via $\prod W_h$, full LSTM gate equations ($\mathbf{f}, \mathbf{i}, \mathbf{o}$, cell update), GRU update + reset gates |

### Phase 5 — Advanced ML & Deep Learning

| Day | Math added |
| --- | --- |
| **58** Transformers & Attention | Scaled dot-product attention $\text{softmax}(QK^\top / \sqrt{d_k}) V$, multi-head decomposition, causal mask, sinusoidal positional encoding |

## Test plan

- [x] `npm run validate-content` → **174/174 lesson files pass**
- [x] `npm run test` → **651/651 unit tests pass**
- [x] `grep -c '^\$\$'` on every edited file → all even (display-math blocks balanced)
- [ ] Manual: spin up `npm run dev` and visually confirm a sample of pages render KaTeX correctly

https://claude.ai/code/session_016pYE3b5ywXweqEaZszGEs3

---
_Generated by [Claude Code](https://claude.ai/code/session_016pYE3b5ywXweqEaZszGEs3)_