### PR TITLE
🧘 Buddha: [SEO/GEO improvement]

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -211,3 +211,13 @@ This scroll records the harmonization of the `Coding-For-MBA` codebase for human
 
 **Changes:**
 -   [x] **[SEO] Semantic HTML Fixes**: Converted `tree-section-label` from `<div>` to `<h2>` in `src/components/Sidebar.tsx` to improve semantic document outline.
+
+### [Date: Current] - XSS Prevention and Accessibility Updates
+
+**Priority Areas:**
+1.  **Security**: Preventing XSS vulnerabilities from literal `<` evaluation in script tags.
+2.  **Accessibility**: Ensuring proper ARIA roles for overlay elements.
+
+**Changes:**
+-   [x] **[GEO][SEO] Structured Data XSS Fix**: Updated the JSON-LD stringify escape sequences from `.replace(/</g, '\\u003c')` to `.replace(/</g, '\\\\u003c')` in `SEOHead.tsx` and `MasteryCheck.tsx` so that React renders the literal `\u003c` in the DOM `dangerouslySetInnerHTML`, preventing XSS execution without breaking JSON parsing.
+-   [x] **[A11Y] Overlay Accessibility Fix**: Replaced `role="dialog"` and `aria-modal="true"` with `role="presentation"` on the `.image-zoom-overlay` element inside `MarkdownRenderer.tsx`. This accurately represents the element as a non-interactive layout backdrop to screen readers, preventing confusion when clicking the background overlay.

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -230,8 +230,7 @@ const ImageWithZoom = (props: JSX.IntrinsicElements['img'] & ExtraProps) => {
           <div
             className="image-zoom-overlay"
             onClick={() => setZoomed(false)}
-            role="dialog"
-            aria-modal="true"
+            role="presentation"
             aria-label={`Zoomed: ${rest.alt || 'image'}`}
           >
             <button

--- a/src/components/MasteryCheck.tsx
+++ b/src/components/MasteryCheck.tsx
@@ -53,7 +53,7 @@ export default function MasteryCheck({
       <script
         type="application/ld+json"
         /* nosec */ dangerouslySetInnerHTML={{
-          __html: JSON.stringify(faqSchema).replace(/</g, '\\u003c'),
+          __html: JSON.stringify(faqSchema).replace(/</g, '\\\\u003c'),
         }}
       />
       <div className="mastery-check__header">

--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -129,7 +129,7 @@ export default function SEOHead({
           key={`jsonld-${i}`}
           type="application/ld+json"
           /* nosec */ dangerouslySetInnerHTML={{
-            __html: JSON.stringify(schema).replace(/</g, '\\u003c'),
+            __html: JSON.stringify(schema).replace(/</g, '\\\\u003c'),
           }}
         />
       ))}


### PR DESCRIPTION
Fixes an XSS vulnerability in `MasteryCheck.tsx` and `SEOHead.tsx` when safely stringifying JSON-LD for React by properly injecting the unicode `<` character as `\u003c`. Additionally, updates the `.image-zoom-overlay` element in `MarkdownRenderer.tsx` from `role="dialog"` to `role="presentation"` to prevent screen readers from incorrectly announcing interactive layout overlays that respond to click-outside dismiss events.

---
*PR created automatically by Jules for task [18291686509392089399](https://jules.google.com/task/18291686509392089399) started by @saint2706*