### PR TITLE
🔍 Hunter: Fixed 11 errors - typing and missing dependencies in MarkdownRenderer

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -195,3 +195,7 @@
 ## Session 34
 - **Fixed:** Resolved `TS2790` by using optional properties when casting `window` to delete properties.
 - **Verified:** Build, lint, and tests pass.
+
+## Session 35
+- **Fixed:** Removed `any` typings from `child` and `sectionNode` inside mapping iterations in `src/components/MarkdownRenderer.tsx` by updating parameters to correctly typed alternatives using `Nodes` and `Content` imported from `mdast`.
+- **Verified:** Build, lint, and tests pass.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
+    "remark-parse": "^11.0.0",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.1.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },
@@ -64,6 +67,8 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/canvas-confetti": "^1.6.4",
     "@types/d3": "^7.4.3",
+    "@types/hast": "^3.0.4",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^25.6.0",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -445,7 +445,7 @@ function getInlineNodeText(node: Nodes): string {
   }
 
   if ('children' in node && Array.isArray(node.children)) {
-    return node.children.map((child) => getInlineNodeText(child as Nodes)).join('')
+    return node.children.map((child: Nodes) => getInlineNodeText(child as Nodes)).join('')
   }
 
   return ''
@@ -453,7 +453,7 @@ function getInlineNodeText(node: Nodes): string {
 
 function getHeadingText(node: Heading): string {
   return node.children
-    .map((child) => getInlineNodeText(child as Nodes))
+    .map((child: Nodes) => getInlineNodeText(child as Nodes))
     .join('')
     .trim()
 }
@@ -464,7 +464,7 @@ function isLabeledParagraph(node: Content, label: string): boolean {
   if (!first || first.type !== 'strong') return false
 
   const strongText = (first as Strong).children
-    .map((child) => getInlineNodeText(child as Nodes))
+    .map((child: Nodes) => getInlineNodeText(child as Nodes))
     .join('')
     .trim()
     .replace(/:$/, '')
@@ -479,7 +479,7 @@ function extractLabeledTextFromParagraph(node: Content, label: string): string {
 
   const rest = children
     .slice(1)
-    .map((child) => getInlineNodeText(child as Nodes))
+    .map((child: Nodes) => getInlineNodeText(child as Nodes))
     .join('')
     .trim()
 
@@ -594,7 +594,7 @@ function findInteractiveBlocks(content: string): InteractiveBlock[] {
 
     const title = questionMatch?.[2]?.trim() || ''
     const detailsNodeIndex = sectionNodes.findIndex(
-      (sectionNode) => sectionNode?.type === 'html' && /<details[\s>]/i.test(sectionNode.value),
+      (sectionNode: Content) => sectionNode?.type === 'html' && /<details[\s>]/i.test(sectionNode.value),
     )
 
     const questionNodes =
@@ -622,7 +622,7 @@ function findInteractiveBlocks(content: string): InteractiveBlock[] {
 
     const { code: codeSnippet, remaining: questionText } = extractCodeBlock(questionBody)
     const answerText = answerBody
-      .replace(/```[\s\S]*?```/g, (codeBlock) => {
+      .replace(/```[\s\S]*?```/g, (codeBlock: string) => {
         const codeContent = codeBlock.replace(/```(?:\w+)?\s*\n?/, '').replace(/\n?```$/, '')
         return codeContent
       })


### PR DESCRIPTION
This branch fixes several missing dependencies resulting in TypeScript module resolution failures and typing issues.

- Fixed `TS2307: Cannot find module 'remark-parse'` and similar for `unified`, `mdast`, `unist-util-visit`, and `hast`. 
- Replaced implicit `any` definitions in `src/components/MarkdownRenderer.tsx` with explicit imports mapping to specific node structures (`Nodes`, `Content`, `Heading`). 
- Ran build, lint and test confirming zero regressions.
- Logged changes in hunter-progress.md as Session 35.

---
*PR created automatically by Jules for task [50011869942336770](https://jules.google.com/task/50011869942336770) started by @saint2706*