### PR TITLE
🧘 Buddha: [SEO] Update manifest curriculum length to 140 days

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -229,3 +229,10 @@ This scroll records the harmonization of the `Coding-For-MBA` codebase for human
 
 **Changes:**
 -   [x] **[GEO][SEO] Structured Data XSS Fix Revert**: Reverted the JSON-LD stringify escape sequences from `.replace(/</g, \\u003c)` back to `.replace(/</g, \u003c)` in `SEOHead.tsx` and `MasteryCheck.tsx` to comply with industry standards.
+
+### [Date: Current] - Manifest update
+**Priority Areas:**
+1. **SEO (Visibility)**: Accurate metadata.
+
+**Changes:**
+- [x] **[SEO] Manifest update**: Updated public/manifest.json to reflect 140 days instead of 108

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "Coding for MBA — 108-Day Technical Curriculum",
+  "name": "Coding for MBA — 140-Day Technical Curriculum",
   "short_name": "Coding for MBA",
-  "description": "A structured 108-day curriculum covering Python, Data Science, Machine Learning, Business Intelligence, and Enterprise SQL — designed for MBA professionals.",
+  "description": "A structured 140-day curriculum covering Python, Data Science, Machine Learning, Business Intelligence, and Enterprise SQL — designed for MBA professionals.",
   "start_url": "/Coding-For-MBA/",
   "scope": "/Coding-For-MBA/",
   "display": "standalone",


### PR DESCRIPTION
Update curriculum length from 108 days to 140 days in the PWA manifest file to match the actual curriculum size, improving SEO and metadata accuracy.

---
*PR created automatically by Jules for task [17741900406495877759](https://jules.google.com/task/17741900406495877759) started by @saint2706*