### PR TITLE
🧘 Buddha: Added top-level h1 to Home page [SEO]

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -237,3 +237,10 @@ This scroll records the harmonization of the `Coding-For-MBA` codebase for human
 **Changes:**
 - [x] **[SEO] Manifest update**: Updated public/manifest.json to reflect 140 days instead of 108
 - [SEO/GEO] Refactored `dangerouslySetInnerHTML` in JSON-LD `<script>` blocks in `SEOHead.tsx` and `MasteryCheck.tsx` to use direct child string interpolation with XSS escaping (`\u003c`). This improves security compliance and fulfills the instruction to avoid unsanitized `dangerouslySetInnerHTML`.
+
+### [Date: Current] - Deep Semantic HTML Outline Harmonization
+**Priority Areas:**
+1.  **SEO (Visibility)**: Perfect HTML structure.
+
+**Changes:**
+-   [x] **[SEO] Semantic HTML Fixes**: Injected an `<h1 className="sr-only">Coding for MBA - The Analyst's Terminal</h1>` inside `src/pages/Home.tsx` just before `EditorialCover` to ensure the Home Page document outline has a top-level `<h1>` heading.

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -182,6 +182,7 @@ export default function Home() {
         breadcrumbs={[{ name: 'Home', url: '/' }]}
       />
 
+      <h1 className="sr-only">Coding for MBA - The Analyst&apos;s Terminal</h1>
       <EditorialCover>
         <EditorialCover.Eyebrow>
           <span className="cover-issue">ISSUE 01</span>


### PR DESCRIPTION
Added a top-level `<h1>` tag with the class `sr-only` to the Home.tsx page before the `EditorialCover` component. This fulfills the `Add semantic HTML (h1-h6 hierarchy)` directive by providing a valid semantic document outline for search engines and screen readers while keeping the element visually hidden. Includes apostrophe HTML entity escaping (`&apos;`) to prevent linting errors.

---
*PR created automatically by Jules for task [4461476045964898815](https://jules.google.com/task/4461476045964898815) started by @saint2706*