### PR TITLE
🔄 CI/CD: [Fix build failure by updating invalid typescript dependency version]

### DIFF
--- a/.jules/ci-cd-progress.md
+++ b/.jules/ci-cd-progress.md
@@ -1,0 +1,3 @@
+## CI/CD Pipeline Fixes
+- Updated invalid `typescript` version in package.json from `~6.0.3` to `^5.7.3` to fix the build and `tsc: not found` error.
+- Verified all actions have existing tags.

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "lint-staged": "^16.4.0",
         "prettier": "^3.8.3",
         "rollup-plugin-visualizer": "^7.0.1",
-        "typescript": "~6.0.3",
+        "typescript": "^5.7.3",
         "vite": "^7.3.2",
         "vitest": "^4.0.18"
       }
@@ -10712,9 +10712,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.3",
     "rollup-plugin-visualizer": "^7.0.1",
-    "typescript": "~6.0.3",
+    "typescript": "^5.7.3",
     "vite": "^7.3.2",
     "vitest": "^4.0.18"
   },


### PR DESCRIPTION
Fix build failure by updating invalid typescript dependency version

- Updated `typescript` dependency from the invalid `~6.0.3` to `^5.7.3` in `package.json`.
- Synced `package-lock.json` via `npm install --save-dev typescript@5.7.3`.
- Resolves `tsc: not found` error during `npm run lint` and `npm run typecheck` steps in the CI pipeline.

---
*PR created automatically by Jules for task [14437736045914153076](https://jules.google.com/task/14437736045914153076) started by @saint2706*