### PR TITLE
docs: generate gap analysis for phase 01 curriculum

### DIFF
--- a/docs/gap-analysis/Phase_01_Algorithmic_Thinking_Python_Foundations.md
+++ b/docs/gap-analysis/Phase_01_Algorithmic_Thinking_Python_Foundations.md
@@ -1,0 +1,236 @@
+# Gap Analysis — Phase 01: Algorithmic Thinking & Python Foundations
+
+> Audited against the Phase 1 Quality Bar. See [GAP_ANALYSIS.md](../../GAP_ANALYSIS.md) for the full rubric, gap taxonomy, and severity legend.
+
+## Phase summary
+
+Phase 01 serves as the gold standard for the curriculum. A deep audit reveals that while the core pedagogical narrative (the "Never-Coded" bridge, business framing) is incredibly strong, there is a consistent structural debt across almost all lessons. Specifically, Mastery Check answers lack `<details>` collapsing tags, and there is a systemic omission of Glossary sections and explicit Expected Outputs in the Hands-on Labs. The lessons are fundamentally excellent, but they require systematic structural formatting to achieve the true "Quality Bar".
+
+**Recurring gaps in this phase:**
+- [G:Mastery] Mastery Check answers are consistently left un-collapsed.
+- [C:Lab] Hands-on Lab exercises frequently drop bare code or goals without providing exact `Expected Output` blocks.
+- [O:Glossary] Missing explicit `## Glossary` of key terms section across the board.
+
+**Lessons audited:** 14
+
+---
+
+## Day 01 — Introduction to Python
+
+**Path:** `content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_01_Introduction/README.md`
+
+**Assessment:** The lesson opens strong with 'To a computer, code is just text', establishing an excellent conceptual baseline. The 'Coffee Shop Analogy' effectively maps abstract algorithms to real-world tasks. However, it misses the mark on providing a cohesive, structured summary at the end and completely omits the glossary.
+
+**Gap task stubs:**
+- [ ] [P1][J:Summary] Missing a cohesive, structured summary at the end.
+- [ ] [P1][G:Mastery] Mastery Check answers are not collapsible (missing `<details>` tags).
+- [ ] [P1][O:Glossary] Missing explicit `## Glossary` section. Append to the bottom of the document.
+
+---
+
+## Day 02 — Variables & Built-in Functions
+
+**Path:** `content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_02_Variables_Builtin_Functions/README.md`
+
+**Assessment:** While the lesson successfully frames variables as 'labeled storage boxes', the section discussing `type()` and `id()` feels somewhat abrupt. Quotes like 'Python figures it out' could benefit from deeper production context regarding type safety. The hands-on labs are good but lack explicit expected outputs.
+
+**Gap task stubs:**
+- [ ] [P1][I:Senior] Add production insight regarding type safety where it states 'Python figures it out'.
+- [ ] [P1][G:Mastery] Mastery Check answers are not collapsible (missing `<details>` tags).
+- [ ] [P1][O:Glossary] Missing explicit `## Glossary` section. Append to the bottom of the document.
+- [ ] [P1][C:Lab] Line 191: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Create a complete customer pro...`
+- [ ] [P1][C:Lab] Line 215: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Build a pricing calculator tha...`
+- [ ] [P1][C:Lab] Line 240: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Use built-in functions to anal...`
+
+---
+
+## Day 03 — Operators
+
+**Path:** `content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_03_Operators/README.md`
+
+**Assessment:** The lesson does a great job explaining PEMDAS and modulo (`%`), using practical examples like 'Checking if a number is even'. However, the transition into bitwise operators is thin, simply stating 'You won't use these often' without providing a strong business justification for when you *would*.
+
+**Gap task stubs:**
+- [ ] [P2][E:Framing] The transition into bitwise operators is thin ('You won't use these often') and lacks a business justification.
+- [ ] [P1][G:Mastery] Mastery Check answers are not collapsible (missing `<details>` tags).
+- [ ] [P1][O:Glossary] Missing explicit `## Glossary` section. Append to the bottom of the document.
+- [ ] [P1][C:Lab] Line 250: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Determine if a customer qualif...`
+- [ ] [P1][C:Lab] Line 283: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Calculate sales commission bas...`
+- [ ] [P1][C:Lab] Line 312: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Generate stock alerts using lo...`
+
+---
+
+## Day 04 — Strings
+
+**Path:** `content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_04_Strings/README.md`
+
+**Assessment:** This is a very strong lesson. The analogy comparing strings to 'a bead necklace' is perfect for beginners. The 'f-strings' section correctly highlights modern formatting, stating 'This is the modern Python way'. It only falls short on the structural Quality Bar items like collapsible mastery checks.
+
+**Gap task stubs:**
+- [ ] [P1][G:Mastery] Mastery Check answers are not collapsible (missing `<details>` tags).
+- [ ] [P1][O:Glossary] Missing explicit `## Glossary` section. Append to the bottom of the document.
+- [ ] [P1][C:Lab] Line 237: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Generate personalized email ad...`
+- [ ] [P1][C:Lab] Line 302: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Clean messy customer data....`
+
+---
+
+## Day 05 — Lists
+
+**Path:** `content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_05_Lists/README.md`
+
+**Assessment:** The lesson frames lists effectively as 'dynamic containers', but the discussion on list slicing (e.g., `my_list[1:4]`) is slightly mechanical. Quoting 'It extracts a portion' is accurate but lacks a strong business 'why'—such as extracting the top 3 sales figures from a sorted list.
+
+**Gap task stubs:**
+- [ ] [P1][E:Framing] List slicing explanation ('It extracts a portion') lacks a strong business 'why' (e.g., extracting top 3 sales figures).
+- [ ] [P1][G:Mastery] Mastery Check answers are not collapsible (missing `<details>` tags).
+- [ ] [P1][O:Glossary] Missing explicit `## Glossary` section. Append to the bottom of the document.
+- [ ] [P1][C:Lab] Line 247: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Build a simple sales tracking ...`
+- [ ] [P1][C:Lab] Line 272: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Manage a product inventory lis...`
+- [ ] [P1][C:Lab] Line 303: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Find top and bottom performers...`
+
+---
+
+## Day 06 — Tuples
+
+**Path:** `content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_06_Tuples/README.md`
+
+**Assessment:** A solid explanation of immutability, using the 'Coordinates on a map' analogy to explain why you wouldn't want data to change. The section contrasting Lists vs Tuples notes 'Tuples are faster', but lacks deeper senior insight on memory allocation differences in large-scale applications.
+
+**Gap task stubs:**
+- [ ] [P2][I:Senior] The claim 'Tuples are faster' lacks deeper senior insight on memory allocation differences in large-scale applications.
+- [ ] [P1][G:Mastery] Mastery Check answers are not collapsible (missing `<details>` tags).
+- [ ] [P1][O:Glossary] Missing explicit `## Glossary` section. Append to the bottom of the document.
+- [ ] [P1][C:Lab] Line 236: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Create an immutable product re...`
+- [ ] [P1][C:Lab] Line 257: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Work with coordinate tuples....`
+- [ ] [P1][C:Lab] Line 286: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Create structured sales record...`
+
+---
+
+## Day 07 — Sets
+
+**Path:** `content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_07_Sets/README.md`
+
+**Assessment:** The business framing here is excellent, particularly the use case for 'Finding unique customers'. The lesson correctly states 'Sets are unordered', but the Venn diagram analogy could be pushed further with a concrete SQL JOIN comparison for MBA students familiar with databases.
+
+**Gap task stubs:**
+- [ ] [P1][A:Concept] The Venn diagram analogy could be pushed further with a concrete SQL JOIN comparison.
+- [ ] [P1][G:Mastery] Mastery Check answers are not collapsible (missing `<details>` tags).
+- [ ] [P1][O:Glossary] Missing explicit `## Glossary` section. Append to the bottom of the document.
+- [ ] [P1][C:Lab] Line 241: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Find customer overlaps between...`
+- [ ] [P1][C:Lab] Line 270: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Compare required skills vs. te...`
+- [ ] [P1][C:Lab] Line 295: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Clean a list of emails and cat...`
+
+---
+
+## Day 08 — Dictionaries
+
+**Path:** `content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_08_Dictionaries/README.md`
+
+**Assessment:** The 'Phonebook' analogy works well, but the lesson glosses over the `.get()` method. Stating 'Use .get() to avoid errors' is true, but it misses a critical production insight regarding default values and handling missing JSON keys in API responses.
+
+**Gap task stubs:**
+- [ ] [P1][I:Senior] Glosses over the `.get()` method ('Use .get() to avoid errors'). Needs critical production insight regarding default values and handling missing JSON keys in API responses.
+- [ ] [P1][G:Mastery] Mastery Check answers are not collapsible (missing `<details>` tags).
+- [ ] [P1][O:Glossary] Missing explicit `## Glossary` section. Append to the bottom of the document.
+- [ ] [P1][C:Lab] Line 253: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Build a product lookup system....`
+- [ ] [P1][C:Lab] Line 285: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Count occurrences of each word...`
+- [ ] [P1][C:Lab] Line 315: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Aggregate sales by region and ...`
+
+---
+
+## Day 09 — Conditionals
+
+**Path:** `content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_09_Conditionals/README.md`
+
+**Assessment:** The logical flow of `if/elif/else` is well-explained using a 'Bouncer at a club' analogy. However, the section on truthy/falsy values simply lists them ('0 is False, empty list is False') without explaining *why* this is a common idiom in Python codebases (e.g., `if not my_list:`).
+
+**Gap task stubs:**
+- [ ] [P1][A:Concept] Lists truthy/falsy values but doesn't explain *why* it's a common idiom in Python codebases (e.g., `if not my_list:`).
+- [ ] [P1][G:Mastery] Mastery Check answers are not collapsible (missing `<details>` tags).
+- [ ] [P1][O:Glossary] Missing explicit `## Glossary` section. Append to the bottom of the document.
+- [ ] [P1][C:Lab] Line 287: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Implement a multi-criteria loa...`
+- [ ] [P1][C:Lab] Line 333: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Calculate shipping based on we...`
+- [ ] [P1][C:Lab] Line 372: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Classify customers based on sp...`
+
+---
+
+## Day 10 — Loops
+
+**Path:** `content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_10_Loops/README.md`
+
+**Assessment:** The distinction between `for` and `while` loops is clear. The lesson says 'Use a while loop when you don't know how many times to repeat', which is a good rule of thumb. However, it lacks a strong 'Common Pitfalls' callout regarding infinite loops and blocking the main thread.
+
+**Gap task stubs:**
+- [ ] [P1][H:Pitfalls] Lacks a strong 'Common Pitfalls' callout regarding infinite loops and blocking the main thread.
+- [ ] [P1][G:Mastery] Mastery Check answers are not collapsible (missing `<details>` tags).
+- [ ] [P1][O:Glossary] Missing explicit `## Glossary` section. Append to the bottom of the document.
+- [ ] [P1][C:Lab] Line 277: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Generate a formatted sales rep...`
+- [ ] [P1][C:Lab] Line 306: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Find all prime numbers up to N...`
+- [ ] [P1][C:Lab] Line 335: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Validate password with retry l...`
+- [ ] [P1][B:CodeCtx] Line 53: Code block preceded by shallow preamble. Quote: `You write:`. Add 'why/what' context.
+
+---
+
+## Day 11 — Functions
+
+**Path:** `content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_11_Functions/README.md`
+
+**Assessment:** The concept of DRY (Don't Repeat Yourself) is introduced effectively. The lesson states 'Functions act as mini-programs', which is conceptually sound. However, the explanation of `*args` and `**kwargs` feels rushed and lacks a concrete business scenario where arbitrary arguments are necessary.
+
+**Gap task stubs:**
+- [ ] [P1][E:Framing] Explanation of `*args` and `**kwargs` feels rushed and lacks a concrete business scenario.
+- [ ] [P1][G:Mastery] Mastery Check answers are not collapsible (missing `<details>` tags).
+- [ ] [P1][O:Glossary] Missing explicit `## Glossary` section. Append to the bottom of the document.
+- [ ] [P1][C:Lab] Line 424: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Build a set of financial calcu...`
+- [ ] [P1][C:Lab] Line 459: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Create validation functions wi...`
+- [ ] [P1][C:Lab] Line 512: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Build a configurable report ge...`
+
+---
+
+## Day 11B — Generators & Iterators
+
+**Path:** `content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_11B_Generators_Iterators/README.md`
+
+**Assessment:** This is a more advanced topic, and the lesson rightly focuses on memory efficiency ('Yielding one item at a time saves RAM'). The explanation of `yield` is good, but the overall framing feels slightly more academic and less 'MBA-focused' than the earlier lessons.
+
+**Gap task stubs:**
+- [ ] [P2][E:Framing] Overall framing feels slightly more academic and less 'MBA-focused' than earlier lessons.
+- [ ] [P1][G:Mastery] Mastery Check answers are not collapsible (missing `<details>` tags).
+- [ ] [P1][O:Glossary] Missing explicit `## Glossary` section. Append to the bottom of the document.
+- [ ] [P1][C:Lab] Line 238: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Implement __iter__ and __ne...`
+- [ ] [P1][C:Lab] Line 265: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Process a large transaction st...`
+- [ ] [P1][C:Lab] Line 310: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Use chain, islice, and gr...`
+- [ ] [P2][J:Summary] Line 415: Missing preview of the next lesson at the end of the summary.
+
+---
+
+## Day 11C — Debugging Workflows
+
+**Path:** `content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_11C_Debugging_Workflows/README.md`
+
+**Assessment:** A highly practical lesson. The framing around 'Debugging is just scientific method' is fantastic. However, the lesson relies heavily on `print()` debugging and only briefly mentions `pdb`. It says 'For complex issues, use a debugger', but doesn't actually show *how* to step through code.
+
+**Gap task stubs:**
+- [ ] [P1][A:Concept] States 'For complex issues, use a debugger' but doesn't actually show *how* to step through code.
+- [ ] [P1][O:Glossary] Missing explicit `## Glossary` section. Append to the bottom of the document.
+- [ ] [P1][G:Mastery] Missing `## Mastery Check` section.
+
+---
+
+## Day 12 — List Comprehensions
+
+**Path:** `content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_12_List_Comprehension/README.md`
+
+**Assessment:** The lesson effectively pitches list comprehensions as 'Pythonic and concise'. It correctly warns against overly complex comprehensions ('Don't sacrifice readability for brevity'). However, it misses an opportunity to explicitly compare the execution speed of comprehensions vs standard loops.
+
+**Gap task stubs:**
+- [ ] [P1][I:Senior] Misses an opportunity to explicitly compare the execution speed of comprehensions vs standard loops.
+- [ ] [P1][G:Mastery] Mastery Check answers are not collapsible (missing `<details>` tags).
+- [ ] [P1][O:Glossary] Missing explicit `## Glossary` section. Append to the bottom of the document.
+- [ ] [P1][C:Lab] Line 270: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Transform and filter sales dat...`
+- [ ] [P1][C:Lab] Line 301: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Clean and analyze text data....`
+- [ ] [P1][C:Lab] Line 338: Exercise provides bare code without expected output. Add Expected Output section after goal: `**Goal**: Perform matrix transformations...`
+- [ ] [P2][J:Summary] Line 512: Missing preview of the next lesson at the end of the summary.
+- [ ] [P1][B:CodeCtx] Line 48: Code block preceded by shallow preamble. Quote: `You write:`. Add 'why/what' context.
+
+---


### PR DESCRIPTION
Generated a comprehensive gap-analysis markdown document for the Phase 01 curriculum.

- Audited 14 lessons against the Phase 1 Quality Bar.
- Wrote a custom Python script to programmatically inspect README and quiz.json files.
- Extracted exact line numbers, quoted text, and utilized the specified taxonomy tags (e.g. `[C:Lab]`, `[O:Glossary]`, `[G:Mastery]`) and severities (`[P1]`, `[P2]`).
- Ensured actionable stubs and grounded qualitative assessments for each lesson.

---
*PR created automatically by Jules for task [10045652654533240757](https://jules.google.com/task/10045652654533240757) started by @saint2706*