### PR TITLE
📚 Docs: Add missing JSDoc returns

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -129,3 +129,8 @@ Added complete and well-formatted JSDoc to the following exported components, fu
   - Validated frontmatter and metadata with `npm run validate-content`.
   - Confirmed no placeholder text like 'TODO: Add content' exists in the codebase.
 - Added ^https://cube\\.dev to ignorePatterns in mlc_config.json
+- Added missing `@returns` JSDoc to `EditorialCover` in `src/components/EditorialCover.tsx`
+- Added missing `@returns` JSDoc to `MapListToggle` in `src/components/MapListToggle.tsx`
+- Added missing `@returns` JSDoc to `SidebarPhaseGroup` in `src/components/SidebarPhaseGroup.tsx`
+- Added missing `@returns` JSDoc to `TerminalDashboard` in `src/components/TerminalDashboard.tsx`
+- Added missing `@returns` JSDoc to `SyntaxHighlighter` in `src/utils/prism.ts`

--- a/src/components/EditorialCover.tsx
+++ b/src/components/EditorialCover.tsx
@@ -57,5 +57,6 @@ const EditorialCover = Object.assign(Cover, {
 
 /**
  * The combined EditorialCover component exposing sub-components.
+ * @returns {JSX.Element} The rendered EditorialCover component.
  */
 export default EditorialCover

--- a/src/components/MapListToggle.tsx
+++ b/src/components/MapListToggle.tsx
@@ -68,5 +68,6 @@ const MapListToggle = Object.assign(Toggle, { View })
 
 /**
  * The combined MapListToggle component exposing the View sub-component.
+ * @returns {JSX.Element} The rendered MapListToggle component.
  */
 export default MapListToggle

--- a/src/components/SidebarPhaseGroup.tsx
+++ b/src/components/SidebarPhaseGroup.tsx
@@ -202,4 +202,7 @@ function propsAreEqual(
  * @returns {JSX.Element} The phase group accordion block.
  */
 export { propsAreEqual }
+/**
+ * @returns {JSX.Element} The rendered SidebarPhaseGroup component.
+ */
 export default memo(SidebarPhaseGroup, propsAreEqual)

--- a/src/components/TerminalDashboard.tsx
+++ b/src/components/TerminalDashboard.tsx
@@ -69,5 +69,6 @@ const TerminalDashboard = Object.assign(Dashboard, {
 
 /**
  * The combined TerminalDashboard component exposing Tile, TileHeader, TileBody, and TileFooter sub-components.
+ * @returns {JSX.Element} The rendered TerminalDashboard component.
  */
 export default TerminalDashboard

--- a/src/utils/prism.ts
+++ b/src/utils/prism.ts
@@ -30,5 +30,6 @@ SyntaxHighlighter.registerLanguage('javascript', javascript)
  * markdown, typescript, and javascript pre-registered to minimize bundle size.
  *
  * @type {React.ComponentType}
+ * @returns {React.ComponentType} The SyntaxHighlighter component.
  */
 export default SyntaxHighlighter


### PR DESCRIPTION
This PR addresses missing `@returns` tags in JSDoc comments for several exported components.

**Changes:**
* Added `@returns` tag to `EditorialCover` in `src/components/EditorialCover.tsx`
* Added `@returns` tag to `MapListToggle` in `src/components/MapListToggle.tsx`
* Added `@returns` tag to `SidebarPhaseGroup` in `src/components/SidebarPhaseGroup.tsx`
* Added `@returns` tag to `TerminalDashboard` in `src/components/TerminalDashboard.tsx`
* Added `@returns` tag to `SyntaxHighlighter` in `src/utils/prism.ts`
* Updated `.jules/docs-progress.md` with the performed changes.

These changes ensure the project's codebase stays thoroughly documented. Tests and linters run clean.

---
*PR created automatically by Jules for task [1794757245872545152](https://jules.google.com/task/1794757245872545152) started by @saint2706*