### PR TITLE
⚡ Bolt: Centralize completedSet in Zustand store

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -44,3 +44,4 @@
 ⚡ Bolt: Refactored O(N) array allocation chains into standard loops for performance optimization.
 >> 2026-04-28 19:40:31 UTC - ⚡ Bolt | Optimized src/stores/quizStore.ts and src/stores/gamificationStore.ts by replacing chained .map().filter() array allocation chains with standard for loops to minimize intermediate array allocations and reduce garbage collection pressure.
 - Replaced chained map/filter loops with standard loops in `src/components/Sidebar.tsx` and `src/utils/contentLoader.ts` to reduce memory allocation during list iteration.
+⚡ Bolt: Added completedSet to the Zustand store, preventing O(N*M) recalculation bottlenecks across components.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -71,8 +71,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
   const dueByPhase = useMemo(() => getReviewDueCountByPhase(), [])
   const reviewStreak = useMemo(() => getReviewStreak(), [])
 
-  const completedLessons = useProgressStore((state) => state.completedLessons)
-  const completedSet = useMemo(() => new Set(completedLessons), [completedLessons])
+  const completedSet = useProgressStore((state) => state.completedSet || new Set(state.completedLessons))
 
   const completedIdsByPhase = useMemo(() => {
     const idsByPhase: Record<number, string> = {}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -71,7 +71,9 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
   const dueByPhase = useMemo(() => getReviewDueCountByPhase(), [])
   const reviewStreak = useMemo(() => getReviewStreak(), [])
 
-  const completedSet = useProgressStore((state) => state.completedSet || new Set(state.completedLessons))
+  const completedSet = useProgressStore(
+    (state) => state.completedSet || new Set(state.completedLessons),
+  )
 
   const completedIdsByPhase = useMemo(() => {
     const idsByPhase: Record<number, string> = {}

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -22,7 +22,7 @@ vi.mock('../../utils/contentLoader', async () => {
 
 // Mock store
 const useProgressStoreMock = vi.fn((selector) =>
-  selector({ completedLessons: [] } as unknown as ReturnType<
+  selector({ completedLessons: [], completedSet: new Set() } as unknown as ReturnType<
     typeof import('../../stores/progressStore').useProgressStore.getState
   >),
 )

--- a/src/components/__tests__/SidebarPerf.test.tsx
+++ b/src/components/__tests__/SidebarPerf.test.tsx
@@ -14,7 +14,7 @@ vi.mock('../../utils/contentLoader', () => ({
 
 // Mock store
 const useProgressStoreMock = vi.fn((selector) =>
-  selector({ completedLessons: [] } as unknown as ReturnType<
+  selector({ completedLessons: [], completedSet: new Set() } as unknown as ReturnType<
     typeof import('../../stores/progressStore').useProgressStore.getState
   >),
 )

--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -43,7 +43,9 @@ export default function Curriculum() {
   })
   const timelineScaleY = useTransform(scrollYProgress, [0, 1], [0.1, 1])
 
-  const completedSet = useProgressStore((state) => state.completedSet || new Set(state.completedLessons))
+  const completedSet = useProgressStore(
+    (state) => state.completedSet || new Set(state.completedLessons),
+  )
 
   const phasesData = useMemo(() => {
     return phases.map((phase) => {

--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -43,8 +43,7 @@ export default function Curriculum() {
   })
   const timelineScaleY = useTransform(scrollYProgress, [0, 1], [0.1, 1])
 
-  const completedLessons = useProgressStore((state) => state.completedLessons)
-  const completedSet = useMemo(() => new Set(completedLessons), [completedLessons])
+  const completedSet = useProgressStore((state) => state.completedSet || new Set(state.completedLessons))
 
   const phasesData = useMemo(() => {
     return phases.map((phase) => {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -67,14 +67,15 @@ export default function Home() {
   const lastVisitedDay = useProgressStore((state) => state.lastVisitedLesson)
   const lastVisitedLesson = lastVisitedDay ? (getLesson(lastVisitedDay) ?? null) : null
 
-
   const streakDays = useProgressStore((state) => state.streakDays())
   const xp = useGamificationStore((state) => state.xpTotal)
   const dailyChallenge = useGamificationStore((state) => state.dailyChallenge)
   const refreshDailyChallenge = useGamificationStore((state) => state.refreshDailyChallenge)
   const challengeLesson = getLesson(dailyChallenge.day)
 
-  const completedSet = useProgressStore((state) => state.completedSet || new Set(state.completedLessons))
+  const completedSet = useProgressStore(
+    (state) => state.completedSet || new Set(state.completedLessons),
+  )
   const completedCount = useProgressStore((state) => state.completedLessonsCount())
   const totalLessons = stats.totalDays
   const completedPct = Math.round((completedCount / Math.max(1, totalLessons)) * 100)

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -67,14 +67,14 @@ export default function Home() {
   const lastVisitedDay = useProgressStore((state) => state.lastVisitedLesson)
   const lastVisitedLesson = lastVisitedDay ? (getLesson(lastVisitedDay) ?? null) : null
 
-  const completedLessons = useProgressStore((state) => state.completedLessons)
+
   const streakDays = useProgressStore((state) => state.streakDays())
   const xp = useGamificationStore((state) => state.xpTotal)
   const dailyChallenge = useGamificationStore((state) => state.dailyChallenge)
   const refreshDailyChallenge = useGamificationStore((state) => state.refreshDailyChallenge)
   const challengeLesson = getLesson(dailyChallenge.day)
 
-  const completedSet = useMemo(() => new Set(completedLessons), [completedLessons])
+  const completedSet = useProgressStore((state) => state.completedSet || new Set(state.completedLessons))
   const completedCount = useProgressStore((state) => state.completedLessonsCount())
   const totalLessons = stats.totalDays
   const completedPct = Math.round((completedCount / Math.max(1, totalLessons)) * 100)

--- a/src/pages/PhaseOverview.tsx
+++ b/src/pages/PhaseOverview.tsx
@@ -37,7 +37,9 @@ export default function PhaseOverview() {
   const lessons = getLessonsByPhase(phaseNum!)
   const prefersReducedMotion = useReducedMotion()
 
-  const completedSet = useProgressStore((state) => state.completedSet || new Set(state.completedLessons))
+  const completedSet = useProgressStore(
+    (state) => state.completedSet || new Set(state.completedLessons),
+  )
 
   if (!phase) {
     return (

--- a/src/pages/PhaseOverview.tsx
+++ b/src/pages/PhaseOverview.tsx
@@ -37,8 +37,7 @@ export default function PhaseOverview() {
   const lessons = getLessonsByPhase(phaseNum!)
   const prefersReducedMotion = useReducedMotion()
 
-  const completedLessons = useProgressStore((state) => state.completedLessons)
-  const completedSet = useMemo(() => new Set(completedLessons), [completedLessons])
+  const completedSet = useProgressStore((state) => state.completedSet || new Set(state.completedLessons))
 
   if (!phase) {
     return (

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -47,8 +47,7 @@ export default function ProgressDashboard() {
   const phases = getAllPhases()
   const { totalDays: totalLessons } = getCurriculumMetadata()
 
-  const completedLessons = useProgressStore((state) => state.completedLessons)
-  const completedSet = useMemo(() => new Set(completedLessons), [completedLessons])
+  const completedSet = useProgressStore((state) => state.completedSet || new Set(state.completedLessons))
   const completedCount = useProgressStore((state) => state.completedLessonsCount())
 
   const overallPct = totalLessons > 0 ? Math.round((completedCount / totalLessons) * 100) : 0

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -47,7 +47,9 @@ export default function ProgressDashboard() {
   const phases = getAllPhases()
   const { totalDays: totalLessons } = getCurriculumMetadata()
 
-  const completedSet = useProgressStore((state) => state.completedSet || new Set(state.completedLessons))
+  const completedSet = useProgressStore(
+    (state) => state.completedSet || new Set(state.completedLessons),
+  )
   const completedCount = useProgressStore((state) => state.completedLessonsCount())
 
   const overallPct = totalLessons > 0 ? Math.round((completedCount / totalLessons) * 100) : 0

--- a/src/pages/__tests__/ProgressDashboard.test.tsx
+++ b/src/pages/__tests__/ProgressDashboard.test.tsx
@@ -21,6 +21,7 @@ vi.mock('../../stores/progressStore', () => ({
     vi.fn((selector) => {
       const state = {
         completedLessons: ['day-1', 'day-2'],
+        completedSet: new Set(['day-1', 'day-2']),
         completedLessonsCount: () => 2,
         streakDays: () => 5,
         clearAllProgress: mockClearAllProgress,

--- a/src/stores/__tests__/progressStore.test.ts
+++ b/src/stores/__tests__/progressStore.test.ts
@@ -6,6 +6,7 @@ describe('progressStore selectors', () => {
     useProgressStore.setState({
       completedLessons: [],
       lastVisitedLesson: null,
+      completedSet: new Set([1, 3]),
       completionDates: {},
       hasHydrated: false,
     })
@@ -117,6 +118,7 @@ describe('progressStore selectors', () => {
     expect(migrated).toEqual({
       completedLessons: [1, 3],
       lastVisitedLesson: null,
+      completedSet: new Set([1, 3]),
       completionDates: { 1: '2026-03-01' },
     })
   })

--- a/src/stores/progressStore.ts
+++ b/src/stores/progressStore.ts
@@ -60,6 +60,7 @@ const PersistedProgressSchema = z.object({
 })
 
 type ProgressStore = {
+  completedSet: Set<number>
   completedLessons: number[]
   lastVisitedLesson: number | null
   completionDates: Record<number, string>
@@ -148,10 +149,11 @@ function mergeLegacyLastVisited(lastVisitedLesson: number | null): number | null
 
 function normalizePersistedState(
   state: unknown,
-): Pick<ProgressStore, 'completedLessons' | 'lastVisitedLesson' | 'completionDates'> {
+): Pick<ProgressStore, 'completedLessons' | 'lastVisitedLesson' | 'completionDates' | 'completedSet'> {
   if (Array.isArray(state)) {
     return {
       completedLessons: parseValidDays(state),
+      completedSet: new Set(parseValidDays(state)),
       lastVisitedLesson: mergeLegacyLastVisited(null),
       completionDates: {},
     }
@@ -171,6 +173,7 @@ function normalizePersistedState(
 
     return {
       completedLessons,
+      completedSet: new Set(completedLessons),
       lastVisitedLesson,
       completionDates,
     }
@@ -178,6 +181,7 @@ function normalizePersistedState(
 
   return {
     completedLessons: [],
+      completedSet: new Set<number>(),
     lastVisitedLesson: mergeLegacyLastVisited(null),
     completionDates: {},
   }
@@ -192,6 +196,7 @@ export const useProgressStore = create<ProgressStore>()(
   persist(
     (set, get) => ({
       completedLessons: [],
+      completedSet: new Set<number>(),
       lastVisitedLesson: null,
       completionDates: {},
       hasHydrated: false,
@@ -207,6 +212,7 @@ export const useProgressStore = create<ProgressStore>()(
           if (state.completedLessons.includes(normalizedDay)) return state
           return {
             completedLessons: [...state.completedLessons, normalizedDay].sort((a, b) => a - b),
+            completedSet: new Set([...state.completedLessons, normalizedDay]),
             completionDates: {
               ...state.completionDates,
               [normalizedDay]: toDayKey(completedAt),
@@ -220,6 +226,7 @@ export const useProgressStore = create<ProgressStore>()(
 
         set((state) => ({
           completedLessons: state.completedLessons.filter((value) => value !== normalizedDay),
+          completedSet: new Set(state.completedLessons.filter((value) => value !== normalizedDay)),
           completionDates: Object.fromEntries(
             Object.entries(state.completionDates).filter(
               ([savedDay]) => Number(savedDay) !== normalizedDay,
@@ -244,6 +251,7 @@ export const useProgressStore = create<ProgressStore>()(
       clearAllProgress: () => {
         set({
           completedLessons: [],
+          completedSet: new Set<number>(),
           lastVisitedLesson: null,
           completionDates: {},
         })
@@ -255,7 +263,7 @@ export const useProgressStore = create<ProgressStore>()(
         set({ lastVisitedLesson: normalizedDay })
       },
       getCompletedForPhase: (phaseLessonDays) => {
-        const completed = new Set(get().completedLessons)
+        const completed = get().completedSet
         return phaseLessonDays
           .map((day) => dayTokenToProgressId(day))
           .filter((day) => completed.has(day))
@@ -282,7 +290,10 @@ export const useProgressStore = create<ProgressStore>()(
       skipHydration: true,
       onRehydrateStorage: () => (state) => {
         if (!state) return
-        useProgressStore.setState({ hasHydrated: true })
+        useProgressStore.setState({
+          hasHydrated: true,
+          completedSet: new Set(state.completedLessons)
+        })
         removeStoredValue(LAST_VISITED_KEY)
       },
     },

--- a/src/stores/progressStore.ts
+++ b/src/stores/progressStore.ts
@@ -149,7 +149,10 @@ function mergeLegacyLastVisited(lastVisitedLesson: number | null): number | null
 
 function normalizePersistedState(
   state: unknown,
-): Pick<ProgressStore, 'completedLessons' | 'lastVisitedLesson' | 'completionDates' | 'completedSet'> {
+): Pick<
+  ProgressStore,
+  'completedLessons' | 'lastVisitedLesson' | 'completionDates' | 'completedSet'
+> {
   if (Array.isArray(state)) {
     return {
       completedLessons: parseValidDays(state),
@@ -181,7 +184,7 @@ function normalizePersistedState(
 
   return {
     completedLessons: [],
-      completedSet: new Set<number>(),
+    completedSet: new Set<number>(),
     lastVisitedLesson: mergeLegacyLastVisited(null),
     completionDates: {},
   }
@@ -292,7 +295,7 @@ export const useProgressStore = create<ProgressStore>()(
         if (!state) return
         useProgressStore.setState({
           hasHydrated: true,
-          completedSet: new Set(state.completedLessons)
+          completedSet: new Set(state.completedLessons),
         })
         removeStoredValue(LAST_VISITED_KEY)
       },


### PR DESCRIPTION
⚡ Bolt: Added `completedSet` to the Zustand store, preventing O(N*M) recalculation bottlenecks across components.

---
*PR created automatically by Jules for task [12294822779994671825](https://jules.google.com/task/12294822779994671825) started by @saint2706*