### PR TITLE
Add Phase 6 quiz lessons for Days 61-72 (Cutting-Edge ML)

### DIFF
--- a/content/lessons/Phase_06_Cutting_Edge_ML/Day_61_Reinforcement_and_Offline_Learning/quiz.json
+++ b/content/lessons/Phase_06_Cutting_Edge_ML/Day_61_Reinforcement_and_Offline_Learning/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 61,
+    "questions": [
+        {
+            "id": "d61q01",
+            "type": "multiple_choice",
+            "question": "What is the core trade-off in Reinforcement Learning described as 'Explore vs. Exploit,' and why does it matter for a business recommendation system?",
+            "options": [
+                "Whether to use supervised or unsupervised learning for the training data",
+                "Whether the agent should try new actions to discover better rewards (explore) or repeat actions it already knows yield rewards (exploit) — an agent that only exploits creates a filter bubble; one that only explores never masters anything",
+                "Whether to train on more data or fewer features to balance accuracy and speed",
+                "Whether to deploy the model online or offline to balance risk and performance"
+            ],
+            "answer": 1,
+            "explanation": "The explore-exploit dilemma is fundamental to RL. A news feed that only exploits will show you what you already like (filter bubble), missing potentially higher-engagement content. A feed that only explores will show you random articles, frustrating users. The balance is controlled by epsilon (ε): at ε=0.1, the agent explores 10% of the time. Real-world systems like Netflix and Spotify tune this parameter carefully — exploration discovers new interests while exploitation delivers reliable satisfaction."
+        },
+        {
+            "id": "d61q02",
+            "type": "multiple_choice",
+            "question": "In the Q-Learning update formula Q(S,A) ← Q(S,A) + α[R + γ·maxQ(S',A') − Q(S,A)], what does the Discount Factor (γ) control?",
+            "options": [
+                "How quickly the agent forgets old experiences when new data arrives",
+                "The ratio of exploration to exploitation in action selection",
+                "How much the agent values future rewards relative to immediate rewards — γ near 0 creates a short-sighted agent focused on instant payoff; γ near 1 creates a far-sighted agent that plans for long-term gain",
+                "The size of the Q-Table relative to the number of possible states"
+            ],
+            "answer": 2,
+            "explanation": "The discount factor γ determines the present value of future rewards. At γ=0, the agent only cares about the immediate reward R — it's purely greedy. At γ=0.99, a reward 100 steps in the future is still worth 0.99^100 ≈ 0.37 of its face value. This mirrors financial discounting: a dollar today is worth more than a dollar tomorrow. For a supply chain agent, γ controls whether it optimizes for today's cost savings vs. long-term inventory health. Most practical RL systems use γ between 0.9–0.99."
+        },
+        {
+            "id": "d61q03",
+            "type": "multiple_choice",
+            "question": "Why is Offline RL (Batch RL) the preferred approach for training a treatment optimization model in healthcare?",
+            "options": [
+                "Offline RL produces higher accuracy because it has access to more data than Online RL",
+                "Offline RL is faster to train because it uses pre-computed Q-Tables rather than real-time interaction",
+                "Online RL requires dangerous real-world exploration (trying random treatments on patients) to learn; Offline RL learns safely from historical patient records without ever taking a new risky action",
+                "Offline RL is cheaper because it does not require GPUs for training"
+            ],
+            "answer": 2,
+            "explanation": "In Online RL, the agent must explore — trying actions it has never tried before, including potentially harmful ones. In healthcare, 'exploring' means trying a random drug dose on a real patient. This is ethically and legally unacceptable. Offline RL uses a static dataset of historical (State, Action, Reward, Next State) tuples from past patient records to learn which treatments worked best, without ever making a new real-world intervention. This is why Offline RL is used in medical AI, industrial control, and finance — domains where exploration is dangerous or impossible."
+        },
+        {
+            "id": "d61q04",
+            "type": "multiple_choice",
+            "question": "Google's DeepMind used Reinforcement Learning to reduce data center cooling energy by 40%. Which component of the RL framework maps to the cooling system's thermostats and fans?",
+            "options": [
+                "The State — because thermostats observe temperature readings",
+                "The Reward — because energy savings are the positive feedback signal",
+                "The Action — because the agent sets thermostat values and fan speeds to interact with the environment",
+                "The Policy — because the control rules determine cooling behavior"
+            ],
+            "answer": 2,
+            "explanation": "In RL: State = current sensor readings (temperature, power usage across data center zones); Action = control settings the agent applies (thermostat setpoints, fan speeds, pump flow rates); Reward = negative energy consumption (lower energy = higher reward). The agent learned that counter-intuitive cooling strategies — pre-cooling certain zones, running fans at unusual speeds — yielded a 40% energy reduction that human engineers had not considered. This is a landmark business case for RL: the environment is complex, interactions are continuous, and the payoff is measurable in dollars."
+        },
+        {
+            "id": "d61q05",
+            "type": "multiple_choice",
+            "question": "Your e-commerce company wants to use Reinforcement Learning for dynamic pricing. A new RL agent has no historical knowledge and will make random pricing decisions at launch. What is this problem called, and what is the recommended solution?",
+            "options": [
+                "The Reward Hacking problem — solved by designing a multi-objective reward function that balances revenue and customer satisfaction",
+                "The Cold Start problem — solved by pre-training the agent using Imitation Learning (copying past human pricing decisions) or Offline RL on historical pricing logs before going live",
+                "The Sim-to-Real Gap — solved by Domain Randomization to make the simulated pricing environment harder than reality",
+                "The Exploration Overshoot problem — solved by setting epsilon to 0.0 to disable random pricing from day one"
+            ],
+            "answer": 1,
+            "explanation": "The Cold Start problem occurs when a new RL agent has an empty Q-Table and must explore randomly before learning. In dynamic pricing, random exploration means setting prices at $0 or $10,000 for real customers — catastrophic for revenue and brand. The solution is Imitation Learning: initialize the agent by cloning historical human pricing behavior (supervised learning on past decisions), then switch to RL for improvement. Alternatively, Offline RL pre-trains on historical logs. This gives the agent a sensible starting policy before any live interaction, dramatically reducing the costly exploration phase."
+        }
+    ]
+}

--- a/content/lessons/Phase_06_Cutting_Edge_ML/Day_62_Model_Interpretability_and_Fairness/quiz.json
+++ b/content/lessons/Phase_06_Cutting_Edge_ML/Day_62_Model_Interpretability_and_Fairness/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 62,
+    "questions": [
+        {
+            "id": "d62q01",
+            "type": "multiple_choice",
+            "question": "What is the fundamental difference between Global and Local interpretability, and when would you use each?",
+            "options": [
+                "Global interpretability uses SHAP values; local interpretability uses LIME values — they are simply different libraries for the same purpose",
+                "Global interpretability explains how the model behaves on average across all predictions (e.g., 'income is the most important feature overall'); local interpretability explains why the model made a specific individual prediction (e.g., 'Bob was rejected because of his debt ratio')",
+                "Global interpretability is for regulators; local interpretability is for data scientists — they serve different audiences but provide the same information",
+                "Global interpretability applies to linear models; local interpretability applies to deep learning models"
+            ],
+            "answer": 1,
+            "explanation": "Global interpretability answers 'how does this model work in general?' — useful for model audits, stakeholder presentations, and feature engineering decisions. Local interpretability answers 'why did this model make this specific decision?' — critical for GDPR compliance (right to explanation), customer service (explaining a loan rejection), and debugging anomalous predictions. SHAP can provide both: SHAP summary plots give global importance, while a SHAP waterfall plot for a single customer gives local explanation. In a loan approval system, a regulator wants global insight; the rejected applicant wants local explanation."
+        },
+        {
+            "id": "d62q02",
+            "type": "multiple_choice",
+            "question": "SHAP values are grounded in game theory. In the loan approval analogy, what does the 'Shapley Value' of the Debt-to-Income Ratio feature represent?",
+            "options": [
+                "The raw coefficient of Debt-to-Income Ratio in a linear regression model",
+                "The average prediction accuracy when Debt-to-Income Ratio is included vs. excluded from the model",
+                "The marginal contribution of Debt-to-Income Ratio to the prediction across all possible combinations of other features — how much it pushed the prediction above or below the average prediction",
+                "The correlation between Debt-to-Income Ratio and the target variable in the training dataset"
+            ],
+            "answer": 2,
+            "explanation": "Shapley values from cooperative game theory fairly distribute a 'payout' (the prediction minus the base rate) among 'players' (features). For a loan rejection predicted at 80% default risk vs. 10% average: SHAP asks 'how much did Debt-to-Income Ratio contribute?' by averaging its marginal impact across all possible subsets of other features. A SHAP value of +0.35 for Debt-to-Income means this feature alone pushed the default probability 35 percentage points above average. A SHAP value of -0.15 for Employment History means stable employment reduced default risk by 15 points. The sum of all SHAP values equals (prediction - base rate)."
+        },
+        {
+            "id": "d62q03",
+            "type": "multiple_choice",
+            "question": "Your hiring algorithm uses 'Zip Code' as a feature and achieves 92% accuracy. A bias audit reveals that acceptance rates for minority candidates are 35% vs. 58% for majority candidates. What is the core problem, and how should it be addressed?",
+            "options": [
+                "The model is overfitting to zip code — apply L2 regularization to reduce its weight",
+                "The Disparate Impact Ratio is 0.60 (below the 0.8 threshold), indicating proxy variable bias where zip code encodes race/ethnicity — remove zip code or apply fairness constraints (e.g., equalized odds post-processing) even at a small accuracy cost",
+                "The model needs more training data from minority zip codes to improve its accuracy for those groups",
+                "The 35% vs. 58% gap is within acceptable range since both groups are being hired at positive rates"
+            ],
+            "answer": 1,
+            "explanation": "Disparate Impact Ratio = 35%/58% = 0.60, well below the 0.8 legal threshold (Four-Fifths Rule). Zip Code is a proxy variable that encodes race/socioeconomic status — even after removing explicit race as a feature, the model reconstructs it through correlated variables like zip code. This is 'Redlining' in ML form. The fix involves: (1) removing or replacing the proxy variable, (2) applying fairness constraints during training (Fairlearn's ExponentiatedGradient), or (3) post-processing predictions to equalize outcomes. Accepting a 2% accuracy drop to achieve legal compliance is always the right business decision."
+        },
+        {
+            "id": "d62q04",
+            "type": "multiple_choice",
+            "question": "A bank must comply with GDPR's 'right to explanation' for automated credit decisions. Which model type is most appropriate, and why?",
+            "options": [
+                "A 500-layer deep neural network — because higher accuracy means fewer incorrect rejections that need explaining",
+                "An ensemble of 1,000 decision trees (Random Forest) — because ensemble methods are always more interpretable than single models",
+                "A shallow decision tree or logistic regression — because these 'white box' models expose their rules directly (e.g., 'IF debt_ratio > 0.4 AND no_credit_history THEN reject') and can provide legally defensible explanations without post-hoc interpretation tools",
+                "Any model paired with SHAP values — because SHAP makes any model fully transparent and legally compliant regardless of complexity"
+            ],
+            "answer": 2,
+            "explanation": "GDPR requires that automated decisions affecting individuals be explainable in simple terms. While SHAP can post-hoc explain any model, regulators and courts often require inherently interpretable models — ones where the decision logic is transparent by design, not reconstructed after the fact. A logistic regression's coefficients or a decision tree's if-then rules can be printed and shown to a regulator directly. This is the accuracy-interpretability tradeoff in practice: a 2% accuracy sacrifice for 100% legal clarity is not just acceptable — it may be legally required. In healthcare and credit, 'slightly less accurate but legal' beats 'perfect but unaccountable.'"
+        },
+        {
+            "id": "d62q05",
+            "type": "multiple_choice",
+            "question": "When debugging an XGBoost model that predicts customer churn, you find a customer with 5 years of tenure is predicted as high-risk for churn. A SHAP waterfall plot shows 'tenure = 5 years' has a SHAP value of +0.42. What does this tell you?",
+            "options": [
+                "The model has an error — longer tenure should always reduce churn risk, so a positive SHAP value indicates a data bug",
+                "Tenure of 5 years pushed this customer's churn probability 42 percentage points above the average prediction, suggesting the model learned an unusual pattern (e.g., '5-year customers frequently churn due to contract renewals') that should be investigated",
+                "The model assigns 42% of its total prediction weight to the tenure feature across all customers",
+                "SHAP values above 0.4 indicate features that should be removed for reducing model complexity"
+            ],
+            "answer": 1,
+            "explanation": "A positive SHAP value of +0.42 for tenure=5 means that for this specific customer, having 5 years of tenure pushed their predicted churn probability 42 percentage points higher than the baseline. This is counterintuitive (we'd expect longer tenure = lower churn) but could reflect real patterns: many SaaS companies see 5-year contract renewal spikes where customers evaluate competitors. This is the power of local SHAP: it flags cases where the model learned something surprising. You should investigate: Are 5-year customers actually churning more? Is there a data artifact? Is contract expiry driving a real pattern? SHAP turns model debugging into a business investigation."
+        }
+    ]
+}

--- a/content/lessons/Phase_06_Cutting_Edge_ML/Day_63_Causal_Inference_and_Uplift/quiz.json
+++ b/content/lessons/Phase_06_Cutting_Edge_ML/Day_63_Causal_Inference_and_Uplift/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 63,
+    "questions": [
+        {
+            "id": "d63q01",
+            "type": "multiple_choice",
+            "question": "What is the fundamental difference between correlation and causation, and why does it matter for a marketing team deciding whether to increase ad spend?",
+            "options": [
+                "Correlation measures linear relationships; causation measures non-linear relationships — both are equally useful for business decisions",
+                "Correlation shows that two variables move together (e.g., ad spend and revenue both rise in Q4), but this could be driven by a third variable (holiday season); causation proves that increasing ad spend directly produces revenue — only causal knowledge lets you confidently invest more",
+                "Correlation is measured on historical data; causation requires real-time data — the marketing team should switch to real-time analytics",
+                "Correlation is a statistical technique; causation is a business judgment — data scientists handle correlation, executives handle causation"
+            ],
+            "answer": 1,
+            "explanation": "Ice cream sales and drowning rates are highly correlated — not because ice cream causes drowning, but because hot weather (a confounder) drives both. Similarly, a marketing team seeing that ad spend and revenue rise together in Q4 cannot conclude that ads caused revenue — the holiday shopping season drives both. This is Judea Pearl's 'Ladder of Causation': Association (seeing) ≠ Intervention (doing). Randomized A/B tests or causal inference methods like Difference-in-Differences establish true causality. A marketing team that mistakes correlation for causation may waste millions on ads that merely coincide with organic revenue growth."
+        },
+        {
+            "id": "d63q02",
+            "type": "multiple_choice",
+            "question": "Simpson's Paradox occurs in a clinical trial: Drug A shows 78% success overall vs. Drug B's 83%. However, Drug A outperforms Drug B in both mild AND severe patient subgroups. How is this possible, and which drug should doctors prescribe?",
+            "options": [
+                "This is a data entry error — it is mathematically impossible for one drug to be better in every subgroup but worse overall",
+                "Drug B was tested on more patients, giving it statistical power that Drug A lacks — doctors should use Drug B because sample size matters more than subgroup results",
+                "Drug A was disproportionately assigned to harder cases (severe patients); Drug B got easier cases — the overall rates are confounded by severity. Doctors should prescribe Drug A since it performs better within each comparable severity level",
+                "Both drugs perform equivalently — the paradox shows statistical analysis is unreliable for clinical decisions"
+            ],
+            "answer": 2,
+            "explanation": "This is the classic Berkeley admissions paradox applied to medicine. Drug A (78% overall) was used more on severe cases (which have lower base success rates), making its overall average look worse. Drug B (83% overall) was mostly used on mild cases (higher base success rates). When you control for severity — comparing like-for-like — Drug A wins in every category. The confounder (severity) must be accounted for. Doctors should prescribe Drug A, stratifying by patient severity. This illustrates why aggregate statistics can be actively misleading in medical and business decisions, and why stratified analysis or regression with controls is essential."
+        },
+        {
+            "id": "d63q03",
+            "type": "multiple_choice",
+            "question": "Traditional ML predicts P(Buy | User). Uplift modeling predicts P(Buy | Treated) − P(Buy | Control). Why does this distinction change which customers a marketing campaign should target?",
+            "options": [
+                "They are mathematically equivalent — targeting high P(Buy) customers is the same as targeting high uplift customers",
+                "Traditional ML identifies customers likely to buy anyway (Sure Things) and may waste budget on them; uplift modeling identifies Persuadables — customers who buy IF treated but not otherwise — maximizing ROI by spending only where the treatment changes behavior",
+                "Uplift modeling requires A/B test data which is harder to collect, making traditional ML more practical for most campaigns",
+                "Traditional ML is better for large campaigns; uplift modeling is only useful for personalized one-to-one marketing"
+            ],
+            "answer": 1,
+            "explanation": "The four customer segments in uplift modeling: (1) Sure Things — buy regardless of treatment (wasting money on them), (2) Lost Causes — won't buy regardless, (3) Sleeping Dogs — buy when NOT treated, but don't when treated (negative uplift!), (4) Persuadables — the gold segment who buy only because of the treatment. Traditional ML targets high P(Buy) customers who are mostly Sure Things — giving discounts to customers who would have paid full price anyway. Uplift modeling targets Persuadables, maximizing incremental lift per dollar spent. Criteo, Uber, and DoorDash use uplift modeling for promotions — studies show 20-40% improvement in campaign ROI vs. propensity-based targeting."
+        },
+        {
+            "id": "d63q04",
+            "type": "multiple_choice",
+            "question": "You want to measure the causal effect of a new store layout on sales without running a full randomized experiment. Half your stores received the redesign due to budget constraints. Which causal inference method is most appropriate?",
+            "options": [
+                "Simple before-after comparison of redesigned stores — since you know which stores changed, the treatment is clear",
+                "Difference-in-Differences (DiD) — comparing the change in sales in redesigned stores vs. unchanged stores over the same time period, removing the effect of overall market trends that would affect all stores",
+                "Propensity Score Matching — matching redesigned stores to similar non-redesigned stores based on their characteristics, then comparing outcomes",
+                "Regression Discontinuity Design — since stores were assigned based on a budget threshold, you can compare stores just above and below the budget cutoff"
+            ],
+            "answer": 1,
+            "explanation": "Difference-in-Differences compares: (redesigned stores after − redesigned stores before) − (control stores after − control stores before). This isolates the causal effect of the redesign by subtracting out time trends (e.g., seasonal effects, economic conditions) that affect all stores equally. Propensity Score Matching (option C) is also valid and commonly used, but DiD is preferred when you have panel data (same stores observed before and after). Regression Discontinuity (option D) is appropriate here if stores were assigned based on a budget score threshold — actually making it a plausible alternative. DiD is the most commonly used quasi-experimental method in business, used by economists to evaluate policy changes, pricing interventions, and product launches."
+        },
+        {
+            "id": "d63q05",
+            "type": "multiple_choice",
+            "question": "A counterfactual question asks: 'Would this customer have churned if we had NOT sent the cancellation-prevention email?' Why can't a standard supervised learning model answer this question directly?",
+            "options": [
+                "Supervised learning models cannot make predictions about future events — they only describe historical patterns",
+                "The fundamental problem of causal inference: for each customer, we can only observe one potential outcome (they either received the email or they didn't) — we never observe what would have happened under the alternative treatment, so there is no ground truth label for the counterfactual",
+                "Standard models lack sufficient training data because counterfactual scenarios are rare in real-world datasets",
+                "Supervised learning requires the target variable to be binary, but churn outcomes are continuous probabilities"
+            ],
+            "answer": 1,
+            "explanation": "This is the Fundamental Problem of Causal Inference (Rubin's Potential Outcomes Framework): for customer Alice who received the email and did NOT churn, we cannot observe what would have happened if she had not received the email. We only observe one timeline. This means we cannot directly compute Individual Treatment Effect (ITE). Standard ML trains on observed labels — it cannot learn counterfactuals because the counterfactual outcome was never observed. Causal methods (propensity scoring, double ML, causal forests) estimate these counterfactual outcomes by carefully comparing similar treated vs. untreated customers, accounting for selection bias. This distinction is why causal inference is more complex — and more valuable — than standard prediction."
+        }
+    ]
+}

--- a/content/lessons/Phase_06_Cutting_Edge_ML/Day_64_Modern_NLP_Pipelines/quiz.json
+++ b/content/lessons/Phase_06_Cutting_Edge_ML/Day_64_Modern_NLP_Pipelines/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 64,
+    "questions": [
+        {
+            "id": "d64q01",
+            "type": "multiple_choice",
+            "question": "What is Transfer Learning in NLP, and why does it make building a custom medical text classifier dramatically cheaper than training from scratch?",
+            "options": [
+                "Transfer Learning moves a model trained on one programming language to another, reducing the need to retrain on new syntax",
+                "Transfer Learning downloads a pre-trained model (like BERT, trained on billions of words at $500K+ cost) and fine-tunes it on your small domain-specific dataset — you inherit all the general language understanding and only teach the model your specific task on thousands of examples instead of billions",
+                "Transfer Learning transfers the weights from one model architecture to another to reduce inference latency",
+                "Transfer Learning uses a teacher model to label unlabeled data for a student model, reducing annotation costs"
+            ],
+            "answer": 1,
+            "explanation": "Training BERT from scratch cost Google ~$500,000 in compute and required 3.3 billion words. Your medical startup cannot do this. But BERT already 'knows' English grammar, semantics, and world knowledge. Transfer Learning lets you download this pre-trained model and fine-tune it on your 10,000 labeled medical records — a process that takes hours on a single GPU and costs tens of dollars. The pre-trained model provides the foundation; fine-tuning teaches it your specific domain (medical terminology, diagnosis codes, clinical language patterns). This is why modern NLP democratized — any company with a few thousand labeled examples can now build state-of-the-art text models."
+        },
+        {
+            "id": "d64q02",
+            "type": "multiple_choice",
+            "question": "BERT and GPT are both transformer-based models. What architectural difference makes BERT better for text classification and GPT better for text generation?",
+            "options": [
+                "BERT uses convolutional layers for classification; GPT uses recurrent layers for generation",
+                "BERT is an encoder that reads text bidirectionally (using context from both left and right), making it excellent at understanding meaning; GPT is a decoder that generates text left-to-right (each token only sees preceding tokens), making it natural for generation tasks",
+                "BERT requires more training data than GPT, which is why BERT is used for large enterprise classification and GPT for smaller generation tasks",
+                "BERT is open-source; GPT is proprietary — the difference is licensing, not architecture"
+            ],
+            "answer": 1,
+            "explanation": "BERT (Bidirectional Encoder Representations from Transformers) uses the encoder stack and Masked Language Modeling — it sees the full context on both sides of every word. For 'The bank approved the loan,' BERT knows 'bank' means financial institution, not riverbank, because it sees both 'approved' and 'loan' simultaneously. This bidirectional understanding excels at classification, NER, and question answering. GPT (Generative Pretrained Transformer) uses the decoder stack with causal masking — when generating token 5, it only sees tokens 1-4. This constraint makes it naturally suited for autoregressive generation. For customer support: use BERT to classify ticket intent; use GPT to draft the response."
+        },
+        {
+            "id": "d64q03",
+            "type": "multiple_choice",
+            "question": "You use a Hugging Face pipeline for sentiment analysis on customer reviews: `pipeline('sentiment-analysis')('The product arrived broken')`. What is happening under the hood, and why is this remarkably powerful for business?",
+            "options": [
+                "The pipeline calls a rule-based keyword matching system that labels reviews containing 'broken' as negative",
+                "The pipeline runs tokenization → feeds tokens to a pre-trained BERT-like model → outputs a label (NEGATIVE) and confidence score — a complete NLP pipeline in one line that would have required months of ML engineering just 5 years ago",
+                "The pipeline sends the text to an external cloud API and returns cached results from a sentiment database",
+                "The pipeline uses TF-IDF vectorization plus a logistic regression classifier trained on Amazon reviews"
+            ],
+            "answer": 1,
+            "explanation": "The Hugging Face pipeline abstracts: (1) Tokenization — splitting 'The product arrived broken' into subword tokens with special [CLS] and [SEP] tokens, (2) Model inference — running the tokenized sequence through a fine-tuned DistilBERT/BERT model with a classification head, (3) Post-processing — converting logits to probabilities via softmax, returning {'label': 'NEGATIVE', 'score': 0.997}. Before transformers, this required weeks of feature engineering, domain-specific dictionaries, and hand-tuned rules. Now a junior analyst can process 10,000 customer reviews in minutes. The business value: real-time brand monitoring, automatic ticket routing, product feedback analysis — all with one pip install."
+        },
+        {
+            "id": "d64q04",
+            "type": "multiple_choice",
+            "question": "Your e-commerce platform wants to extract product names, prices, and brands from unstructured supplier emails. Which NLP task and model type is most appropriate?",
+            "options": [
+                "Text Classification with BERT — classify each email as 'has product info' or 'no product info'",
+                "Named Entity Recognition (NER) with a BERT-based token classification model — it labels each word/token with tags like PRODUCT, PRICE, BRAND, and O (other), extracting structured information from unstructured text",
+                "Text Generation with GPT — prompt the model to rewrite the email in structured JSON format",
+                "Semantic Similarity with Sentence Transformers — compare emails to a template to find the most similar structured email"
+            ],
+            "answer": 1,
+            "explanation": "NER (Named Entity Recognition) is a token-level classification task: each token in the input is assigned an entity label. A fine-tuned BERT NER model on supplier emails would label: 'Samsung [BRAND] Galaxy S24 [PRODUCT] costs $799 [PRICE].' The model outputs IOB2 tags (B-PRODUCT, I-PRODUCT, O, B-PRICE, etc.) which are then post-processed into structured records. This is exactly how companies like Samsara, Flexport, and logistics firms automate document processing. Text Generation (option C) is a valid modern approach using LLMs with structured output, but it requires more expensive models and is less deterministic than a fine-tuned NER model for high-volume, well-defined extraction tasks."
+        },
+        {
+            "id": "d64q05",
+            "type": "multiple_choice",
+            "question": "What is the key difference between tokenization and embeddings, and why do embeddings enable semantic search that keyword search cannot?",
+            "options": [
+                "Tokenization converts text to integers (word IDs); embeddings convert integers back to text — they are inverse operations",
+                "Tokenization splits text into subword tokens and maps them to integer IDs (required for model input); embeddings map those tokens or entire sentences into dense numeric vectors where semantically similar texts are geometrically close — enabling 'angry customer' to match 'frustrated user' even without shared keywords",
+                "Tokenization is fast but inaccurate; embeddings are slow but accurate — you choose based on your latency requirements",
+                "Tokenization handles English text; embeddings are required for multilingual text processing"
+            ],
+            "answer": 1,
+            "explanation": "Tokenization is mechanical: 'unhappy' → ['un', '##happy'] → [1234, 5678]. This is required for model input but discards semantic meaning. Embeddings are learned representations: a sentence encoder maps 'The client is dissatisfied' to a 768-dimensional vector. The crucial property: 'frustrated customer' and 'angry client' map to nearby vectors (high cosine similarity), even though they share no words. Keyword search for 'angry customer' would miss 'frustrated client.' Semantic search with embeddings finds it. This powers modern enterprise search, customer support ticket routing, duplicate detection, and recommendation systems. Sentence Transformers (SBERT) make this accessible in Python with three lines of code."
+        }
+    ]
+}

--- a/content/lessons/Phase_06_Cutting_Edge_ML/Day_65_MLOps_Pipelines_and_CI/quiz.json
+++ b/content/lessons/Phase_06_Cutting_Edge_ML/Day_65_MLOps_Pipelines_and_CI/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 65,
+    "questions": [
+        {
+            "id": "d65q01",
+            "type": "multiple_choice",
+            "question": "Google's famous paper describes ML systems as the 'High-Interest Credit Card of Technical Debt.' Only ~5% of an ML system is model code. What makes up the other 95%, and why does this matter for ML project planning?",
+            "options": [
+                "The other 95% is documentation and testing — ML teams spend most time writing test cases and README files",
+                "The other 95% includes data collection pipelines, data validation, feature stores, serving infrastructure, monitoring, and resource management — underestimating these leads to projects that perform well in notebooks but never reach production, a pattern called 'POC purgatory'",
+                "The other 95% is hyperparameter tuning — finding the optimal model configuration takes far more time than writing the training code",
+                "The other 95% is business analysis and stakeholder meetings — the technical work is actually the smallest part of ML projects"
+            ],
+            "answer": 1,
+            "explanation": "The 'Hidden Technical Debt in ML Systems' paper (Sculley et al., Google, 2015) identified that model code is just the tip of the iceberg. The real cost lies in: data collection pipelines (ETL, streaming), feature engineering and feature stores, data validation (detecting schema drift), experiment tracking, model registry, serving infrastructure (APIs, containers), monitoring (drift detection, performance degradation), and retraining pipelines. This is why 87% of ML models never make it to production (VentureBeat, 2019). MBA teams sponsoring ML projects should budget 3-5x the expected model development time for infrastructure. MLOps addresses this systematically."
+        },
+        {
+            "id": "d65q02",
+            "type": "multiple_choice",
+            "question": "In MLOps, why must you version Code, Data, AND Environment together — and what breaks if you only version the code?",
+            "options": [
+                "Versioning all three is just industry best practice for documentation purposes — missing one only affects auditability, not model performance",
+                "ML results are determined by the intersection of code, data, and environment: the same code on different data or with different library versions (Pandas 1.1 vs 2.0) produces a completely different model — without all three versioned together, you cannot reproduce yesterday's experiment, debug a production failure, or audit a regulatory inquiry",
+                "You only need to version data and environment — code versioning with Git is sufficient for audit trails",
+                "Versioning all three is only necessary for deep learning models; traditional ML models like logistic regression are deterministic and need only code versioning"
+            ],
+            "answer": 1,
+            "explanation": "Reproducibility requires all three components: (1) Code (Git) — the training script. (2) Data (DVC, Delta Lake) — the exact rows used for training, including any preprocessing. A data pipeline that filters differently next month produces a different model. (3) Environment (Docker, conda) — library versions. scikit-learn changed its random state behavior between versions; XGBoost results differ across versions. A model that scored 0.92 AUC on Tuesday might score 0.87 on Wednesday if data was resampled or a library was updated. In regulated industries (banking, healthcare), regulators can demand you reproduce a model from 3 years ago — impossible without all three components versioned."
+        },
+        {
+            "id": "d65q03",
+            "type": "multiple_choice",
+            "question": "What is Continuous Training (CT) in MLOps, and how does it differ from standard CI/CD in software engineering?",
+            "options": [
+                "Continuous Training means the model trains on streaming data 24/7 with no stopping — it is always learning from new inputs",
+                "Standard CI/CD only tests and deploys code changes; CT adds a third trigger: when data distribution drifts or model performance degrades, the pipeline automatically retrains the model on fresh data, re-validates it, and re-deploys — treating the trained model artifact as a deliverable that must also be continuously updated",
+                "Continuous Training is just MLflow's term for experiment tracking — logging all training runs to a central server",
+                "CT is a cloud-specific term for auto-scaling ML training jobs based on data volume"
+            ],
+            "answer": 1,
+            "explanation": "Software CI/CD deploys when code changes. ML systems have an additional degradation vector: the data distribution changes over time (concept drift, data drift) even when the code hasn't changed. A fraud detection model trained in January may degrade in July as fraud patterns evolve. CT addresses this: (1) Monitor production model performance, (2) Detect data drift (PSI, KS test), (3) Trigger retraining when thresholds are crossed, (4) Validate new model on holdout set, (5) Deploy if it beats the incumbent. This 'always-fresh' model is critical for time-sensitive domains: credit scoring, ad CTR prediction, search ranking. Production ML teams at Google, LinkedIn, and Uber retrain key models daily or even hourly."
+        },
+        {
+            "id": "d65q04",
+            "type": "multiple_choice",
+            "question": "Your team uses MLflow to track experiments. A data scientist runs 50 experiments with different hyperparameters. Three months later, the best model underperforms in production. What MLflow capability helps you diagnose why?",
+            "options": [
+                "MLflow's model serving API — it re-runs the model on production data to identify which input patterns cause failures",
+                "MLflow's experiment tracking — you can retrieve the exact hyperparameters, dataset version, metrics (train/validation AUC), and code commit hash for each of the 50 runs, compare them, and identify whether the best-performing experiment on validation set was actually overfit or used stale training data",
+                "MLflow's feature store — it logs all feature transformations so you can identify if production features are computed differently",
+                "MLflow's model registry's Staging environment — re-routing production traffic to the staging model immediately resolves the underperformance"
+            ],
+            "answer": 1,
+            "explanation": "MLflow's core value is experiment reproducibility and comparison. Each tracked run stores: parameters (learning_rate=0.01, max_depth=6), metrics (train_auc=0.95, val_auc=0.91), artifacts (model pickle, feature importances), and tags (git commit hash, data version, user). When a production model underperforms, you can: (1) Pull up all 50 experiments in MLflow UI, (2) Filter by validation AUC, (3) Compare the champion model's validation data timestamp vs. production data timestamp — if 3 months old, it's likely stale. (4) Check if the data version tag shows the exact training dataset, revealing if preprocessing had changed. Without experiment tracking, diagnosing production failures becomes archaeology."
+        },
+        {
+            "id": "d65q05",
+            "type": "multiple_choice",
+            "question": "What is a Feature Store, and why does it solve a critical problem in organizations where multiple ML teams compute the same customer features independently?",
+            "options": [
+                "A Feature Store is a database that stores raw input data before preprocessing — it is simply a centralized data lake for ML teams",
+                "A Feature Store is a centralized repository that computes, stores, and serves features with consistent logic across training and serving: it ensures the 'customer_30d_spend' feature used in fraud detection and the same feature used in churn prediction are computed identically, preventing training-serving skew and duplicated engineering effort",
+                "A Feature Store is MLflow's term for the model registry — it stores trained model artifacts rather than input features",
+                "A Feature Store only matters for real-time ML systems; batch prediction systems do not benefit from centralized feature management"
+            ],
+            "answer": 1,
+            "explanation": "Training-serving skew is a top cause of ML production failures: the fraud model trains on 'customer_avg_transaction_7d' computed one way in Python during training, but production serves a differently computed version from the real-time pipeline. Results degrade silently. Feature Stores (Tecton, Feast, Hopsworks, Databricks Feature Store) solve this: features are defined once with version-controlled logic, computed consistently for both training (historical backfill) and serving (real-time lookup), and shared across teams. Business impact: (1) Feature reuse — 'customer_lifetime_value' defined once, reused by 10 teams; (2) Consistency — training and inference use identical computations; (3) Governance — audit which features each model uses."
+        }
+    ]
+}

--- a/content/lessons/Phase_06_Cutting_Edge_ML/Day_66_Model_Deployment_and_Serving/quiz.json
+++ b/content/lessons/Phase_06_Cutting_Edge_ML/Day_66_Model_Deployment_and_Serving/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 66,
+    "questions": [
+        {
+            "id": "d66q01",
+            "type": "multiple_choice",
+            "question": "A credit card fraud detection system must decide within 200ms whether to approve or decline a transaction. Which serving pattern is required, and why?",
+            "options": [
+                "Batch serving — run fraud checks nightly and flag suspicious accounts for human review the next morning",
+                "Real-time serving via REST API — the fraud model must be called synchronously at transaction time, receive features (merchant, amount, location, velocity), and return a fraud score within the payment processing window before the transaction completes",
+                "Serverless inference — deploy the model as a Lambda function triggered by each transaction event, which introduces too much cold start latency for sub-200ms requirements",
+                "Edge deployment — run the fraud model on the payment terminal device to eliminate network latency entirely"
+            ],
+            "answer": 1,
+            "explanation": "Real-time serving is mandatory when a prediction must influence an in-progress user action. Fraud detection requires: (1) Synchronous call — the payment gateway waits for the fraud score before approving, (2) Sub-200ms latency — Visa's network has strict SLAs, (3) Stateless API — each request is independent with all features in the payload. Batch serving (option A) would mean approving all transactions then flagging fraud afterward — too late, money is already moved. Serverless (option C) has cold start latency (100-500ms) making it marginal for this SLA. Real-time REST APIs with models loaded in memory (FastAPI + Uvicorn) easily achieve <50ms for tabular models. Visa processes 65,000 transactions per second using real-time ML."
+        },
+        {
+            "id": "d66q02",
+            "type": "multiple_choice",
+            "question": "Your data team wants to generate personalized product recommendations for 10 million users to include in tomorrow morning's email campaign. Which serving pattern is most appropriate?",
+            "options": [
+                "Real-time API serving — trigger recommendations when users open their email client to ensure freshness",
+                "Batch serving — run the recommendation model overnight on all 10 million users, store results in a database, and retrieve pre-computed recommendations at email send time without any model inference at send time",
+                "Canary deployment — send recommendations to 5% of users first and measure click-through before sending to all 10 million",
+                "Streaming inference — process each user in a Kafka stream as they become active during the day"
+            ],
+            "answer": 1,
+            "explanation": "Batch serving is ideal when: (1) Predictions are needed for a fixed, known set of items (all 10M users), (2) Freshness requirements are hours, not milliseconds, (3) Computation cost favors pre-computing vs. on-demand. Running the recommendation model overnight produces a 'recommendation table' (user_id → [item_1, item_2, ...]) stored in a fast key-value store (Redis, DynamoDB). Email send just queries pre-computed results — zero model inference latency at send time. Real-time inference for 10M email recipients simultaneously would overwhelm any API serving infrastructure. Batch ML jobs at Google, Netflix, and Spotify generate billions of pre-computed recommendations daily during off-peak hours."
+        },
+        {
+            "id": "d66q03",
+            "type": "multiple_choice",
+            "question": "A team says their ML model works perfectly on their laptop but fails when deployed to production. How does Docker solve this problem, and what is the core principle behind it?",
+            "options": [
+                "Docker compresses the model file for faster network transfer to production servers",
+                "Docker packages the entire runtime environment (OS libraries, Python version, pip packages, model artifacts, FastAPI server code) into a portable container image — 'shipping your machine' so the exact environment that works locally is reproduced identically in production, staging, and any cloud provider",
+                "Docker is a cloud service that automatically scales ML APIs based on request volume, eliminating the need for DevOps engineers",
+                "Docker converts Python models to compiled binaries for 10x faster inference in production"
+            ],
+            "answer": 1,
+            "explanation": "'It works on my machine' is the classic deployment failure. The root cause: environment differences. Your laptop has Python 3.11, numpy 1.26, scikit-learn 1.4, and CUDA 11.8. Production has Python 3.9, numpy 1.23, and no GPU. Docker solves this with containerization: a Dockerfile specifies the exact base image (python:3.11-slim), pip packages (requirements.txt with pinned versions), and application code. Building creates an immutable image. Running the image creates a container with an identical environment everywhere — local, CI/CD, AWS, GCP, on-premise. This is why Docker adoption in ML teams jumped from 15% (2019) to 78% (2023) — reproducible deployments became non-negotiable for production ML."
+        },
+        {
+            "id": "d66q04",
+            "type": "multiple_choice",
+            "question": "What is a Canary Deployment, and why is it the safest approach when rolling out a new version of a high-stakes ML model like a loan approval system?",
+            "options": [
+                "A Canary Deployment is a backup deployment that activates only if the primary model fails — it is a disaster recovery strategy",
+                "A Canary Deployment routes a small percentage (e.g., 5%) of live traffic to the new model version while 95% still uses the old model — if the new model shows degraded performance or unexpected behavior, only 5% of users are affected, and you can roll back instantly before full rollout",
+                "A Canary Deployment tests the model on synthetic 'canary' users who have agreed to receive experimental AI decisions",
+                "A Canary Deployment runs both model versions in parallel and always serves the more conservative (lower-risk) prediction to customers"
+            ],
+            "answer": 1,
+            "explanation": "Named after the 'canary in a coal mine,' canary deployments detect problems before they affect all users. For a loan approval model: new model v2 gets 5% of applicants. If v2 has a bug (e.g., approving high-risk loans at twice the rate), you catch it with 5% blast radius instead of 100%. Monitoring during canary phase: approval rates by risk segment, model latency, error rates, business KPIs (default rates if observable). Tools: Nginx weighted routing, Kubernetes traffic splitting, AWS CodeDeploy, Istio. Compare to Blue-Green deployment (100% instant switchover — less safe for models). Canary is standard practice at Amazon, Netflix, and any company where model errors have financial consequences."
+        },
+        {
+            "id": "d66q05",
+            "type": "multiple_choice",
+            "question": "When should you choose serverless inference (AWS Lambda, Google Cloud Functions) over a persistent FastAPI server for an ML model?",
+            "options": [
+                "Always choose serverless — it is cheaper and faster than maintaining a persistent server for any ML use case",
+                "Choose serverless when traffic is sporadic and unpredictable (e.g., a nightly report that calls the model 100 times then goes quiet for 23 hours) — serverless scales to zero, eliminating idle compute costs; choose persistent servers for high-throughput, latency-sensitive APIs where cold start delay is unacceptable",
+                "Choose serverless only for models smaller than 100MB — larger models cannot fit in Lambda's memory limit",
+                "Serverless is only appropriate for preprocessing pipelines, not for actual model inference"
+            ],
+            "answer": 1,
+            "explanation": "Serverless excels at bursty, infrequent traffic: scale to zero (pay nothing when idle), instant scale-up for bursts, no server management. Tradeoffs: cold start latency (100-500ms for Python runtime initialization + model loading), memory limits (AWS Lambda: up to 10GB RAM, 15-minute timeout), and stateless execution. Use serverless for: nightly batch triggers, webhook handlers, low-volume APIs (<100 req/min), event-driven inference. Use persistent servers (FastAPI + ECS/Kubernetes) for: real-time fraud detection, recommendation APIs, any use case requiring <100ms latency, GPU-based models, or sustained high throughput. The business decision: persistent server costs $500/month idle; serverless costs $0 idle but $X per 1M invocations."
+        }
+    ]
+}

--- a/content/lessons/Phase_06_Cutting_Edge_ML/Day_67_Model_Monitoring_and_Reliability/quiz.json
+++ b/content/lessons/Phase_06_Cutting_Edge_ML/Day_67_Model_Monitoring_and_Reliability/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 67,
+    "questions": [
+        {
+            "id": "d67q01",
+            "type": "multiple_choice",
+            "question": "What is the difference between Data Drift and Concept Drift, and which is harder to detect in a production ML system?",
+            "options": [
+                "Data Drift means the model's code has bugs; Concept Drift means the training data was corrupted — both are detected by running unit tests",
+                "Data Drift (covariate shift) means the input feature distribution changes (e.g., users now submit more mobile transactions vs. desktop); Concept Drift means the relationship between inputs and the correct output changes (e.g., 'buying masks' went from indicating a medical worker to indicating any person post-COVID) — Concept Drift is harder because it requires labeled ground truth to detect, which is often delayed by weeks",
+                "Data Drift is detectable by monitoring model accuracy; Concept Drift is detectable by monitoring input feature statistics — they require different monitoring tools",
+                "Both types of drift are equivalent in practice — detecting one is sufficient to identify either problem"
+            ],
+            "answer": 1,
+            "explanation": "Data Drift is detectable immediately by comparing input distributions: statistical tests (KS test, PSI) flag when today's features look different from training data, with no labels needed. Concept Drift is insidious: the inputs may look normal, but the meaning has changed. A credit model trained pre-COVID vs. post-COVID sees similar features (income, debt ratio) but 'high income + high debt' now means something different (stimulus checks changed behavior). Detecting Concept Drift requires ground truth labels — knowing whether a loan defaulted — which may arrive weeks or months after prediction. This delayed feedback makes Concept Drift the more dangerous and difficult challenge in production ML."
+        },
+        {
+            "id": "d67q02",
+            "type": "multiple_choice",
+            "question": "The Population Stability Index (PSI) for your fraud model's 'transaction_amount' feature shows PSI = 0.28 this month. What action should you take?",
+            "options": [
+                "No action needed — PSI values below 0.5 indicate stable distributions in most financial models",
+                "Retrain the model immediately using the most recent data — PSI > 0.2 indicates significant distribution shift that likely degrades model performance and warrants retraining",
+                "Increase the model's decision threshold from 0.5 to 0.7 to compensate for the distribution shift without retraining",
+                "PSI is only relevant for categorical features — PSI of 0.28 on a continuous feature like transaction amount should be ignored"
+            ],
+            "answer": 1,
+            "explanation": "PSI (Population Stability Index) is an industry-standard drift metric from credit scoring: PSI < 0.1 = no significant change (monitor normally); 0.1 ≤ PSI < 0.2 = moderate shift (investigate); PSI ≥ 0.2 = significant shift (action required, likely retrain). PSI = 0.28 means the transaction amount distribution has shifted substantially from training time — perhaps due to inflation, new merchant categories, or seasonal spending changes. At this level, the model's fraud detection boundaries are likely miscalibrated. Standard practice: investigate root cause, assess model performance on recent labeled data, and retrain on fresh data incorporating the new distribution. Many financial institutions set automated retraining triggers at PSI ≥ 0.2."
+        },
+        {
+            "id": "d67q03",
+            "type": "multiple_choice",
+            "question": "What is a 'silent failure' in production ML, and why is it more dangerous than an obvious API error?",
+            "options": [
+                "A silent failure is when an ML model's API returns HTTP 500 errors without logging — easily fixed by adding error handling",
+                "A silent failure is when a model continues returning predictions that appear valid (proper format, no errors) but are systematically wrong due to drift or data pipeline issues — dangerous because there are no error alarms, dashboards show normal operation, and business decisions are made on degraded predictions for weeks or months before anyone notices",
+                "A silent failure refers to a model that gives correct predictions but has high latency — silent because users don't complain about slow responses",
+                "A silent failure is a model that fails only for rare edge cases, affecting less than 1% of predictions — it is less dangerous than widespread failures"
+            ],
+            "answer": 1,
+            "explanation": "Silent failures are the nightmare scenario of production ML. Unlike a server crash (immediate alert, obvious fix), a silent failure looks normal: the API returns 200 OK, predictions are numeric, logs show no errors. But the model is confidently wrong. Example: a churn model's input pipeline started dropping the 'recent_purchase' feature due to a schema change. The model still returns churn probabilities — using the previous month's feature values from cache. The model looks healthy; business analysts act on stale predictions. Silent failures are detected only by monitoring business outcomes (actual churn vs. predicted), model performance metrics on labeled data, or data quality checks. This is why end-to-end monitoring (not just API health) is critical."
+        },
+        {
+            "id": "d67q04",
+            "type": "multiple_choice",
+            "question": "Your recommendation model's API returns predictions with 500ms latency 10% of the time, causing user-visible slowdowns. Which reliability pattern should you implement to prevent cascading failures across dependent services?",
+            "options": [
+                "Increase the model server's CPU allocation by 4x to reduce latency — hardware scaling is the only reliable solution for latency issues",
+                "Implement a Circuit Breaker pattern: when the error rate or latency exceeds a threshold (e.g., >5% errors in 30 seconds), stop calling the slow ML service and return cached/fallback recommendations instead, allowing the model service to recover without cascading load",
+                "Add a retry mechanism to call the model 3 times if it exceeds 500ms — retries will eventually succeed and are transparent to users",
+                "Switch to synchronous model calls instead of asynchronous calls to reduce the coordination overhead causing the latency spikes"
+            ],
+            "answer": 1,
+            "explanation": "The Circuit Breaker pattern (from Martin Fowler) has three states: (1) Closed — normal operation, all calls go through; (2) Open — error threshold breached, all calls return fallback immediately; (3) Half-Open — after recovery timeout, test with a few requests. For a recommendation API: fallback = show trending/popular items (still useful, just not personalized). Without a circuit breaker: when the model is slow, the mobile app waits 500ms for each of 10 recommendations = 5-second load time. Users abandon. The spike in retries (option C) actually makes cascading failures worse — adding 3x load to an already stressed system. Circuit Breaker trades recommendation quality for site availability, the right tradeoff during outages."
+        },
+        {
+            "id": "d67q05",
+            "type": "multiple_choice",
+            "question": "You deploy a new pricing model and want to validate its business impact before full rollout. You decide to monitor 'average revenue per user' as the primary business metric alongside technical model metrics. Why is monitoring business metrics separately from model metrics (like AUC) essential?",
+            "options": [
+                "Business metrics are monitored by different teams (Finance vs. Engineering) and serve compliance purposes, while model metrics serve technical purposes — they are separate concerns",
+                "A model can have excellent technical metrics (high AUC, low log loss) but poor business outcomes — for example, a pricing model that maximizes predicted conversion probability might recommend prices that are technically 'optimal' but damage brand perception or long-term customer lifetime value, which only business metrics would reveal",
+                "Business metrics are easier to monitor than model metrics because they use existing BI dashboards rather than requiring ML infrastructure",
+                "Model metrics like AUC are leading indicators of business performance — monitoring business metrics separately is redundant since they will always correlate"
+            ],
+            "answer": 1,
+            "explanation": "The Goodhart's Law problem in ML: 'When a measure becomes a target, it ceases to be a good measure.' A pricing model optimized for predicted purchase probability might learn to recommend aggressive discounts that boost short-term conversions but train customers to wait for sales, degrading long-term margin. The model's AUC is excellent (it accurately predicts who will buy at the discounted price), but ARPU and LTV are falling. Business metrics (revenue, margin, churn rate, NPS) measure what actually matters; model metrics measure proxy performance. Both must be monitored independently. Amazon and Booking.com discovered this when recommendation systems maximized CTR but reduced session quality — model metrics looked great, business metrics revealed the problem."
+        }
+    ]
+}

--- a/content/lessons/Phase_06_Cutting_Edge_ML/Day_68_AI_Agents_and_Tool_Use/quiz.json
+++ b/content/lessons/Phase_06_Cutting_Edge_ML/Day_68_AI_Agents_and_Tool_Use/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 68,
+    "questions": [
+        {
+            "id": "d68q01",
+            "type": "multiple_choice",
+            "question": "What is the ReAct (Reason + Act) pattern for AI agents, and why is it more reliable than asking an LLM to answer a multi-step question in a single prompt?",
+            "options": [
+                "ReAct stands for Recursive + Actionable — it breaks complex prompts into sub-prompts and combines their outputs automatically",
+                "ReAct interleaves Thought (reasoning about what to do next), Action (calling a tool), and Observation (reading the result) in a loop — this grounds the agent's reasoning in real external data at each step, preventing hallucination and enabling complex multi-step tasks that single-prompt approaches cannot reliably solve",
+                "ReAct is a React.js framework for building AI agent user interfaces — it separates agent logic from the UI layer",
+                "ReAct is a method for training LLMs with reinforcement learning, using human feedback as the reward signal"
+            ],
+            "answer": 1,
+            "explanation": "Single-prompt LLMs hallucinate when asked multi-step questions requiring real data: 'What is AAPL's current P/E ratio compared to the sector average?' The model guesses from training data (stale). ReAct solves this: Thought: 'I need current AAPL price and earnings' → Action: search_web('AAPL stock P/E ratio') → Observation: 'AAPL P/E = 32.4' → Thought: 'Now I need sector average' → Action: search_web('Technology sector P/E average 2025') → Observation: '28.7' → Final Answer: 'AAPL P/E of 32.4 is 13% above the tech sector average of 28.7.' Each step is grounded in fresh data. This is why production AI agents (AutoGPT, LangChain agents, Claude with tools) use ReAct — reliability requires anchoring reasoning to verified observations."
+        },
+        {
+            "id": "d68q02",
+            "type": "multiple_choice",
+            "question": "When using OpenAI Function Calling (or Claude's tool use), what is the LLM's role vs. the developer's role?",
+            "options": [
+                "The LLM executes the function code directly on its own compute infrastructure; the developer only defines the function signature",
+                "The LLM decides WHICH function to call and WITH WHAT arguments based on the conversation context; the developer writes the actual function code and executes it — the LLM never runs code, it only produces a structured JSON specification of the desired tool call that the developer's code then executes",
+                "The developer provides candidate answers for the LLM to choose between; the LLM selects the most accurate answer using its internal knowledge",
+                "Function calling is only available for OpenAI models — Anthropic and Google models cannot call external functions"
+            ],
+            "answer": 1,
+            "explanation": "This is a critical architectural distinction. When you provide tools to an LLM: (1) Developer defines tool schemas (name, description, parameter types), (2) User sends a message, (3) LLM decides if a tool call is needed and returns a structured JSON: {'function': 'get_stock_price', 'arguments': {'ticker': 'AAPL'}}, (4) Developer's code receives this JSON, executes the actual function (API call, database query, calculation), and returns the result to the LLM, (5) LLM incorporates the observation and continues reasoning. The LLM is the 'brain' choosing what to do; your code is the 'hands' doing it. The LLM has no internet access, cannot make API calls, and cannot execute code — it only generates text that specifies desired actions."
+        },
+        {
+            "id": "d68q03",
+            "type": "multiple_choice",
+            "question": "You build an AI agent to handle customer support tickets. The agent can: search the knowledge base, look up order status, process refunds, and escalate to humans. What is the most important safety constraint to implement?",
+            "options": [
+                "Limit the agent to 5 tool calls per conversation to prevent infinite loops",
+                "Require human approval before any irreversible actions (like processing refunds or cancellations) — read-only actions (knowledge base search, order lookup) can run autonomously, but write actions that affect real customer accounts or financial systems should have a human-in-the-loop confirmation step",
+                "Use the smallest LLM possible for customer support to minimize API costs — smaller models make fewer errors",
+                "Log all agent actions to a database but allow the agent to operate fully autonomously to maximize throughput"
+            ],
+            "answer": 1,
+            "explanation": "The key agent safety principle: separate read (reversible, low-risk) from write (irreversible, high-risk) operations. An agent searching the knowledge base or checking order status carries negligible risk — if it makes a mistake, it just misses information. An agent processing a refund, cancelling a subscription, or modifying account details takes irreversible real-world actions. Best practice: implement a 'human-in-the-loop' gate for write operations. Show the agent's proposed action ('I plan to issue a $89.99 refund to order #12345') and require explicit approval. This pattern is used by Intercom, Zendesk, and Salesforce's AI agents. Fully autonomous write actions require extensive testing, tight permission scopes, and robust rollback mechanisms before deployment."
+        },
+        {
+            "id": "d68q04",
+            "type": "multiple_choice",
+            "question": "What is the key challenge of multi-agent systems where multiple AI agents collaborate on a task, compared to single-agent systems?",
+            "options": [
+                "Multi-agent systems require more API tokens per task — the main challenge is cost optimization",
+                "Multi-agent systems introduce coordination challenges: agents can give conflicting instructions to each other, error propagation across agents compounds small mistakes into large failures, and debugging becomes exponentially harder since you must trace decisions across multiple agents' reasoning chains",
+                "Multi-agent systems are simply parallel single agents — there are no unique challenges beyond scaling infrastructure",
+                "The main challenge is that multiple agents always reach the same conclusion through consensus, limiting the diversity of solutions they can generate"
+            ],
+            "answer": 1,
+            "explanation": "Multi-agent systems unlock parallelism and specialization (a research agent + writing agent + fact-checking agent), but introduce unique failure modes: (1) Error amplification — Agent A misinterprets data and passes the wrong summary to Agent B, which builds a flawed analysis, which Agent C uses for a recommendation — small early errors cascade. (2) Conflicting instructions — two planning agents propose incompatible actions simultaneously. (3) Circular dependencies — Agent A waits for Agent B which waits for Agent A. (4) Debugging complexity — tracing why a final output is wrong requires reconstructing the full chain of agent decisions. Frameworks like LangGraph, AutoGen, and CrewAI provide orchestration patterns (supervisor, peer-to-peer, hierarchical) to manage these challenges."
+        },
+        {
+            "id": "d68q05",
+            "type": "multiple_choice",
+            "question": "Your company wants to use an AI agent to automate competitive intelligence gathering — monitoring competitor websites, analyzing pricing changes, and summarizing insights weekly. What practical constraint makes this agent more complex than it initially appears?",
+            "options": [
+                "LLMs cannot read URLs — all web content must be manually converted to plain text before feeding to the agent",
+                "The agent must handle reliability challenges: websites change structure (breaking scrapers), some sites block bots (requiring rate limiting and fallbacks), content may be behind login walls, and the agent must distinguish factual changes from SEO-optimized noise — robust agents require error handling, retry logic, source validation, and human review of low-confidence findings",
+                "Competitive intelligence is legally protected trade secret information — AI agents cannot legally access competitor public websites",
+                "The agent would need to be retrained weekly to incorporate new competitor information — without retraining, the LLM has stale knowledge"
+            ],
+            "answer": 1,
+            "explanation": "Building production-grade web agents reveals practical challenges beyond the happy path: (1) Web structure changes — a pricing table's HTML changes, your scraper breaks silently. (2) Anti-bot measures — competitors using Cloudflare return CAPTCHAs instead of price data. (3) Rate limiting — aggressive scraping gets your IP blocked. (4) Content quality — press releases ≠ factual claims; filtering signal from noise requires judgment. (5) Source attribution — the agent must track where each insight came from for auditability. (6) Freshness vs. accuracy — a website might not update for months, making 'no change' findings ambiguous. Production competitive intelligence agents at companies like Crayon and Klue address all these with fallback sources, human review queues, and confidence scoring."
+        }
+    ]
+}

--- a/content/lessons/Phase_06_Cutting_Edge_ML/Day_69_Responsible_AI_in_Practice/quiz.json
+++ b/content/lessons/Phase_06_Cutting_Edge_ML/Day_69_Responsible_AI_in_Practice/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 69,
+    "questions": [
+        {
+            "id": "d69q01",
+            "type": "multiple_choice",
+            "question": "What is Demographic Parity as a fairness metric, and in what business context is it the most appropriate standard to apply?",
+            "options": [
+                "Demographic Parity requires that the model achieves equal accuracy across all demographic groups — it is the universal fairness standard for any ML system",
+                "Demographic Parity requires equal positive prediction rates across groups (P(Ŷ=1|A=0) = P(Ŷ=1|A=1)) — most appropriate for contexts like hiring ad targeting or loan marketing where equal access to opportunity is the fairness goal, regardless of underlying qualification rates",
+                "Demographic Parity requires that training datasets contain equal numbers of samples from each demographic group — it is a data collection standard, not a model evaluation metric",
+                "Demographic Parity is the same as Equal Opportunity — both require equalizing true positive rates across groups"
+            ],
+            "answer": 1,
+            "explanation": "Demographic Parity (Statistical Parity) says: the same fraction of each group should receive positive predictions. Example: if 30% of male applicants receive a job interview, 30% of female applicants should too. This is appropriate when the policy goal is equal access regardless of historical qualification gaps (which themselves may reflect systemic bias). However, it has critics: if men genuinely have more programming experience due to historical educational access differences, enforcing equal hiring rates may lower overall hiring quality. The Impossibility Theorem (Chouldechova, 2017) proves you cannot simultaneously satisfy Demographic Parity, Equal Opportunity, and Predictive Parity when base rates differ across groups. Choosing the right metric requires engaging legal counsel and ethicists."
+        },
+        {
+            "id": "d69q02",
+            "type": "multiple_choice",
+            "question": "A bail recommendation algorithm has Equal Opportunity (equal True Positive Rates for actual criminals) but not Demographic Parity. A civil rights group argues this is still discriminatory. What is the source of this disagreement, and why can't both sides be right simultaneously?",
+            "options": [
+                "The disagreement is purely political — both metrics are technically equivalent when sample sizes are large enough",
+                "The Impossibility Theorem: when base rates of recidivism differ between groups, you mathematically cannot achieve both Equal Opportunity (equal TPR) and Demographic Parity (equal positive prediction rates) simultaneously — each metric embodies a different moral theory of fairness, and choosing between them requires a values judgment beyond statistics",
+                "The disagreement can be resolved by using a more powerful model — better algorithms can satisfy all fairness metrics simultaneously",
+                "The civil rights group is wrong — Equal Opportunity is the legally mandated standard in the US, and Demographic Parity is optional"
+            ],
+            "answer": 1,
+            "explanation": "This is the famous COMPAS recidivism controversy. ProPublica found COMPAS violated Demographic Parity (Black defendants labeled higher risk at 2x the rate of white defendants). Northpointe (the vendor) showed COMPAS satisfied Predictive Parity (risk scores equally calibrated across races — a score of 7 means ~70% recidivism for both groups). Both were simultaneously true and both were valid criticisms. Chouldechova (2017) proved mathematically that if recidivism base rates differ between groups, you cannot achieve both metrics at once. The choice between them is a moral judgment: do we prioritize equal calibration (individual fairness) or equal outcomes (group fairness)? This is why AI ethics requires philosophers, legal scholars, and community stakeholders — not just data scientists."
+        },
+        {
+            "id": "d69q03",
+            "type": "multiple_choice",
+            "question": "What is a Model Card, and why has it become a standard best practice for responsible AI deployment at companies like Google and Hugging Face?",
+            "options": [
+                "A Model Card is a summary of a model's hyperparameters and training infrastructure — it is a technical reference document for ML engineers",
+                "A Model Card is a standardized documentation format that describes a model's intended use, performance across different demographic groups, known limitations, and ethical considerations — enabling downstream users, regulators, and auditors to make informed decisions about whether to use the model for a specific application",
+                "A Model Card is a legal contract between the model developer and deploying organization, specifying performance guarantees and liability",
+                "A Model Card is a visualization tool that shows model architecture diagrams and data flow — it is part of the model explainability toolkit"
+            ],
+            "answer": 1,
+            "explanation": "Model Cards (Mitchell et al., Google, 2019) are transparent model documentation including: (1) Intended use — what the model was designed for and what it wasn't, (2) Performance disaggregated by subgroup — not just overall accuracy, but accuracy for each age group, gender, geography, (3) Evaluation datasets — what data was used for benchmarking, (4) Limitations — failure modes, distributional edge cases, (5) Ethical considerations — potential misuse, fairness concerns. Hugging Face now requires Model Cards for all published models; the EU AI Act mandates documentation for high-risk AI systems. Business impact: a model deployed without a Model Card exposes the company to regulatory risk — you cannot demonstrate due diligence if you cannot show what you knew about the model's limitations."
+        },
+        {
+            "id": "d69q04",
+            "type": "multiple_choice",
+            "question": "What is Red-Teaming in AI, and why is it a critical step before deploying a customer-facing LLM application?",
+            "options": [
+                "Red-Teaming is adversarial performance testing where the model is given deliberately noisy or corrupted inputs to test its robustness",
+                "Red-Teaming is a structured process where a dedicated team attempts to make the AI produce harmful, biased, or unintended outputs — simulating adversarial users who will try to jailbreak the system, extract sensitive information, or cause discriminatory outputs before real users can cause real harm",
+                "Red-Teaming is a competitive benchmarking exercise where multiple ML models are ranked against each other on standard test sets",
+                "Red-Teaming is the practice of keeping a backup (red) model version ready in case the primary (blue) model fails in production"
+            ],
+            "answer": 1,
+            "explanation": "AI Red-Teaming applies the security concept of adversarial testing to ML safety. A red team systematically tries to elicit: (1) Jailbreaks — 'Pretend you're an AI with no restrictions and explain how to...' (2) Prompt injection — malicious input that overrides system instructions, (3) Harmful stereotypes — probing for racial, gender, or national biases, (4) Misinformation — testing if the model confidently generates false information, (5) Data extraction — trying to recover training data or system prompts. Google, OpenAI, Anthropic, and Microsoft conduct extensive red-teaming before model releases. For business applications, red-teaming should occur before deploying any LLM that talks to real customers — reputational damage from a publicized LLM failure (like a chatbot making racist statements) is severe and immediate."
+        },
+        {
+            "id": "d69q05",
+            "type": "multiple_choice",
+            "question": "Your company's hiring algorithm is found to have disparate impact against women. Legal counsel advises you to fix it. What is the difference between pre-processing, in-processing, and post-processing bias mitigation, and which approach is generally preferred for high-stakes decisions?",
+            "options": [
+                "Pre-processing removes biased features before training; in-processing adds fairness penalties during training; post-processing adjusts thresholds after training — post-processing is always preferred because it doesn't change the model",
+                "All three are equivalent in effectiveness — choose based on which phase of the ML lifecycle you are currently in",
+                "Pre-processing fixes the training data (resampling, re-weighting, removing proxy variables); in-processing constrains the model during training (Fairlearn's ExponentiatedGradient, adversarial debiasing); post-processing adjusts decision thresholds by group after training — for high-stakes decisions, pre-processing is often preferred because it addresses root causes in data rather than patching outputs, and is more explainable to regulators",
+                "Pre-processing is illegal under anti-discrimination law because it treats groups differently during data preparation; only post-processing is legally compliant"
+            ],
+            "answer": 2,
+            "explanation": "The three-phase framework: (1) Pre-processing (upstream fix): rebalance training data, remove proxy variables, use fairness-aware data augmentation. Pros: addresses root cause, model itself is fair. (2) In-processing (constrained training): add fairness constraints (e.g., demographic parity constraint) to the loss function. Pros: jointly optimizes accuracy and fairness. Cons: more complex training. (3) Post-processing (output adjustment): apply different decision thresholds per group to equalize outcomes. Pros: easy to implement without retraining. Cons: explicitly treats groups differently in decisions, which may raise legal concerns depending on jurisdiction. Regulators generally prefer pre-processing because it demonstrates the organization took fairness seriously throughout the development process, not as an afterthought. IBM's AI Fairness 360 toolkit provides all three approaches."
+        }
+    ]
+}

--- a/content/lessons/Phase_06_Cutting_Edge_ML/Day_70_LLM_Fine_Tuning_and_PEFT/quiz.json
+++ b/content/lessons/Phase_06_Cutting_Edge_ML/Day_70_LLM_Fine_Tuning_and_PEFT/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 70,
+    "questions": [
+        {
+            "id": "d70q01",
+            "type": "multiple_choice",
+            "question": "Why is full fine-tuning of a large language model like GPT-3 (175B parameters) impractical for most organizations, and what problem does PEFT solve?",
+            "options": [
+                "Full fine-tuning requires proprietary training data that most organizations cannot access; PEFT provides a way to train without private data",
+                "Full fine-tuning of a 175B model requires ~350GB GPU VRAM, weeks of training, and costs $100,000+ — prohibitive for all but the largest tech companies; PEFT (Parameter-Efficient Fine-Tuning) trains only a tiny fraction of new parameters while keeping the original model frozen, achieving comparable results with a fraction of the compute and cost",
+                "Full fine-tuning permanently modifies the base model making it unusable for other tasks; PEFT preserves multitasking by training only output layers",
+                "Full fine-tuning is deprecated by OpenAI and Anthropic — PEFT is the only supported customization method for modern LLMs"
+            ],
+            "answer": 1,
+            "explanation": "The compute economics of LLM fine-tuning: GPT-3 (175B parameters) at float16 requires ~350GB VRAM just for the model weights — you'd need 5+ A100 80GB GPUs minimum, costing $30-50/hour in cloud compute, running for weeks = $100K+. Most organizations have 0-2 GPUs. PEFT methods address this by: (1) Freezing the original model weights (no gradient updates needed for billions of parameters), (2) Adding a small number of trainable parameters (adapters, low-rank matrices), (3) Training only these new parameters — often <1% of total model size. LoRA on a 7B model can run on a single RTX 3090 (24GB) in hours for ~$10. This democratized LLM customization, enabling startups and enterprises alike to build domain-specific models."
+        },
+        {
+            "id": "d70q02",
+            "type": "multiple_choice",
+            "question": "LoRA (Low-Rank Adaptation) decomposes the weight update ΔW into two small matrices A×B. If a weight matrix W is 4096×4096 (16.7M parameters) and LoRA uses rank r=8, how many trainable parameters does LoRA add, and why is this mathematically sound?",
+            "options": [
+                "LoRA adds 16.7M parameters — equal to the original matrix — because it must match the original dimension for the addition W_new = W + ΔW to work",
+                "LoRA adds (4096×8) + (8×4096) = 65,536 parameters — less than 0.4% of the original — and is mathematically sound because weight updates in pre-trained models tend to have low intrinsic rank, meaning they can be well-approximated by the product of two smaller matrices",
+                "LoRA adds 8 parameters — one scalar weight per rank dimension — because rank decomposition reduces any matrix to its singular values",
+                "LoRA cannot be applied to matrices larger than 1024×1024 — for larger matrices, QLoRA must be used instead"
+            ],
+            "answer": 1,
+            "explanation": "LoRA's math: instead of updating W (d×k = 4096×4096 = 16.7M params), learn ΔW = A×B where A is (d×r = 4096×8) and B is (r×k = 8×4096). Total new params = 4096×8 + 8×4096 = 32,768 + 32,768 = 65,536. That's 0.4% of the original. The theoretical justification (Aghajanyan et al., 2020): LLM weight updates during fine-tuning have low 'intrinsic dimensionality' — the meaningful changes live in a much lower-dimensional subspace than the full matrix. Empirically confirmed: LoRA with r=4–16 matches full fine-tuning performance on most tasks. At inference, A×B is merged back into W with zero latency overhead. This insight transformed practical LLM deployment — the original LoRA paper has 5,000+ citations."
+        },
+        {
+            "id": "d70q03",
+            "type": "multiple_choice",
+            "question": "What is QLoRA, and how does it make fine-tuning a 70B parameter model feasible on a single consumer GPU?",
+            "options": [
+                "QLoRA (Quantized LoRA) is a method that quantizes the LoRA adapter weights from float32 to int4 during training, reducing gradient computation costs",
+                "QLoRA combines 4-bit quantization of the frozen base model (reducing its memory footprint by ~4x) with LoRA adapters trained in full precision — making a 70B model's frozen weights fit in ~40GB instead of ~140GB, enabling fine-tuning on a single A100 GPU that would otherwise require 4+ GPUs",
+                "QLoRA is identical to LoRA but uses a different optimizer (Q-Adam) that requires less memory than Adam",
+                "QLoRA stands for Quick LoRA — it achieves identical results to standard LoRA but trains 4x faster by skipping matrix multiplication for zero-valued entries"
+            ],
+            "answer": 1,
+            "explanation": "QLoRA (Dettmers et al., 2023) achieved a landmark result: fine-tuning a 65B LLaMA model on a single 48GB GPU. The key innovations: (1) 4-bit NormalFloat (NF4) quantization — store the frozen base model in 4 bits instead of 16, reducing memory by 4x. A 70B model at float16 = ~140GB; at NF4 = ~35GB. (2) Double quantization — even quantize the quantization constants, saving another ~0.5 bits per parameter. (3) Paged Optimizer — use CPU RAM for optimizer states that don't fit on GPU. LoRA adapters are still trained in full bfloat16 precision, so gradient updates are accurate. The result: 'fine-tune a model that would need 8 GPUs on 1 GPU for 1/8 the cost.' This paper had extraordinary practical impact — it enabled the open-source LLM fine-tuning community to flourish."
+        },
+        {
+            "id": "d70q04",
+            "type": "multiple_choice",
+            "question": "What is Instruction Tuning, and how does it transform a base LLM (which predicts next tokens) into a useful assistant that follows user instructions?",
+            "options": [
+                "Instruction Tuning is the process of adding special instruction tokens (<<SYS>>, [INST]) to the tokenizer vocabulary — it is a tokenization technique, not a training technique",
+                "Instruction Tuning fine-tunes the base model on a dataset of (instruction, response) pairs — teaching it to follow the format 'when a user asks X, produce a helpful Y response' rather than just continuing text, transforming a document-completion model into an instruction-following assistant",
+                "Instruction Tuning is only applicable to decoder-only models — BERT-based models are instruction-tuned by default during pre-training",
+                "Instruction Tuning requires RLHF (Reinforcement Learning from Human Feedback) — you cannot do instruction tuning without human preference data"
+            ],
+            "answer": 1,
+            "explanation": "Base LLMs (GPT-3, LLaMA before fine-tuning) are trained to predict the next token in a document — they continue text, not follow instructions. Given 'Write an email about Q3 results,' a base model might continue with 'company performance metrics showing...' as if completing an article. Instruction tuning (InstructGPT, 2022) trains on examples like: Input: 'Write a professional email summarizing Q3 revenue growth of 15%.' Output: 'Dear team, I'm pleased to share our Q3 results...' With thousands of such pairs, the model learns the instruction-following format. This transformed GPT-3 into ChatGPT. For business use cases, instruction tuning on company-specific examples (internal data analysis requests, reporting templates, customer service scripts) customizes the model to your organization's conventions and tone."
+        },
+        {
+            "id": "d70q05",
+            "type": "multiple_choice",
+            "question": "Your company wants to customize an LLM for analyzing financial reports using its proprietary terminology. You have 50,000 labeled examples and need the model to stay current with new reports. Should you use fine-tuning (LoRA) or RAG (Retrieval-Augmented Generation), and why?",
+            "options": [
+                "Always use fine-tuning — RAG is too slow for production financial analysis requiring real-time responses",
+                "Always use RAG — fine-tuning is too expensive for any business application",
+                "Use fine-tuning (LoRA) to teach the model your terminology, writing style, and analysis format (knowledge baked into weights); use RAG to provide up-to-date document content at query time (knowledge retrieved dynamically) — the best production systems often combine both: fine-tune for style/format, RAG for current content",
+                "Use fine-tuning only — RAG cannot handle financial documents because it requires structured data, not unstructured PDFs"
+            ],
+            "answer": 2,
+            "explanation": "Fine-tuning vs. RAG is a common architectural decision: Fine-tuning bakes knowledge into model weights — good for teaching consistent style ('our internal definition of EBITDA adjustment'), output format (report structure), and domain vocabulary. It does NOT help with freshness — a model fine-tuned in January doesn't know about February's earnings. RAG provides dynamic knowledge retrieval — when Q2 earnings arrive, you add them to the vector database; the model immediately has access without retraining. The optimal architecture combines both: (1) Fine-tune for format/style/domain knowledge, (2) RAG for current document retrieval. For your financial analysis use case: fine-tune on 50K historical analyses to learn your firm's methodology, then RAG to retrieve relevant sections of each new 10-K filing at query time. This is how Bloomberg's BloombergGPT architecture works."
+        }
+    ]
+}

--- a/content/lessons/Phase_06_Cutting_Edge_ML/Day_71_RAG_and_Vector_Databases/quiz.json
+++ b/content/lessons/Phase_06_Cutting_Edge_ML/Day_71_RAG_and_Vector_Databases/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 71,
+    "questions": [
+        {
+            "id": "d71q01",
+            "type": "multiple_choice",
+            "question": "What problem does Retrieval-Augmented Generation (RAG) solve that a standard LLM cannot address?",
+            "options": [
+                "RAG solves the hallucination problem entirely — an LLM with RAG will never generate false information",
+                "Standard LLMs have a training cutoff and cannot access private/proprietary data; RAG solves this by retrieving relevant documents from an external knowledge base at query time, grounding the LLM's response in current, domain-specific content that was never part of training",
+                "RAG makes LLMs faster by caching frequently asked questions and returning pre-computed answers",
+                "RAG replaces the need for fine-tuning — it teaches the model new skills by providing examples in the retrieved context"
+            ],
+            "answer": 1,
+            "explanation": "Standard LLMs have two fundamental limitations: (1) Knowledge cutoff — a model trained through 2024 cannot answer questions about 2025 events. (2) No private data access — GPT-4 cannot read your internal HR policies, sales contracts, or product documentation. RAG addresses both: at query time, the user's question is embedded into a vector, similar document chunks are retrieved from your vector database, and those chunks are injected into the LLM's prompt as context. The model answers based on the retrieved content, not just its weights. RAG is the standard architecture for enterprise LLM applications: customer support chatbots (retrieve from knowledge base), legal research tools (retrieve from case documents), and internal Q&A systems (retrieve from Confluence/Slack)."
+        },
+        {
+            "id": "d71q02",
+            "type": "multiple_choice",
+            "question": "What is a text embedding, and what geometric property makes it useful for semantic search?",
+            "options": [
+                "A text embedding is a compressed version of text that reduces storage requirements while preserving all original characters",
+                "A text embedding maps text to a dense numeric vector (e.g., 768 dimensions) in a space where semantically similar texts are geometrically close — 'unhappy customer' and 'dissatisfied client' map to nearby vectors (high cosine similarity), enabling semantic search that finds relevant content even without keyword overlap",
+                "A text embedding is an index structure that enables O(log n) exact keyword matching across millions of documents",
+                "A text embedding is a probability distribution over a vocabulary that represents word frequency in a document — similar to TF-IDF but computed by neural networks"
+            ],
+            "answer": 1,
+            "explanation": "Embedding models (BERT, Sentence Transformers, OpenAI text-embedding-3) encode text into high-dimensional vectors with a critical geometric property: semantic similarity corresponds to vector proximity. 'Revenue declined' and 'Sales decreased' land near each other in vector space even though they share no words. This enables semantic search: embed the query, find the closest document vectors (nearest neighbor search), retrieve those documents. Compare to keyword search (Elasticsearch, CTRL+F): searching for 'client satisfaction' misses documents about 'customer happiness.' In practice, embedding quality directly determines RAG quality — better embeddings = better retrieval = better final answers. Evaluation: use metrics like NDCG (ranking quality) and Hit Rate (did the right document appear in top-k results)."
+        },
+        {
+            "id": "d71q03",
+            "type": "multiple_choice",
+            "question": "Why do RAG systems chunk documents rather than embedding entire documents at once, and what is the tradeoff in chunk size?",
+            "options": [
+                "Chunking is required because embedding models have a maximum token limit (e.g., 512 tokens for many models) and cannot process longer texts; it is purely a technical constraint with no quality implications",
+                "Chunking splits documents into smaller pieces for embedding because: (1) embedding a full 50-page report produces one vector that averages out all topics, making retrieval imprecise; (2) smaller chunks enable retrieval of the specific section relevant to a query. Smaller chunks = more precise retrieval but risk losing surrounding context; larger chunks = more context but noisier embeddings — the optimal size depends on document structure",
+                "Chunking is an optimization technique that reduces vector database storage costs by deduplicating redundant content across documents",
+                "Chunking is only needed for very large documents (>100 pages) — short documents under 10 pages should always be embedded as a single unit"
+            ],
+            "answer": 1,
+            "explanation": "Chunking strategy is one of the most impactful RAG design decisions. Imagine embedding a 50-page annual report as one vector: a query about 'R&D spending' gets the single company vector, not the specific paragraph about R&D. By chunking into 200-500 token pieces, each chunk's embedding captures one specific topic. Tradeoffs: (1) Small chunks (50-100 tokens): very precise retrieval, but may miss context (a sentence mentioning 'costs' without surrounding explanation), (2) Large chunks (500-1000 tokens): more contextual, but the embedding averages many topics — 'what was the revenue?' might retrieve a chunk primarily about expenses that happens to mention revenue. Advanced approaches: recursive chunking (respect document structure), sliding window with overlap (each chunk shares context with neighbors), and semantic chunking (split at topic boundaries detected by embeddings)."
+        },
+        {
+            "id": "d71q04",
+            "type": "multiple_choice",
+            "question": "What is Approximate Nearest Neighbor (ANN) search, and why is it used in vector databases instead of exact nearest neighbor search for production RAG systems?",
+            "options": [
+                "ANN search is a newer algorithm that achieves exact nearest neighbor results — 'approximate' refers to the approximation of the distance metric, not the results",
+                "Exact nearest neighbor requires comparing a query vector to every document vector (O(n) complexity) — with 10 million documents, this takes seconds per query. ANN algorithms like HNSW and IVF trade a small accuracy loss (occasionally missing the #1 closest vector) for sub-millisecond search across millions of vectors, making production-scale semantic search feasible",
+                "ANN search is used because embedding vectors are probabilistic and exact distance comparisons are mathematically undefined",
+                "ANN is required for cosine similarity; exact nearest neighbor can only compute Euclidean distance"
+            ],
+            "answer": 1,
+            "explanation": "The scaling problem: exact nearest neighbor search computes the dot product between your query vector and every stored vector. At 10M documents × 768 dimensions, that's 7.68 billion float multiplications per query — taking 2-10 seconds on a CPU. Unacceptable for real-time RAG. ANN algorithms use data structures that dramatically prune the search space: (1) HNSW (Hierarchical Navigable Small World): a graph structure enabling greedy search in O(log n) time, (2) IVF (Inverted File Index): clusters vectors and only searches relevant clusters. Trade-off: occasionally the true nearest neighbor is in a cluster that wasn't searched — typically <1% accuracy loss. Pinecone, Weaviate, Chroma, and Qdrant all use ANN under the hood. In practice, retrieving the top-10 relevant chunks via ANN in 5ms is far more valuable than getting the exact top-10 in 5 seconds."
+        },
+        {
+            "id": "d71q05",
+            "type": "multiple_choice",
+            "question": "You build a RAG system for your company's legal contract database. Users ask questions and get answers, but the system frequently hallucinates contract terms that don't exist. What is the most likely root cause and fix?",
+            "options": [
+                "The LLM needs to be fine-tuned on legal language — the hallucinations are caused by the base model's lack of legal domain knowledge",
+                "Poor retrieval quality — the system is not finding the relevant contract clauses, so the LLM receives irrelevant context and fills gaps with hallucination; fix by improving embeddings (use a legal-domain embedding model), chunking strategy (preserve contract clause structure), and adding a re-ranking step to select the most relevant retrieved chunks",
+                "The vector database needs more memory — hallucinations occur when ANN search times out and returns random results",
+                "The chunking overlap is too large — overlapping chunks confuse the LLM by providing redundant context that triggers creative generation"
+            ],
+            "answer": 1,
+            "explanation": "In RAG systems, hallucinations are almost always a retrieval problem, not an LLM problem. If the retrieved context contains the correct answer, modern LLMs rarely hallucinate — they just quote the context. If retrieval fails (returns irrelevant clauses), the LLM has no relevant information and either says 'I don't know' (good behavior) or confidently invents an answer (hallucination). Diagnosis: evaluate retrieval quality independently — given 50 test questions with known correct source clauses, what fraction of the time does the retrieval find the right clause in top-3? Below 80% indicates a retrieval problem. Fixes: (1) Domain-specific embedding model (legal-BERT > general BERT for legal text), (2) Better chunking (split at clause boundaries, not fixed token counts), (3) Cross-encoder re-ranking (slow but accurate second-stage ranking), (4) Metadata filtering (only search clauses from the specific contract)."
+        }
+    ]
+}

--- a/content/lessons/Phase_06_Cutting_Edge_ML/Day_72_Multimodal_AI/quiz.json
+++ b/content/lessons/Phase_06_Cutting_Edge_ML/Day_72_Multimodal_AI/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 72,
+    "questions": [
+        {
+            "id": "d72q01",
+            "type": "multiple_choice",
+            "question": "What is a Vision-Language Model (VLM), and what makes it fundamentally different from a text-only LLM?",
+            "options": [
+                "A VLM is a text LLM that has been given access to an image search API — it finds similar images online rather than processing images directly",
+                "A VLM processes both images and text in a unified architecture — it encodes images into the same embedding space as text, enabling the model to reason about visual content (charts, photos, documents, screenshots) alongside textual context in a single forward pass",
+                "A VLM is a specialized computer vision model (like ResNet) that has been expanded with a language decoder for generating captions — it cannot engage in multi-turn conversation about images",
+                "A VLM is identical to a text LLM but trained exclusively on image captions rather than web text"
+            ],
+            "answer": 1,
+            "explanation": "VLMs (GPT-4o, Gemini, Claude 3.5 Sonnet, LLaVA) accept multimodal inputs in a unified architecture. The key innovation: images are converted into visual tokens or embeddings by a vision encoder (often a ViT — Vision Transformer), then projected into the same embedding space as text tokens. The LLM then processes a sequence containing both visual and text embeddings, enabling it to: analyze charts and graphs, read text in images (OCR), describe scenes, answer questions about product photos, understand diagrams. This is not image search — the model directly processes pixel-level information. The practical impact: a single API call can now extract data from a scanned invoice, explain a complex dashboard screenshot, or analyze competitor product photos."
+        },
+        {
+            "id": "d72q02",
+            "type": "multiple_choice",
+            "question": "Your operations team receives thousands of supplier invoices as PDF scans monthly. Currently, data entry clerks manually type invoice data into your ERP system. How would a multimodal AI system transform this process, and what accuracy benchmark should you establish before deployment?",
+            "options": [
+                "Multimodal AI cannot process scanned PDFs because they are images, not structured text — you would need OCR software to convert scans to text first before any AI processing",
+                "A VLM can directly process invoice images and extract structured data (vendor name, date, line items, amounts, tax) in a single API call; before deployment, benchmark against 200+ manually verified invoices to measure field-level extraction accuracy, and require >95% accuracy with human review for flagged low-confidence extractions",
+                "Multimodal AI processes invoices faster than humans but always requires human verification of every field — it provides speed without accuracy improvement",
+                "The best approach is to use a specialized invoice OCR tool (AWS Textract, Google Document AI) rather than a general-purpose VLM, as VLMs are not designed for document extraction"
+            ],
+            "answer": 1,
+            "explanation": "Document AI is one of the highest-ROI multimodal use cases. VLMs can extract structured data from unstructured invoice images: {vendor: 'ACME Corp', date: '2025-03-15', total: 4850.00, line_items: [{description: 'Cloud services', qty: 1, unit_price: 4850.00}]}. Modern VLMs (GPT-4o, Claude 3.5 Sonnet) achieve 95-99% field-level accuracy on standard invoice formats. Deployment best practices: (1) Start with a benchmark set of 200+ invoices with verified ground truth, (2) Measure per-field accuracy (vendor name, amount, date separately), (3) Implement confidence scoring — flag low-confidence extractions for human review, (4) Maintain a rejection rate target (flag <10% for human review while catching >99% of errors). Companies using this pattern report 80-90% reduction in manual data entry for invoice processing."
+        },
+        {
+            "id": "d72q03",
+            "type": "multiple_choice",
+            "question": "What are image embeddings, and how do they enable reverse image search (finding similar products from a photo) in an e-commerce platform?",
+            "options": [
+                "Image embeddings are compressed versions of images that reduce file size for faster loading — they are used for CDN optimization, not search",
+                "Image embeddings map images to dense numeric vectors (like text embeddings) where visually similar images are geometrically close — a photo of a red leather handbag maps to a vector near other red leather handbag images; reverse image search finds products with the highest cosine similarity to the query image's embedding",
+                "Image embeddings are metadata tags (color, shape, category) extracted from images by computer vision models and stored in a relational database",
+                "Image embeddings require the image to contain text (labels, SKU numbers) — they extract text from images for indexing in a text search engine"
+            ],
+            "answer": 1,
+            "explanation": "CLIP (Contrastive Language-Image Pre-training, OpenAI) and similar models learn a shared embedding space for images and text: an image of a red sneaker and the text 'red running shoes' map to nearby vectors. This enables: (1) Image-to-image search: embed a customer's photo of a product they want → find closest product images in your catalog. (2) Text-to-image search: 'casual blue summer dress' → find matching product images without keyword tags. (3) Cross-modal retrieval: search your image library using text descriptions. Implementation: encode product catalog images once with CLIP, store in a vector database (Pinecone, Qdrant), at query time embed the user's uploaded photo and return top-k similar products. Pinterest's 'Shop the Look' and IKEA's visual search use exactly this architecture."
+        },
+        {
+            "id": "d72q04",
+            "type": "multiple_choice",
+            "question": "What is Multimodal RAG, and how does it extend standard text-based RAG for use cases like analyzing a company's annual reports that contain charts, tables, and text?",
+            "options": [
+                "Multimodal RAG is identical to standard RAG but uses a larger chunk size to accommodate image file sizes",
+                "Multimodal RAG stores and retrieves both text chunks and image embeddings — when a user asks 'What does the revenue trend chart show?', the system retrieves the relevant chart image alongside text context and passes both to a VLM to generate an answer grounded in the actual visual content",
+                "Multimodal RAG converts all images to text descriptions using OCR before indexing — it is text-only RAG applied to documents that happen to contain images",
+                "Multimodal RAG is only appropriate for databases that contain exclusively images — it cannot handle mixed text-and-image documents"
+            ],
+            "answer": 1,
+            "explanation": "Standard RAG embeds text chunks and retrieves text. But annual reports, technical manuals, and research papers contain critical information in charts, graphs, and tables that cannot be captured by text extraction alone — a revenue bar chart's trend is not conveyed by the surrounding caption text. Multimodal RAG: (1) Index phase: extract text chunks AND store images/diagrams with their embeddings (using CLIP or VLM-generated descriptions), (2) Retrieval phase: query retrieves both relevant text chunks AND relevant images, (3) Generation phase: pass retrieved text + retrieved images to a VLM — it can read the chart directly and integrate with text context. This is how enterprises build 'ask your annual report' or 'ask your manual' systems. GPT-4o's ability to process 10+ images in a single context window makes this practical."
+        },
+        {
+            "id": "d72q05",
+            "type": "multiple_choice",
+            "question": "A retail company wants to automate product catalog quality control using VLMs — automatically flagging product images that have poor lighting, missing backgrounds, or text overlaid on images. What is the most important consideration before deploying this at scale?",
+            "options": [
+                "VLMs cannot assess image quality — they only understand image content (objects, scenes) but cannot evaluate technical photography attributes",
+                "Cost management — processing 1 million product images at VLM API rates can cost thousands of dollars; validate that the business value (reduced manual QC labor) exceeds the inference cost, and consider a tiered approach: fast/cheap model for initial screening, expensive VLM only for borderline cases",
+                "The VLM must be fine-tuned on your specific product catalog before deployment — off-the-shelf VLMs have no knowledge of retail photography standards",
+                "You must obtain consent from the photographers whose images you are processing through the VLM API, as image analysis constitutes processing of copyrighted creative works"
+            ],
+            "answer": 1,
+            "explanation": "Scaling multimodal AI to millions of images introduces real cost economics that must be evaluated before deployment. At GPT-4o pricing (~$0.01/image for standard resolution), 1 million images = $10,000/run. If your catalog updates 100K products daily, that's $1,000/day just for image QC API costs. The tiered approach is standard practice: (1) Tier 1: fast, cheap rule-based checks (image dimensions, file size, aspect ratio) — eliminates 70% of obvious failures, (2) Tier 2: small/cheap vision model (MobileNet, ViT-B) for binary quality assessment, (3) Tier 3: VLM API only for ambiguous cases requiring nuanced judgment (~5-10% of images). This reduces VLM costs by 90%+ while maintaining quality. Before any production deployment, calculate: QC labor cost saved vs. VLM API cost, then build the tier architecture to achieve target ROI."
+        }
+    ]
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `quiz.json` files for all 12 Phase 6 lessons (Days 61–72), completing quiz coverage for the **Cutting-Edge ML** phase
- Each quiz has 5 MBA-contextualized multiple-choice questions with 4 options, 0-indexed answers, and detailed explanations grounded in real business scenarios
- Follows the identical format and quality bar established by Phases 1–5 and Phase 10

## Lessons Covered

| Day | Topic |
|-----|-------|
| 61 | Reinforcement & Offline Learning |
| 62 | Model Interpretability & Fairness |
| 63 | Causal Inference & Uplift |
| 64 | Modern NLP Pipelines |
| 65 | MLOps Pipelines & CI |
| 66 | Model Deployment & Serving |
| 67 | Model Monitoring & Reliability |
| 68 | AI Agents & Tool Use |
| 69 | Responsible AI in Practice |
| 70 | LLM Fine-Tuning & PEFT |
| 71 | RAG & Vector Databases |
| 72 | Multimodal AI |

## Test plan

- [ ] Verify all 12 `quiz.json` files parse as valid JSON
- [ ] Confirm question IDs follow `d<day>q<n>` convention (e.g. `d61q01`)
- [ ] Confirm each quiz has exactly 5 questions with 4 options and a valid `answer` index (0–3)
- [ ] Spot-check answer correctness and explanation accuracy against lesson README content
- [ ] Run existing content validation script (`npm run validate-content`) to confirm no schema violations

https://claude.ai/code/session_01RsH6rWDsEzZHpShtNUJX87
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsH6rWDsEzZHpShtNUJX87)_