### PR TITLE
📚 Docs: Add missing JSDoc comments and audit documentation

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -129,3 +129,7 @@ Added complete and well-formatted JSDoc to the following exported components, fu
   - Validated frontmatter and metadata with `npm run validate-content`.
   - Confirmed no placeholder text like 'TODO: Add content' exists in the codebase.
 - Added ^https://cube\\.dev to ignorePatterns in mlc_config.json
+- **[2026-05-14] JSDoc Audit Completion**
+  - Added missing JSDoc comments to `src/components/SidebarPhaseGroup.tsx` for `propsAreEqual` and default export.
+  - Validated markdown content without errors.
+  - Validated markdown links with `markdown-link-check` successfully.

--- a/src/components/SidebarPhaseGroup.tsx
+++ b/src/components/SidebarPhaseGroup.tsx
@@ -22,6 +22,13 @@ interface SidebarPhaseGroupProps {
   onClose: () => void
 }
 
+/**
+ * Renders an accordion group of lessons for a specific phase in the sidebar curriculum.
+ * Memoized to prevent re-rendering when navigation occurs outside of the current phase.
+ *
+ * @param {SidebarPhaseGroupProps} props - The component props.
+ * @returns {JSX.Element} The phase group accordion block.
+ */
 function SidebarPhaseGroup({
   phase,
   isActive,
@@ -195,11 +202,15 @@ function propsAreEqual(
 }
 
 /**
- * Renders an accordion group of lessons for a specific phase in the sidebar curriculum.
- * Memoized to prevent re-rendering when navigation occurs outside of the current phase.
+ * Compares old and new props to determine if the component should re-render.
  *
- * @param {SidebarPhaseGroupProps} props - The component props.
- * @returns {JSX.Element} The phase group accordion block.
+ * @param {SidebarPhaseGroupProps} prevProps - The previous props.
+ * @param {SidebarPhaseGroupProps} nextProps - The next props.
+ * @returns {boolean} True if the props are equal, false otherwise.
  */
 export { propsAreEqual }
+
+/**
+ * Memoized version of the SidebarPhaseGroup component.
+ */
 export default memo(SidebarPhaseGroup, propsAreEqual)


### PR DESCRIPTION
- **What:** Added missing JSDoc comments to exported functions in `SidebarPhaseGroup.tsx`.
- **Why:** To fulfill documentation coverage requirements and improve IDE intellisense without breaking strict linting checks.
- **How:** Placed `propsAreEqual` JSDoc comments directly above the export statement and documented the memoized default export. Also recorded progress in `.jules/docs-progress.md` and ensured all tests, typechecks, and link validations pass.

---
*PR created automatically by Jules for task [16588291978122036108](https://jules.google.com/task/16588291978122036108) started by @saint2706*