### PR TITLE
📚 Docs: Fix markdown-link-check Invalid URL crash

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -128,9 +128,11 @@ Added complete and well-formatted JSDoc to the following exported components, fu
   - Found and fixed one code style issue in `src/stores/quizStore.ts` using `npm run format`.
   - Validated frontmatter and metadata with `npm run validate-content`.
   - Confirmed no placeholder text like 'TODO: Add content' exists in the codebase.
-- Added ^https://cube\\.dev to ignorePatterns in mlc_config.json
+- Added `^https://cube\\.dev` to ignorePatterns in mlc_config.json
 - Added missing `@returns` JSDoc to `EditorialCover` in `src/components/EditorialCover.tsx`
 - Added missing `@returns` JSDoc to `MapListToggle` in `src/components/MapListToggle.tsx`
 - Added missing `@returns` JSDoc to `SidebarPhaseGroup` in `src/components/SidebarPhaseGroup.tsx`
 - Added missing `@returns` JSDoc to `TerminalDashboard` in `src/components/TerminalDashboard.tsx`
 - Added missing `@returns` JSDoc to `SyntaxHighlighter` in `src/utils/prism.ts`
+- **[2026-05-08] Documentation Audit & Improvements**
+  - Fixed `TypeError: Invalid URL` crash in `markdown-link-check` by fixing malformed link inside `.jules/docs-progress.md`.


### PR DESCRIPTION
This PR resolves an issue where the `markdown-link-check` tool was failing silently or with a `TypeError: Invalid URL` due to a malformed regular expression string (`^https://cube\.dev`) written without backticks in `.jules/docs-progress.md`. By properly wrapping this pattern in a markdown code block, the link checker successfully parses the file without crashing. All `npm run test`, `npm run lint`, and `npm run build` checks pass successfully.

---
*PR created automatically by Jules for task [12907164926795270942](https://jules.google.com/task/12907164926795270942) started by @saint2706*