### PR TITLE
🧘 Buddha: [SEO/GEO improvement] Semantic Heading Optimization

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -236,3 +236,6 @@ This scroll records the harmonization of the `Coding-For-MBA` codebase for human
 
 **Changes:**
 - [x] **[SEO] Manifest update**: Updated public/manifest.json to reflect 140 days instead of 108
+- [GEO] Fixed JSON-LD XSS vulnerability by correcting the escape sequence for less-than characters.
+- [GEO][SEO] Structured Data XSS Fix Revert: Reverted the JSON-LD stringify escape sequences from .replace(/</g, \u003c) back to .replace(/</g, \\u003c) to comply with industry standards.
+- [SEO] Semantic HTML Fixes: Added a screen-reader-only <h1> tag to Home.tsx to resolve the skipped heading level issue where the page's first heading was an <h2>.

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -182,6 +182,7 @@ export default function Home() {
         breadcrumbs={[{ name: 'Home', url: '/' }]}
       />
 
+      <h1 className="sr-only">Coding for MBA — The Analyst's Terminal</h1>
       <EditorialCover>
         <EditorialCover.Eyebrow>
           <span className="cover-issue">ISSUE 01</span>


### PR DESCRIPTION
Adds a screen-reader-only `<h1>` tag to `Home.tsx` to fix a semantic HTML hierarchy issue where the page's first heading was an `<h2>`. Also includes a documented log of the fix in `.jules/buddha-scroll.md`.

---
*PR created automatically by Jules for task [1432816392964835044](https://jules.google.com/task/1432816392964835044) started by @saint2706*