### PR TITLE
docs: Add missing JSDocs to exported functions

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -134,3 +134,6 @@ Added complete and well-formatted JSDoc to the following exported components, fu
 - Added missing `@returns` JSDoc to `SidebarPhaseGroup` in `src/components/SidebarPhaseGroup.tsx`
 - Added missing `@returns` JSDoc to `TerminalDashboard` in `src/components/TerminalDashboard.tsx`
 - Added missing `@returns` JSDoc to `SyntaxHighlighter` in `src/utils/prism.ts`
+- Added missing JSDoc comments to `scripts/validate-content.d.ts` for exported functions.
+- Added missing JSDoc comments to `scripts/vite-plugin-critical-css.ts` for the default exported plugin.
+- Verified all links using `markdown-link-check`.

--- a/scripts/validate-content.d.ts
+++ b/scripts/validate-content.d.ts
@@ -1,3 +1,22 @@
+/**
+ * Recursively finds all README.md files within a given directory.
+ * @param {string} dir - The directory to search.
+ * @param {string} [lessonsDir] - An optional base directory to resolve relative paths.
+ * @returns {string[]} An array of file paths to the found README.md files.
+ */
 export function findReadmes(dir: string, lessonsDir?: string): string[]
+
+/**
+ * Validates the structure and frontmatter of a single lesson's markdown content.
+ * @param {string} rawContent - The raw markdown string to validate.
+ * @param {string} [fileName] - An optional file name for error reporting context.
+ * @returns {string[]} An array of validation error messages. Returns an empty array if valid.
+ */
 export function validateLessonContent(rawContent: string, fileName?: string): string[]
+
+/**
+ * Executes the validation suite across all lesson files in the specified directory.
+ * @param {string} [lessonsDir] - The base directory containing lessons to validate. Defaults to the configured lessons path.
+ * @returns {number} The total count of validation errors found. Returns 0 if all tests pass.
+ */
 export function runValidation(lessonsDir?: string): number

--- a/scripts/vite-plugin-critical-css.ts
+++ b/scripts/vite-plugin-critical-css.ts
@@ -11,6 +11,10 @@ import path from 'node:path'
 
 import type { Plugin, ResolvedConfig } from 'vite'
 
+/**
+ * Vite Plugin - Critical CSS
+ * @returns {Plugin} The Vite plugin instance.
+ */
 export default function criticalCss(): Plugin {
   let resolvedConfig: ResolvedConfig | null = null
 


### PR DESCRIPTION
Added missing JSDoc comments to scripts/validate-content.d.ts and scripts/vite-plugin-critical-css.ts.

---
*PR created automatically by Jules for task [1170201767181118208](https://jules.google.com/task/1170201767181118208) started by @saint2706*