### PR TITLE
🎨 Picasso: Add keyboard focus states to MarkdownRenderer buttons

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -78,3 +78,4 @@ Added focus-visible outlines to sidebar close, navbar hamburger, and navbar sear
 **Learning:** When adding ARIA labels, ensure they dynamically reflect the current state of the button if its function or text changes (e.g., "Hide Answer" vs "Show Answer").
 
 - Added missing aria-labels to buttons in MapListToggle and MarkdownRenderer
+- 🎨 Picasso: Added missing focus-visible classes to buttons in MarkdownRenderer for better keyboard navigation.

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -80,7 +80,7 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
         <div style={{ display: 'flex', gap: '0.4rem', alignItems: 'center' }}>
           <button
             type="button"
-            className="code-block-copy"
+            className="code-block-copy focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
             onClick={() => setWrapLines((w) => !w)}
             aria-label={wrapLines ? 'Disable line wrapping' : 'Enable line wrapping'}
             title={wrapLines ? 'Unwrap long lines' : 'Wrap long lines'}
@@ -142,7 +142,7 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
       {isLong && (
         <button
           type="button"
-          className="code-block-expand-btn"
+          className="code-block-expand-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
           onClick={() => setCollapsed((c) => !c)}
           aria-expanded={!collapsed}
           aria-label={collapsed ? 'Expand code block' : 'Collapse code block'}
@@ -236,7 +236,7 @@ const ImageWithZoom = (props: JSX.IntrinsicElements['img'] & ExtraProps) => {
           >
             <button
               type="button"
-              className="image-zoom-close"
+              className="image-zoom-close focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
               onClick={(e) => {
                 e.stopPropagation()
                 setZoomed(false)


### PR DESCRIPTION
Adds `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2` to interactive `<button>` elements in `MarkdownRenderer.tsx` to improve keyboard navigation accessibility. Logged progress in `.jules/picasso.md`. Verified with automated tests and Playwright visual script.

---
*PR created automatically by Jules for task [2724861775702175269](https://jules.google.com/task/2724861775702175269) started by @saint2706*