### PR TITLE
🎨 Picasso: [UX improvement] Add missing aria-labels to buttons

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -76,3 +76,5 @@ Added focus-visible outlines to sidebar close, navbar hamburger, and navbar sear
 - Updated `ExerciseWidget` solution toggle button to have a dynamic `aria-label` that reflects its state instead of a static "Toggle solution".
 - Added `focus-visible` to `MapListToggle` button for keyboard accessibility.
 **Learning:** When adding ARIA labels, ensure they dynamically reflect the current state of the button if its function or text changes (e.g., "Hide Answer" vs "Show Answer").
+
+- Added missing aria-labels to buttons in MapListToggle and MarkdownRenderer

--- a/src/components/MapListToggle.tsx
+++ b/src/components/MapListToggle.tsx
@@ -43,6 +43,7 @@ function Toggle({ defaultActive, ariaLabel = 'Switch view', children }: TogglePr
               type="button"
               role="tab"
               aria-selected={isActive}
+              aria-label={`Switch to ${v.props.label} view`}
               className={`map-list-toggle-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2${isActive ? ' active' : ''}`}
               onClick={() => setActive(v.props.label)}
             >

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -145,6 +145,7 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
           className="code-block-expand-btn"
           onClick={() => setCollapsed((c) => !c)}
           aria-expanded={!collapsed}
+          aria-label={collapsed ? 'Expand code block' : 'Collapse code block'}
         >
           {collapsed
             ? `▼ Show ${hiddenLineCount} more line${hiddenLineCount !== 1 ? 's' : ''}`

--- a/src/stores/quizStore.ts
+++ b/src/stores/quizStore.ts
@@ -168,8 +168,7 @@ export const useQuizStore = create<QuizStore>()(
             results.push(stats)
           }
         }
-        return results
-          .sort((a, b) => a.accuracy - b.accuracy || b.incorrect - a.incorrect)
+        return results.sort((a, b) => a.accuracy - b.accuracy || b.incorrect - a.incorrect)
       },
       getRecentAttempts: (quizId, limit = 5) =>
         get()


### PR DESCRIPTION
Added missing `aria-label`s to buttons to ensure keyboard accessibility and improve screen reader experience, as part of the Picasso UX persona workflow.

- MapListToggle: added dynamic aria-labels like "Switch to map view"
- MarkdownRenderer: added "Expand code block" and "Collapse code block" labels.

---
*PR created automatically by Jules for task [3532938359963660318](https://jules.google.com/task/3532938359963660318) started by @saint2706*