### PR TITLE
📚 Docs: Fix broken Google AI Responsibility link

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -120,3 +120,4 @@ Added complete and well-formatted JSDoc to the following exported components, fu
 ## 2026-05-05
 - Fixed 3 broken links in `SECURITY.md` pointing to GitHub Code Security and Node.js security best practices.
 - Updated `mlc_config.json` with ignore patterns to prevent false positives from markdown-link-check (e.g., `../SKILL.md`, `www.shapeofai.com`, `eur-lex.europa.eu`).
+- Fixed broken Google AI Responsibility link in Day 119

--- a/content/lessons/Phase_10_Generative_AI_LLM_Engineering/Day_119_AI_Ethics_in_Practice/README.md
+++ b/content/lessons/Phase_10_Generative_AI_LLM_Engineering/Day_119_AI_Ethics_in_Practice/README.md
@@ -429,7 +429,7 @@ A model card (introduced by Google, 2019) is a standardized fact sheet about an 
 - [AI Fairness 360 (AIF360) — IBM Open Source](https://ai-fairness-360.org/)
 - [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework)
 - [EU AI Act — Official Text](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689)
-- [Google Responsible AI Practices](https://ai.google/responsibility/responsible-ai-practices/)
+- [Google Responsible AI Practices](https://ai.google/principles/#our-ai-principles-in-action)
 - [OWASP LLM Top 10 — Full Security Checklist](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
 
 ---


### PR DESCRIPTION
This pull request updates the `https://ai.google/responsibility/responsible-ai-practices/` link in Day 119's `README.md` to point to the active `https://ai.google/principles/#our-ai-principles-in-action` URL. The broken link caused markdown-link-check to fail. Also logged the progress in `.jules/docs-progress.md`.

---
*PR created automatically by Jules for task [15413605496648806676](https://jules.google.com/task/15413605496648806676) started by @saint2706*