### PR TITLE
🎨 Picasso: added aria-hidden to decorative text inside buttons for accessibility

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -79,3 +79,5 @@ Added focus-visible outlines to sidebar close, navbar hamburger, and navbar sear
 
 - Added missing aria-labels to buttons in MapListToggle and MarkdownRenderer
 - 🎨 Picasso: Added missing focus-visible classes to buttons in MarkdownRenderer for better keyboard navigation.
+## Adding aria-hidden="true" to decorative symbols inside buttons
+Added aria-hidden="true" to icons/decorative text characters inside buttons where the button already has an aria-label, so screen readers do not announce redundant symbols (e.g., ✕ inside "Close" buttons). Affected files: src/components/Navbar.tsx, src/components/PythonRunner.tsx, src/components/MarkdownRenderer.tsx.

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -85,7 +85,7 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
             aria-label={wrapLines ? 'Disable line wrapping' : 'Enable line wrapping'}
             title={wrapLines ? 'Unwrap long lines' : 'Wrap long lines'}
           >
-            {wrapLines ? '↔ Unwrap' : '↩ Wrap'}
+            {wrapLines ? <> <span aria-hidden="true">↔</span> Unwrap </> : <> <span aria-hidden="true">↩</span> Wrap </> }
           </button>
           {isPython && (
             <button
@@ -94,7 +94,7 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
               onClick={() => setShowPlayground((p) => !p)}
               aria-label={showPlayground ? 'Close playground' : 'Try this code'}
             >
-              {showPlayground ? '✕ Close' : '▶ Try It'}
+              {showPlayground ? <> <span aria-hidden="true">✕</span> Close </> : <> <span aria-hidden="true">▶</span> Try It </> }
             </button>
           )}
           <CopyButton text={code} ariaLabel="Copy code to clipboard" />
@@ -243,7 +243,7 @@ const ImageWithZoom = (props: JSX.IntrinsicElements['img'] & ExtraProps) => {
               }}
               aria-label="Close zoomed image"
             >
-              ✕
+              <span aria-hidden="true">✕</span>
             </button>
             <img
               src={rest.src}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -129,7 +129,7 @@ export default function Navbar({ onToggleSidebar, sidebarOpen }: NavbarProps) {
                 aria-label="Clear search"
                 title="Clear search"
               >
-                ✕
+                <span aria-hidden="true">✕</span>
               </button>
             ) : (
               <kbd className="navbar-search-shortcut">/</kbd>

--- a/src/components/PythonRunner.tsx
+++ b/src/components/PythonRunner.tsx
@@ -163,7 +163,7 @@ const PythonRunner = forwardRef<PythonRunnerHandle, PythonRunnerProps>(
               aria-label="Cancel current Python execution"
               title="Cancel execution"
             >
-              ✕ Cancel
+              <span aria-hidden="true">✕</span> Cancel
             </button>
           )}
         </div>


### PR DESCRIPTION
Adds aria-hidden="true" to decorative icons and text characters inside buttons that already have an aria-label, ensuring screen readers do not announce redundant symbols.

---
*PR created automatically by Jules for task [12792259768947971825](https://jules.google.com/task/12792259768947971825) started by @saint2706*