### PR TITLE
🧘 Buddha: [SEO/GEO improvement]

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -237,3 +237,5 @@ This scroll records the harmonization of the `Coding-For-MBA` codebase for human
 **Changes:**
 - [x] **[SEO] Manifest update**: Updated public/manifest.json to reflect 140 days instead of 108
 - [SEO/GEO] Refactored `dangerouslySetInnerHTML` in JSON-LD `<script>` blocks in `SEOHead.tsx` and `MasteryCheck.tsx` to use direct child string interpolation with XSS escaping (`\u003c`). This improves security compliance and fulfills the instruction to avoid unsanitized `dangerouslySetInnerHTML`.
+-   [x] **[PERF][GEO] Static Import for Home**: Converted `Home` component to a static import in `src/App.tsx` to prevent lazy-loading the LCP (Hero) element, improving Core Web Vitals.
+-   [x] **[GEO] JSDoc Return Types**: Added missing `@returns` and `@param` JSDoc tags to functions in `scripts/generate-llms-txt.js`.

--- a/scripts/generate-llms-txt.js
+++ b/scripts/generate-llms-txt.js
@@ -8,14 +8,23 @@ const ROOT = join(__dirname, '..')
 const LESSONS_DIR = join(ROOT, 'content', 'lessons')
 const BASE_URL = process.env.SITE_URL || 'https://saint2706.github.io/Coding-For-MBA'
 
-/** Extract frontmatter `day`, `phase` or `title` value from a markdown file. */
+/**
+ * Extract frontmatter `day`, `phase` or `title` value from a markdown file.
+ * @param {string} filePath
+ * @returns {Record<string, any>} The extracted frontmatter object.
+ */
 function extractFrontmatter(filePath) {
   const raw = readFileSync(filePath, 'utf-8')
   const { frontmatter } = parseMarkdown(raw)
   return frontmatter
 }
 
-/** Recursively find files matching a name. */
+/**
+ * Recursively find files matching a name.
+ * @param {string} dir
+ * @param {string} filename
+ * @returns {string[]} An array of file paths.
+ */
 function findFiles(dir, filename) {
   const results = []
   for (const entry of readdirSync(dir, { withFileTypes: true })) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,8 +22,8 @@ import { useUserPreferencesStore } from './stores/userPreferencesStore'
 import { useLearningAnalytics } from './hooks/useLearningAnalytics'
 import { hydrateGamificationStore } from './stores/gamificationStore'
 import { preloadSearchIndex } from './utils/searchIndex'
+import Home from './pages/Home'
 
-const Home = lazy(() => import('./pages/Home'))
 const Lesson = lazy(() => import('./pages/Lesson'))
 const PhaseOverview = lazy(() => import('./pages/PhaseOverview'))
 const Curriculum = lazy(() => import('./pages/Curriculum'))

--- a/src/utils/prefetchRoutes.ts
+++ b/src/utils/prefetchRoutes.ts
@@ -12,7 +12,6 @@
 
 const routePrefetchers: Array<{ match: (path: string) => boolean; load: () => Promise<unknown> }> =
   [
-    { match: (path) => path === '/', load: () => import('../pages/Home') },
     { match: (path) => path === '/curriculum', load: () => import('../pages/Curriculum') },
     { match: (path) => path.startsWith('/phase/'), load: () => import('../pages/PhaseOverview') },
     { match: (path) => path.startsWith('/lesson/'), load: () => import('../pages/Lesson') },


### PR DESCRIPTION
I have completed the tasks outlined by the Buddha agent persona guidelines:

1. **Fix Lazy-Loaded LCP (Home Route)**: `Home` was previously a lazy-loaded component, delaying the Largest Contentful Paint (LCP). It is now statically imported in `src/App.tsx`, and the redundant prefetch logic for the homepage route was removed from `src/utils/prefetchRoutes.ts`.
2. **Missing JSDoc Tags**: Added `@param` and `@returns` metadata to functions in `scripts/generate-llms-txt.js` to ensure perfect validation checks in any potential AI audits.
3. **Validating Previous Edits**: Confirmed that `dangerouslySetInnerHTML` was indeed cleanly removed previously in favor of proper encoding directly, which resolves another Core Web Vitals / Security recommendation seamlessly.
4. **Validating Headings (h1-h6)**: Audited heading structures throughout `src/pages` to ensure semantic `<h1/h2/h3>` hierarchy is followed securely.
5. All tests, static checks, and TypeScript compilations complete successfully. The `.jules/buddha-scroll.md` file was populated with the appropriate tracking points.

---
*PR created automatically by Jules for task [13699179123934131541](https://jules.google.com/task/13699179123934131541) started by @saint2706*