### PR TITLE
🛡️ Sentinel: Apply non-breaking npm audit fixes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,11 @@
 - **Description:** The JSON-LD schema strings were originally replacing `<` characters with `\\u003c`. This injected literal backslashes into the inner HTML, which breaks JSON-LD parsing and leaves the content vulnerable to XSS injection if unsanitized data enters the JSON.
 - **Fix:** Changed the replacement string to `\u003c`, which translates to the correct `<` sequence in the parsed JavaScript string and prevents XSS by replacing all `<` tokens.
 - **Severity:** High
+
+### Dependency Security Audit (2025-05-21)
+- **Vulnerability**: 5 vulnerabilities found (4 moderate, 1 high) in `basic-ftp`, `brace-expansion`, `uuid`, and `ws`.
+- **Severity**: High/Moderate.
+- **Fix**: Executed `npm audit fix` to resolve `basic-ftp`, `brace-expansion`, and `ws`. Overrode `uuid` to `^11.1.1` in `package.json` to resolve the final vulnerability without a forced breaking change to `@lhci/cli`.
+
+### Dependency Security Audit Update (2025-05-21)
+- Reverted the `uuid` version override due to breaking changes to `@lhci/cli` at runtime. The vulnerability is deemed lower risk for our implementation context.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3164,9 +3164,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3267,9 +3267,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9236,9 +9236,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
🛡️ Sentinel Security Update

This PR addresses vulnerabilities identified during a routine dependency security audit.

**Vulnerabilities Addressed:**
*   **basic-ftp** (High Severity): Denial of service vulnerability via unbounded multiline control response buffering. Fixed via patch update.
*   **brace-expansion** (Moderate Severity): Large numeric range defeats documented DoS protection. Fixed via patch update.
*   **ws** (Moderate Severity): Uninitialized memory disclosure. Fixed via patch update.

**Skipped Fix:**
*   **uuid** (Moderate Severity): Requires a major version bump from v8 to v11. Attempting to override this version caused a breaking change to `@lhci/cli`, which depends on the older version. Since `@lhci/cli` is a development dependency and the risk is lower in that context compared to breaking the build pipeline with an unsupported major version upgrade, this fix was skipped and reverted.

**Verification:**
*   `npm run build` passes.
*   `npm run test` passes.
*   Documented findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2900733925235582804](https://jules.google.com/task/2900733925235582804) started by @saint2706*