### PR TITLE
📚 Docs: Audit documentation and fix JSDoc types

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -134,3 +134,8 @@ Added complete and well-formatted JSDoc to the following exported components, fu
 - Added missing `@returns` JSDoc to `SidebarPhaseGroup` in `src/components/SidebarPhaseGroup.tsx`
 - Added missing `@returns` JSDoc to `TerminalDashboard` in `src/components/TerminalDashboard.tsx`
 - Added missing `@returns` JSDoc to `SyntaxHighlighter` in `src/utils/prism.ts`
+
+### 2026-03-10
+- Audited `docs/`, `content/`, and `src/` for missing JSDoc comments, placeholder texts, and broken links.
+- Found no broken links or placeholder texts.
+- Fixed incomplete JSDoc comments in `src/utils/linkSafety.ts` by adding explicit types for `@param` and `@returns` to `normalizeAndValidateHref` and `getSecureLinkAttributes` to ensure TSDoc compliance.

--- a/src/utils/linkSafety.ts
+++ b/src/utils/linkSafety.ts
@@ -23,8 +23,8 @@ const URL_SCHEME_PATTERN = /^[a-zA-Z][^:/?#]*:/
  * Validates and normalizes a URL string.
  * Detects if the link is external and safe to use.
  *
- * @param href - The raw URL string to check.
- * @returns Object containing the normalized URL and safety flags.
+ * @param {string | null | undefined} href - The raw URL string to check.
+ * @returns {{ normalizedHref: string | null, isExternal: boolean, isSafe: boolean }} Object containing the normalized URL and safety flags.
  */
 export const normalizeAndValidateHref = (href?: string | null) => {
   if (typeof href !== 'string') {
@@ -81,9 +81,9 @@ export interface LinkProps {
  * Generates secure HTML attributes for a link.
  * Automatically adds `rel="noopener noreferrer"` and `target="_blank"` for external links.
  *
- * @param href - The destination URL.
- * @param props - Additional link properties (target, rel).
- * @returns Safe props object or null if the link is unsafe.
+ * @param {string | null | undefined} href - The destination URL.
+ * @param {LinkProps} props - Additional link properties (target, rel).
+ * @returns {{ href: string, target?: string, rel?: string } | null} Safe props object or null if the link is unsafe.
  */
 export const getSecureLinkAttributes = (href?: string | null, props: LinkProps = {}) => {
   const { normalizedHref, isExternal, isSafe } = normalizeAndValidateHref(href)


### PR DESCRIPTION
- Audited `docs/`, `content/`, and `src/` for missing JSDoc comments, placeholder texts, and broken links.
- Found no broken links or placeholder texts.
- Fixed incomplete JSDoc comments in `src/utils/linkSafety.ts` by adding explicit types for `@param` and `@returns` to `normalizeAndValidateHref` and `getSecureLinkAttributes` to ensure TSDoc compliance.
- Recorded progress in `.jules/docs-progress.md`.

---
*PR created automatically by Jules for task [4790649718257159938](https://jules.google.com/task/4790649718257159938) started by @saint2706*