### PR TITLE
🛡️ Sentinel: Mitigate basic-ftp high severity vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,4 @@
 - **Description:** The JSON-LD schema strings were originally replacing `<` characters with `\\u003c`. This injected literal backslashes into the inner HTML, which breaks JSON-LD parsing and leaves the content vulnerable to XSS injection if unsanitized data enters the JSON.
 - **Fix:** Changed the replacement string to `\u003c`, which translates to the correct `<` sequence in the parsed JavaScript string and prevents XSS by replacing all `<` tokens.
 - **Severity:** High
+- Fixed HIGH severity basic-ftp vulnerability via npm overrides

--- a/package-lock.json
+++ b/package-lock.json
@@ -3163,16 +3163,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/beasties": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/beasties/-/beasties-0.4.2.tgz",
@@ -5544,6 +5534,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/gh-pages": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
   "overrides": {
     "tmp": "^0.2.4",
     "brace-expansion": "^5.0.5",
-    "yaml": "^2.3.4"
+    "yaml": "^2.3.4",
+    "basic-ftp": "^5.3.1"
   },
   "devDependencies": {
     "@lhci/cli": "^0.15.1",


### PR DESCRIPTION
Mitigated `basic-ftp` high severity vulnerability (Denial of Service) via `npm overrides` to force the updated resolution (`^5.3.1`) across transitive dependencies. Verified changes by running the test suite locally. Documented findings and fix in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [5250245296630868112](https://jules.google.com/task/5250245296630868112) started by @saint2706*