### PR TITLE
🛡️ Sentinel: Fix high severity DoS vulnerability in basic-ftp

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,4 @@
 - **Description:** The JSON-LD schema strings were originally replacing `<` characters with `\\u003c`. This injected literal backslashes into the inner HTML, which breaks JSON-LD parsing and leaves the content vulnerable to XSS injection if unsanitized data enters the JSON.
 - **Fix:** Changed the replacement string to `\u003c`, which translates to the correct `<` sequence in the parsed JavaScript string and prevents XSS by replacing all `<` tokens.
 - **Severity:** High
+- [x] **[SECURITY] Dependency Fix**: Updated `basic-ftp` to version 5.3.1 in `package.json` overrides to resolve a high severity DoS vulnerability via unbounded memory consumption (GHSA-rpmf-866q-6p89).

--- a/package-lock.json
+++ b/package-lock.json
@@ -3164,9 +3164,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
   "overrides": {
     "tmp": "^0.2.4",
     "brace-expansion": "^5.0.5",
-    "yaml": "^2.3.4"
+    "yaml": "^2.3.4",
+    "basic-ftp": "^5.3.1"
   },
   "devDependencies": {
     "@lhci/cli": "^0.15.1",


### PR DESCRIPTION
Updates the `basic-ftp` dependency via `package.json` overrides to version `^5.3.1` to resolve a high severity Denial of Service (DoS) vulnerability (GHSA-rpmf-866q-6p89). The fix was verified using `npm audit` which now reports 0 vulnerabilities. Changes were documented in `.jules/sentinel.md` following the Sentinel agent protocol.

---
*PR created automatically by Jules for task [100300924424500166](https://jules.google.com/task/100300924424500166) started by @saint2706*