### PR TITLE
🎨 Picasso: Fix dynamic aria-label conflict with aria-live region

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -79,3 +79,4 @@ Added focus-visible outlines to sidebar close, navbar hamburger, and navbar sear
 
 - Added missing aria-labels to buttons in MapListToggle and MarkdownRenderer
 - 🎨 Picasso: Added missing focus-visible classes to buttons in MarkdownRenderer for better keyboard navigation.
+Fixed dynamic aria-label conflict with aria-live region in CopyButton.tsx

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -76,7 +76,7 @@ export default function CopyButton({
       type="button"
       className={`${className} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`}
       onClick={handleCopy}
-      aria-label={copied ? 'Code copied to clipboard' : label}
+      aria-label={label}
       title={label}
     >
       {copied ? (


### PR DESCRIPTION
### 🎨 Picasso: UX/Accessibility Improvement

**Issue:**
The `CopyButton` component had a dynamic `aria-label` that updated when the button state changed from "Copy" to "Copied". Concurrently, there is an `sr-only` visually hidden element with `aria-live="polite"` and `aria-atomic="true"` that updates with the text "Code copied to clipboard". Changing the `aria-label` dynamically can conflict with the live region announcement, leading to confusing or dropped screen reader announcements.

**Fix:**
Removed the dynamic updating from the `aria-label` attribute on the `<button>`. The `aria-label` now remains statically set to its base label ("Copy to clipboard" or "Copy code"), allowing the `aria-live` region to handle announcing the state change.

**Testing:**
Verified the change using a UI script and ran full unit testing (`npm run test -- src/components/__tests__/CopyButton.test.tsx`), typechecks, and the build script locally.

---
*PR created automatically by Jules for task [13669196464543995638](https://jules.google.com/task/13669196464543995638) started by @saint2706*