### PR TITLE
🎨 Picasso: Accessible decorative symbols in buttons

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -79,3 +79,6 @@ Added focus-visible outlines to sidebar close, navbar hamburger, and navbar sear
 
 - Added missing aria-labels to buttons in MapListToggle and MarkdownRenderer
 - 🎨 Picasso: Added missing focus-visible classes to buttons in MarkdownRenderer for better keyboard navigation.
+### Accessibility: Wrapped decorative symbols
+- Added `aria-hidden="true"` to `span` wrappers around symbols like `✕`, `▶`, `▼`, `▲`, `↔`, `↩` in `MarkdownRenderer.tsx`, `Navbar.tsx`, and `PythonRunner.tsx` inside interactive elements.
+- This ensures screen readers do not read out loud repetitive uninformative visual decorative text.

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -85,7 +85,15 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
             aria-label={wrapLines ? 'Disable line wrapping' : 'Enable line wrapping'}
             title={wrapLines ? 'Unwrap long lines' : 'Wrap long lines'}
           >
-            {wrapLines ? '↔ Unwrap' : '↩ Wrap'}
+            {wrapLines ? (
+              <>
+                <span aria-hidden="true">↔</span> Unwrap
+              </>
+            ) : (
+              <>
+                <span aria-hidden="true">↩</span> Wrap
+              </>
+            )}
           </button>
           {isPython && (
             <button
@@ -94,7 +102,15 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
               onClick={() => setShowPlayground((p) => !p)}
               aria-label={showPlayground ? 'Close playground' : 'Try this code'}
             >
-              {showPlayground ? '✕ Close' : '▶ Try It'}
+              {showPlayground ? (
+                <>
+                  <span aria-hidden="true">✕</span> Close
+                </>
+              ) : (
+                <>
+                  <span aria-hidden="true">▶</span> Try It
+                </>
+              )}
             </button>
           )}
           <CopyButton text={code} ariaLabel="Copy code to clipboard" />
@@ -147,9 +163,16 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
           aria-expanded={!collapsed}
           aria-label={collapsed ? 'Expand code block' : 'Collapse code block'}
         >
-          {collapsed
-            ? `▼ Show ${hiddenLineCount} more line${hiddenLineCount !== 1 ? 's' : ''}`
-            : '▲ Collapse'}
+          {collapsed ? (
+            <>
+              <span aria-hidden="true">▼</span> Show {hiddenLineCount} more line
+              {hiddenLineCount !== 1 ? 's' : ''}
+            </>
+          ) : (
+            <>
+              <span aria-hidden="true">▲</span> Collapse
+            </>
+          )}
         </button>
       )}
       {showPlayground && (
@@ -243,7 +266,7 @@ const ImageWithZoom = (props: JSX.IntrinsicElements['img'] & ExtraProps) => {
               }}
               aria-label="Close zoomed image"
             >
-              ✕
+              <span aria-hidden="true">✕</span>
             </button>
             <img
               src={rest.src}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -129,7 +129,7 @@ export default function Navbar({ onToggleSidebar, sidebarOpen }: NavbarProps) {
                 aria-label="Clear search"
                 title="Clear search"
               >
-                ✕
+                <span aria-hidden="true">✕</span>
               </button>
             ) : (
               <kbd className="navbar-search-shortcut">/</kbd>

--- a/src/components/PythonRunner.tsx
+++ b/src/components/PythonRunner.tsx
@@ -163,7 +163,7 @@ const PythonRunner = forwardRef<PythonRunnerHandle, PythonRunnerProps>(
               aria-label="Cancel current Python execution"
               title="Cancel execution"
             >
-              ✕ Cancel
+              <span aria-hidden="true">✕</span> Cancel
             </button>
           )}
         </div>


### PR DESCRIPTION
Added `aria-hidden="true"` to `span` wrappers around symbols like `✕`, `▶`, `▼`, `▲`, `↔`, `↩` in `MarkdownRenderer.tsx`, `Navbar.tsx`, and `PythonRunner.tsx` inside interactive elements. This ensures screen readers do not read out loud repetitive uninformative visual decorative text.

---
*PR created automatically by Jules for task [3029661376061264142](https://jules.google.com/task/3029661376061264142) started by @saint2706*