### PR TITLE
🧘 Buddha: [SEO] Revert XSS Structured Data Fix

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -221,3 +221,11 @@ This scroll records the harmonization of the `Coding-For-MBA` codebase for human
 **Changes:**
 -   [x] **[GEO][SEO] Structured Data XSS Fix**: Updated the JSON-LD stringify escape sequences from `.replace(/</g, '\\u003c')` to `.replace(/</g, '\\\\u003c')` in `SEOHead.tsx` and `MasteryCheck.tsx` so that React renders the literal `\u003c` in the DOM `dangerouslySetInnerHTML`, preventing XSS execution without breaking JSON parsing.
 -   [x] **[A11Y] Overlay Accessibility Fix**: Replaced `role="dialog"` and `aria-modal="true"` with `role="presentation"` on the `.image-zoom-overlay` element inside `MarkdownRenderer.tsx`. This accurately represents the element as a non-interactive layout backdrop to screen readers, preventing confusion when clicking the background overlay.
+
+### [Date: Current] - XSS Prevention Revert
+
+**Priority Areas:**
+1.  **Security**: Revert incorrect XSS prevention in script tags.
+
+**Changes:**
+-   [x] **[GEO][SEO] Structured Data XSS Fix Revert**: Reverted the JSON-LD stringify escape sequences from `.replace(/</g, \\u003c)` back to `.replace(/</g, \u003c)` in `SEOHead.tsx` and `MasteryCheck.tsx` to comply with industry standards.

--- a/src/components/MasteryCheck.tsx
+++ b/src/components/MasteryCheck.tsx
@@ -53,7 +53,7 @@ export default function MasteryCheck({
       <script
         type="application/ld+json"
         /* nosec */ dangerouslySetInnerHTML={{
-          __html: JSON.stringify(faqSchema).replace(/</g, '\\\\u003c'),
+          __html: JSON.stringify(faqSchema).replace(/</g, '\\u003c'),
         }}
       />
       <div className="mastery-check__header">

--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -129,7 +129,7 @@ export default function SEOHead({
           key={`jsonld-${i}`}
           type="application/ld+json"
           /* nosec */ dangerouslySetInnerHTML={{
-            __html: JSON.stringify(schema).replace(/</g, '\\\\u003c'),
+            __html: JSON.stringify(schema).replace(/</g, '\\u003c'),
           }}
         />
       ))}

--- a/src/stores/quizStore.ts
+++ b/src/stores/quizStore.ts
@@ -168,8 +168,7 @@ export const useQuizStore = create<QuizStore>()(
             results.push(stats)
           }
         }
-        return results
-          .sort((a, b) => a.accuracy - b.accuracy || b.incorrect - a.incorrect)
+        return results.sort((a, b) => a.accuracy - b.accuracy || b.incorrect - a.incorrect)
       },
       getRecentAttempts: (quizId, limit = 5) =>
         get()


### PR DESCRIPTION
**Priority Area:** GEO/SEO Structured Data Integrity
**Action:** Reverted overly aggressive XSS prevention on JSON-LD structured data payload injection. 

### Why this is needed:
React's `dangerouslySetInnerHTML` accepts a string. When we inject `<script type="application/ld+json">`, we want to ensure any user-injected text containing `</script>` or `<` doesn't break out of the script tag and execute arbitrary code. The standard pattern is `JSON.stringify(schema).replace(/</g, '\\u003c')`. This replaces the literal `<` bracket with the string `\u003c` during hydration.

A previous update mistakenly changed this to `.replace(/</g, '\\\\u003c')`. This tells React to output a *literal backslash* followed by `u003c` in the DOM tree. When a search engine parser reads the resulting string, it encounters invalid JSON formatting, preventing Rich Snippet parsing.

### Changes:
* Restored `\\u003c` escape sequences in `src/components/SEOHead.tsx` and `src/components/MasteryCheck.tsx`.
* Tracked reversion in `.jules/buddha-scroll.md`.

*Verified by running the test suite, linter, and production build successfully.*

---
*PR created automatically by Jules for task [7330009301908710251](https://jules.google.com/task/7330009301908710251) started by @saint2706*