### PR TITLE
🧘 Buddha: [PERF] Static import Home for LCP optimization

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -237,3 +237,8 @@ This scroll records the harmonization of the `Coding-For-MBA` codebase for human
 **Changes:**
 - [x] **[SEO] Manifest update**: Updated public/manifest.json to reflect 140 days instead of 108
 - [SEO/GEO] Refactored `dangerouslySetInnerHTML` in JSON-LD `<script>` blocks in `SEOHead.tsx` and `MasteryCheck.tsx` to use direct child string interpolation with XSS escaping (`\u003c`). This improves security compliance and fulfills the instruction to avoid unsanitized `dangerouslySetInnerHTML`.
+
+## [PERF] LCP Optimization
+- Converted the `Home` page route from a lazy-loaded component to a static import in `src/App.tsx`.
+- Removed the corresponding dynamic import entry from `src/utils/prefetchRoutes.ts`.
+- Ensures the Largest Contentful Paint (Hero element) is not delayed by client-side chunk loading.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,8 +22,8 @@ import { useUserPreferencesStore } from './stores/userPreferencesStore'
 import { useLearningAnalytics } from './hooks/useLearningAnalytics'
 import { hydrateGamificationStore } from './stores/gamificationStore'
 import { preloadSearchIndex } from './utils/searchIndex'
+import Home from './pages/Home'
 
-const Home = lazy(() => import('./pages/Home'))
 const Lesson = lazy(() => import('./pages/Lesson'))
 const PhaseOverview = lazy(() => import('./pages/PhaseOverview'))
 const Curriculum = lazy(() => import('./pages/Curriculum'))

--- a/src/utils/prefetchRoutes.ts
+++ b/src/utils/prefetchRoutes.ts
@@ -12,7 +12,6 @@
 
 const routePrefetchers: Array<{ match: (path: string) => boolean; load: () => Promise<unknown> }> =
   [
-    { match: (path) => path === '/', load: () => import('../pages/Home') },
     { match: (path) => path === '/curriculum', load: () => import('../pages/Curriculum') },
     { match: (path) => path.startsWith('/phase/'), load: () => import('../pages/PhaseOverview') },
     { match: (path) => path.startsWith('/lesson/'), load: () => import('../pages/Lesson') },


### PR DESCRIPTION
Converted the `Home` route in `src/App.tsx` from a lazy-loaded component to a static import. This prevents the Hero element (Largest Contentful Paint) from being unnecessarily delayed by client-side chunk loading. Also cleaned up the now-redundant prefetching entry in `src/utils/prefetchRoutes.ts` and logged the SEO/GEO improvement in `.jules/buddha-scroll.md`.

---
*PR created automatically by Jules for task [13299778535840512628](https://jules.google.com/task/13299778535840512628) started by @saint2706*