### PR TITLE
Fulfill all 51 Phase 11 gap-analysis stubs (Days 126-137)

### DIFF
--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_126_Cloud_Fundamentals/README.md
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_126_Cloud_Fundamentals/README.md
@@ -27,7 +27,7 @@ outcomes:
   - "Estimate monthly cloud costs for a data platform"
 ---
 
-# ☁️ Day 121: Cloud Fundamentals — AWS, GCP, Azure
+# ☁️ Day 126: Cloud Fundamentals — AWS, GCP, Azure
 
 > *"The cloud isn't someone else's computer — it's someone else's data centre that bills you by the second."*
 
@@ -85,6 +85,12 @@ For data engineers, the cloud isn't optional — it's where 85% of new enterpris
 | **Market Share (2025)** | ~32%                     | ~12%                          | ~23%                         |
 | **Strength**            | Broadest service catalog | Best for analytics/AI         | Best for enterprises on M365 |
 | **Pricing Model**       | Pay-per-use, reserved    | Sustained-use discounts, flat | Enterprise agreements        |
+
+**AWS** wins on breadth: if you need a niche managed service — IoT, satellite ground stations, quantum computing — AWS probably already shipped it. That breadth has a tax, though: AWS's IAM model and service sprawl (200+ services) mean more surface area for misconfiguration, more decisions per project, and a steeper ramp for new hires. Teams choose AWS when they need "a service for everything" and have the platform engineering maturity to manage the complexity.
+
+**GCP** wins on analytics economics: BigQuery's serverless, pay-per-query model and genuinely excellent query optimizer make it the cheapest path to "ask a question of 50TB of data right now" for most mid-size teams. The trade-off is ecosystem depth — GCP has fewer third-party integrations, a smaller bench of consultants and systems integrators, and noticeably thinner enterprise support compared to AWS or Azure, which can matter when something breaks at 2 a.m. and you need a vendor on the phone.
+
+**Azure** wins when the organization already lives in Microsoft's world: Entra ID (AAD) becomes your single IAM source of truth across Office 365, on-prem Active Directory, and cloud resources, and Power BI/Synapse integrate natively with tools business users already know. The cost is on the analytics-native side — Synapse and its surrounding tooling are generally considered less mature and less performant than BigQuery or Snowflake for pure large-scale analytical workloads, so Azure-first data teams often end up bolting on Databricks or Snowflake anyway.
 
 ### 3. Regions and Availability Zones
 
@@ -221,9 +227,30 @@ The answer is never "because cloud is expensive." It's always: "Here's the query
 
 ---
 
+## Glossary
+
+| Term | Definition |
+| --- | --- |
+| **IaaS** | Infrastructure as a Service — the provider manages physical hardware, virtualization, and networking; you manage the OS, runtime, and everything above it (e.g., EC2, GCE). |
+| **PaaS** | Platform as a Service — the provider also manages the OS and runtime; you just deploy code (e.g., Lambda, Cloud Run). |
+| **SaaS** | Software as a Service — fully managed application; you just use it (e.g., Snowflake, dbt Cloud). |
+| **Shared Responsibility Model** | The split between what the cloud provider secures (physical infrastructure, hypervisor, network) and what the customer secures (data, IAM, application config, encryption). |
+| **IAM** | Identity and Access Management — the system for defining who (or what service) can do what, on which resources. |
+| **Region** | A geographic area containing multiple data centres, chosen for data residency, latency, and cost. |
+| **Availability Zone (AZ)** | A physically separate data centre within a region; deploying across 2+ AZs protects against single-data-centre failures. |
+| **Reserved Instance** | Compute capacity purchased with a 1-3 year commitment in exchange for a 40-72% discount over on-demand pricing. |
+| **Spot Instance** | Spare compute capacity sold at a steep discount, which the provider can reclaim with little notice — good for fault-tolerant, interruptible workloads. |
+| **FinOps** | The discipline of continuously tracking, attributing, and optimizing cloud spend across engineering and finance teams. |
+| **Egress** | Data transferred *out* of a cloud provider's network (e.g., to the internet or another cloud); typically the most expensive type of data transfer. |
+| **Least Privilege** | The security principle of granting only the minimum permissions needed to perform a task, nothing more. |
+
+---
+
 ## Hands-on Lab
 
 ### Exercise 1: Cost Calculator
+
+FinOps teams don't reconstruct cost math in a spreadsheet every time a stakeholder asks "what would 10 more instances cost us?" — they build a single reusable function that takes the cost drivers as parameters and returns a structured breakdown, so the same logic powers budgeting, alerting, and "what-if" scenarios. The function below is that pattern in miniature: every pricing dimension (compute, storage, query, egress) becomes a parameter rather than a hardcoded number.
 
 ```python
 def estimate_monthly_cost(
@@ -244,6 +271,23 @@ def estimate_monthly_cost(
 
 # Test: 5 instances at $0.20/hr, 20TB storage at $0.023/GB,
 #        10TB queried at $5/TB, 1TB egress at $0.09/GB
+
+# EXPECTED RESULT
+# Arithmetic:
+#   compute = 5 instances * $0.20/hr * 730 hr/mo        = $730.00
+#   storage = 20 TB * 1024 GB/TB * $0.023/GB             = $471.04
+#   query   = 10 TB * $5/TB                              = $50.00
+#   egress  = 1 TB * 1024 GB/TB * $0.09/GB                = $92.16
+#   total   = 730.00 + 471.04 + 50.00 + 92.16            = $1,343.20
+#
+# estimate_monthly_cost(5, 0.20, 20, 0.023, 10, 5, 1024) ->
+# {
+#     "compute": 730.00,
+#     "storage": 471.04,
+#     "query": 50.00,
+#     "egress": 92.16,
+#     "total": 1343.20,
+# }
 ```
 
 ### Exercise 2: IAM Policy Design
@@ -326,4 +370,4 @@ On-demand: pay by the hour/second with no commitment, full flexibility. Reserved
 - ✅ **Cost management**: Reserved instances, storage tiers, query optimization, billing alerts
 - ✅ **Regions**: Choose by data residency, latency, cost, and service availability
 
-**Tomorrow → Day 122**: **Object Storage** — S3, GCS, Delta Lake, and Iceberg — the foundation of every modern data platform.
+**Tomorrow → Day 127**: **Object Storage** — S3, GCS, Delta Lake, and Iceberg — the foundation of every modern data platform.

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_126_Cloud_Fundamentals/quiz.json
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_126_Cloud_Fundamentals/quiz.json
@@ -1,0 +1,65 @@
+{
+    "day": 126,
+    "questions": [
+        {
+            "id": "d126q01",
+            "type": "multiple_choice",
+            "question": "A team wants to deploy custom application code without managing servers, operating systems, or runtimes. Which cloud computing model fits best?",
+            "options": ["IaaS", "PaaS", "SaaS", "On-premises"],
+            "answer": 1,
+            "explanation": "PaaS (e.g., AWS Lambda, Cloud Run) manages the OS and runtime for you — you just deploy code. IaaS still requires you to manage the OS; SaaS means you don't write or deploy any code at all; on-premises means you manage everything."
+        },
+        {
+            "id": "d126q02",
+            "type": "multiple_choice",
+            "question": "Under the shared responsibility model, which of the following is typically the CUSTOMER's responsibility, not the cloud provider's?",
+            "options": [
+                "Physical security of the data centre",
+                "Maintaining the hypervisor",
+                "Configuring IAM policies and S3 bucket permissions",
+                "Physical network infrastructure between data centres"
+            ],
+            "answer": 2,
+            "explanation": "The provider secures physical infrastructure, the hypervisor, and the network. The customer is responsible for configuring access controls like IAM policies and bucket permissions — misconfigurations here are the leading cause of cloud data breaches."
+        },
+        {
+            "id": "d126q03",
+            "type": "multiple_choice",
+            "question": "Following the principle of least privilege, how should a data engineer's IAM permissions typically be structured?",
+            "options": [
+                "Grant admin/root access so they never get blocked by permission errors",
+                "Grant only the specific permissions needed for their current tasks, via roles rather than individual user grants",
+                "Grant all S3 and database permissions but restrict compute permissions",
+                "Grant permissions based on seniority level only"
+            ],
+            "answer": 1,
+            "explanation": "Least privilege means granting the minimum permissions necessary to do the job, assigned via roles (not ad-hoc individual grants), and reviewed/audited regularly — not broad admin access for convenience."
+        },
+        {
+            "id": "d126q04",
+            "type": "multiple_choice",
+            "question": "Why does deploying a data platform across multiple Availability Zones (AZs) within a region matter?",
+            "options": [
+                "It is required by law in all cloud regions",
+                "It eliminates all egress data transfer costs",
+                "It protects against a single data centre failure, since each AZ is a physically separate facility",
+                "It automatically reduces compute pricing"
+            ],
+            "answer": 2,
+            "explanation": "AZs are physically separate data centres within a region. Spreading workloads across 2+ AZs protects against power outages, network issues, or hardware failures in any single facility, at a small cross-AZ transfer cost (~$0.01/GB)."
+        },
+        {
+            "id": "d126q05",
+            "type": "multiple_choice",
+            "question": "A data platform team runs Airflow workers 24/7 with predictable, steady utilization. Which pricing model would minimize cost?",
+            "options": [
+                "On-demand pricing, for maximum flexibility",
+                "Spot instances, since they are always cheapest",
+                "Reserved Instances, since the workload is steady and predictable",
+                "Free tier, since Airflow is open source"
+            ],
+            "answer": 2,
+            "explanation": "Reserved Instances offer 40-72% discounts in exchange for a 1-3 year commitment, making them ideal for steady, predictable workloads like always-on Airflow workers. On-demand suits variable workloads; spot instances can be reclaimed at any time, which is risky for critical infrastructure."
+        }
+    ]
+}

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_127_Object_Storage/README.md
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_127_Object_Storage/README.md
@@ -26,7 +26,7 @@ outcomes:
   - "Implement lifecycle policies for cost optimization"
 ---
 
-# 📦 Day 122: Object Storage — S3, GCS, Delta Lake, Iceberg
+# 📦 Day 127: Object Storage — S3, GCS, Delta Lake, Iceberg
 
 > *"Object storage is the foundation of every modern data platform — cheap, durable, infinitely scalable, and deceptively simple until you need to manage 10 million files."*
 
@@ -158,6 +158,8 @@ lifecycle_policy = {
 
 ### 4. Open Table Formats — Delta Lake vs Iceberg
 
+Before reaching for a PySpark code example, it helps to compare the two leading table formats side by side as plain data — their creators, transaction-log mechanics, and ecosystems differ in ways that drive real architecture decisions (which engines you can use, how partitioning evolves, whether upserts are cheap). The dictionary below captures that comparison so you can reason about the trade-offs before seeing how Delta Lake's API actually looks in practice.
+
 ```python
 # The problem: Parquet files in a data lake have no ACID transactions,
 # no schema evolution, no time travel. Open table formats add these.
@@ -226,6 +228,23 @@ Over-partition (e.g., by `customer_id` with 1M customers) and you get millions o
 
 ---
 
+## Glossary
+
+| Term | Definition |
+| --- | --- |
+| **Object Storage** | A flat, key-value storage system (e.g., S3, GCS) with no real directory hierarchy — objects are retrieved by a unique key, not a filesystem path. |
+| **Bucket / Key / Prefix** | A bucket is the top-level container; a key is an object's full unique identifier; a prefix is the leading portion of a key used to simulate folder-like grouping. |
+| **Medallion Architecture (Bronze/Silver/Gold)** | A layered data lake pattern: Bronze holds raw, unmodified data; Silver holds cleaned/deduplicated/typed data; Gold holds business-ready aggregates for BI and ML. |
+| **Lifecycle Policy** | A rule that automatically transitions or expires objects based on age (e.g., move to cheaper storage after 30 days, delete after 7). |
+| **Storage Class / Tier** | A pricing/performance category for stored data (e.g., S3 Standard, Standard-IA, Glacier) trading off retrieval speed against cost. |
+| **ACID Transaction** | A write operation that is Atomic, Consistent, Isolated, and Durable — guarantees that table formats like Delta Lake and Iceberg add on top of plain Parquet files. |
+| **Schema Evolution** | The ability to add, remove, or change columns in a table over time without rewriting all existing data. |
+| **Time Travel** | Querying a table as it existed at a previous point in time or version, enabled by a table format's transaction log. |
+| **Z-ORDER** | A Delta Lake technique that co-locates related data within files by sorting on specified columns, speeding up filtered queries. |
+| **Small Files Problem** | The performance degradation caused by having too many tiny files (< 128MB) in object storage, due to per-file metadata and I/O overhead. |
+
+---
+
 ## Hands-on Lab
 
 ### Exercise 1: Design a Data Lake Structure
@@ -244,6 +263,34 @@ Over-partition (e.g., by `customer_id` with 1M customers) and you get millions o
 # 4. Lifecycle policy for cost optimization
 
 data_lake_design = {}
+
+# EXPECTED RESULT (one reasonable, concrete design)
+# data_lake_design = {
+#     "clickstream": {
+#         "bronze": {"path": "raw/clickstream/year=/month=/day=/", "format": "JSON", "partitioning": "daily (year/month/day)"},
+#         "silver": {"path": "cleaned/clickstream/year=/month=/day=/", "format": "Parquet", "partitioning": "daily, deduplicated + typed"},
+#         "gold":   {"path": "curated/clickstream/sessions/", "format": "Parquet", "partitioning": "by month, session-level aggregates"},
+#         "lifecycle": "Bronze -> Standard-IA after 30 days, Glacier after 90 days (high volume, rarely re-read raw)",
+#     },
+#     "orders": {
+#         "bronze": {"path": "raw/orders/year=/month=/day=/", "format": "JSON/CDC log", "partitioning": "daily"},
+#         "silver": {"path": "cleaned/orders/year=/month=/", "format": "Delta Lake (needs upserts from CDC)", "partitioning": "monthly"},
+#         "gold":   {"path": "curated/orders/revenue_by_region/", "format": "Parquet", "partitioning": "by month + region"},
+#         "lifecycle": "Bronze -> Standard-IA after 90 days (regulatory retention 7 years, rarely accessed after first month)",
+#     },
+#     "product_catalog": {
+#         "bronze": {"path": "raw/products/snapshot_date=/", "format": "JSON", "partitioning": "weekly snapshot"},
+#         "silver": {"path": "cleaned/products/", "format": "Parquet", "partitioning": "none (small, 10K rows)"},
+#         "gold":   {"path": "curated/products/catalog_current/", "format": "Delta Lake (supports MERGE for weekly updates)", "partitioning": "none"},
+#         "lifecycle": "Keep all snapshots in Standard (tiny dataset, cost is negligible)",
+#     },
+#     "reviews": {
+#         "bronze": {"path": "raw/reviews/year=/month=/day=/", "format": "JSON (unstructured text)", "partitioning": "daily"},
+#         "silver": {"path": "cleaned/reviews/year=/month=/", "format": "Parquet (+ extracted sentiment/score column)", "partitioning": "monthly"},
+#         "gold":   {"path": "curated/reviews/product_sentiment/", "format": "Parquet", "partitioning": "by product category"},
+#         "lifecycle": "Bronze -> Standard-IA after 60 days, Glacier after 1 year",
+#     },
+# }
 ```
 
 ### Exercise 2: Cost Comparison
@@ -307,4 +354,4 @@ Lifecycle policies automatically move data to cheaper tiers based on age. Recent
 - ✅ **Delta Lake**: Best for Databricks/Spark-first shops — ACID, time travel, Z-ORDER
 - ✅ **Apache Iceberg**: Best for multi-engine environments — hidden partitioning, partition evolution, engine-agnostic
 
-**Tomorrow → Day 123**: **Cloud Data Warehouses** — BigQuery, Snowflake, Redshift — how they actually work under the hood.
+**Tomorrow → Day 128**: **Cloud Data Warehouses** — BigQuery, Snowflake, Redshift — how they actually work under the hood.

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_127_Object_Storage/quiz.json
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_127_Object_Storage/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 127,
+    "questions": [
+        {
+            "id": "d127q01",
+            "type": "multiple_choice",
+            "question": "What is the key structural difference between object storage (like S3) and a traditional filesystem?",
+            "options": [
+                "Object storage supports random byte-level writes within a file; filesystems do not",
+                "Object storage uses a flat namespace with key-value pairs, simulating folders via key prefixes, rather than real nested directories",
+                "Object storage cannot store files larger than 1GB",
+                "Object storage requires a database engine to list files"
+            ],
+            "answer": 1,
+            "explanation": "Object storage has a flat namespace — there are no real directories, just keys that can contain '/' characters to simulate folder structure. Traditional filesystems support real directories and in-place, random-access file modification."
+        },
+        {
+            "id": "d127q02",
+            "type": "multiple_choice",
+            "question": "In the medallion (Bronze/Silver/Gold) architecture, what is the primary purpose of the Bronze layer?",
+            "options": [
+                "Store business-ready aggregates for BI dashboards",
+                "Preserve raw, unmodified data as received, enabling reprocessing without re-ingesting from source systems",
+                "Store only deduplicated and type-cast data",
+                "Cache materialized views for faster queries"
+            ],
+            "answer": 1,
+            "explanation": "Bronze preserves raw data as-is (append-only, immutable) for auditability and so that Silver/Gold can be reprocessed from scratch if a bug is found, without re-querying the original source system."
+        },
+        {
+            "id": "d127q03",
+            "type": "multiple_choice",
+            "question": "A lifecycle policy transitions objects in the 'raw/' prefix to STANDARD_IA after 30 days and GLACIER_IR after 90 days. What is the main benefit of this approach?",
+            "options": [
+                "It increases query performance on recent data",
+                "It automatically reduces storage costs for aging data that is accessed less frequently, without manual intervention",
+                "It converts files from JSON to Parquet automatically",
+                "It enforces schema validation on older files"
+            ],
+            "answer": 1,
+            "explanation": "Lifecycle policies move data to progressively cheaper storage tiers as it ages and is accessed less often, cutting storage costs by 80%+ with no impact on the performance of queries against recent, frequently accessed data."
+        },
+        {
+            "id": "d127q04",
+            "type": "multiple_choice",
+            "question": "A multi-engine environment uses Trino for interactive queries and Spark for batch ETL, and the team frequently needs to change partitioning strategy as query patterns evolve. Which open table format is the better fit, and why?",
+            "options": [
+                "Delta Lake, because it has the best Spark integration",
+                "Apache Iceberg, because it is engine-agnostic and supports partition evolution without rewriting data",
+                "Neither — plain Parquet is sufficient for multi-engine setups",
+                "Delta Lake, because it requires a single engine for consistency"
+            ],
+            "answer": 1,
+            "explanation": "Iceberg was designed to be engine-agnostic (Spark, Trino, Flink, Dremio) and supports partition evolution, letting teams change partitioning strategy over time without rewriting historical data — a strong fit for diverse, multi-engine environments."
+        },
+        {
+            "id": "d127q05",
+            "type": "multiple_choice",
+            "question": "A teammate proposes partitioning a 100M-row table by `customer_id`, where there are 500K unique customers. What is the main pitfall?",
+            "options": [
+                "Partitioning by a non-date column is not supported by any table format",
+                "It creates roughly 500K partitions with tiny files each, causing excessive metadata overhead and per-file I/O — the small files problem",
+                "It will cause schema evolution errors",
+                "It eliminates the need for a transaction log"
+            ],
+            "answer": 1,
+            "explanation": "With 500K unique customer_id values, this creates ~500K partitions of roughly 200 rows each — far too many small files. Most queries are time-bounded anyway, so partitioning by date (and filtering by customer_id within partitions) is the better strategy."
+        }
+    ]
+}

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_128_Cloud_Data_Warehouses/README.md
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_128_Cloud_Data_Warehouses/README.md
@@ -27,7 +27,7 @@ outcomes:
   - "Design a cost-effective warehouse strategy for different workloads"
 ---
 
-# 🏗️ Day 123: Cloud Data Warehouses — BigQuery, Snowflake, Redshift
+# 🏗️ Day 128: Cloud Data Warehouses — BigQuery, Snowflake, Redshift
 
 > *"A cloud data warehouse isn't just a database in the sky — it's a query engine that reads terabytes in seconds, and bills you for every byte it touches."*
 
@@ -58,6 +58,8 @@ The key innovation is **separating storage from compute**. Your data sits in che
 | **Best For**      | Ad-hoc analytics, cost-optimized | Mixed workloads, data sharing | AWS-heavy shops, predictable |
 
 ### 2. BigQuery Deep Dive
+
+Because BigQuery bills by bytes scanned rather than by time spent, the cost of a query is knowable *before* you run it. Running a dry run first — and inspecting `total_bytes_processed` — is a core FinOps habit: it turns "how much will this cost?" from a guess into a number you check before hitting execute, the same way you'd check a price tag before checkout.
 
 ```python
 from google.cloud import bigquery
@@ -189,6 +191,34 @@ BigQuery on-demand ($6.25/TB) is cheapest for sporadic usage. But at scale (>1TB
 
 Snowflake's data sharing lets you share live data with partners, vendors, or other business units **without copying it**. The consumer pays for compute on their own account. This is transformative for organizations with multiple teams or B2B data products.
 
+### Snowflake vs. BigQuery: The Real Trade-offs
+
+The "Flat Rate vs Pay-Per-Query" and "Data Sharing" points above are just the headline differences. The deeper trade-offs that actually drive a platform decision:
+
+- **Multi-cloud portability**: Snowflake runs unmodified on AWS, GCP, and Azure — useful for organizations with multi-cloud mandates, M&A integration (inheriting infrastructure from an acquired company), or regulatory requirements to avoid vendor lock-in. BigQuery only runs on GCP; moving off it means re-platforming.
+- **Workload isolation**: Snowflake's Virtual Warehouses give each team (ETL, analytics, ML) fully independent compute — one team's heavy query cannot slow down another's, and each warehouse can be sized, suspended, and billed separately. BigQuery's on-demand model draws from a shared slot pool; a single runaway query can contend with everyone else's workloads unless you've purchased dedicated flat-rate/reservation capacity.
+- **Governance and data-sharing maturity**: Snowflake's Secure Data Sharing and the Snowflake Marketplace are purpose-built, mature products for exposing live data to partners or monetizing data externally. BigQuery has Analytics Hub as a comparable feature, but it's newer and has a smaller ecosystem of consumers and pre-built listings.
+- **Ecosystem and tooling**: BigQuery integrates most deeply with the rest of GCP (Looker, Vertex AI, Dataflow) and has the edge for teams already standardized on GCP. Snowflake has built a broader third-party ecosystem (Fivetran, dbt, Tableau, Sigma) precisely because it must work well across all three clouds, which can mean more flexibility for heterogeneous tool stacks.
+
+In short: choose BigQuery when you're GCP-native and want serverless simplicity; choose Snowflake when you need multi-cloud flexibility, hard workload isolation between teams, or mature external data-sharing.
+
+---
+
+## Glossary
+
+| Term | Definition |
+| --- | --- |
+| **MPP (Massively Parallel Processing)** | An architecture where a query is split across many compute nodes that process data in parallel, enabling fast scans of terabytes of data. |
+| **Columnar Storage** | A storage layout that groups data by column rather than by row, allowing queries to read only the columns they need — key to both performance and cost in warehouses like BigQuery. |
+| **Slot** | BigQuery's unit of compute capacity; queries consume slots dynamically (on-demand) or from a reserved pool (flat-rate). |
+| **Virtual Warehouse** | Snowflake's unit of compute — an independently sized, scalable cluster that can be suspended/resumed and billed separately from storage. |
+| **Compute-Storage Separation** | An architecture where data is stored independently of the compute that processes it, allowing each to scale (and be billed) independently. |
+| **Materialized View** | A precomputed, automatically maintained query result stored as a table, so repeated expensive queries hit the precomputed result instead of recomputing from scratch. |
+| **Partition Pruning** | The query engine's ability to skip entire partitions (e.g., date ranges) that can't match the WHERE clause, avoiding unnecessary scans. |
+| **Clustering** | Sorting data within partitions by specified columns so the engine reads fewer blocks when filtering on those columns. |
+| **Data Sharing** | Exposing live data to another account or organization without physically copying it — the consumer queries the same underlying data and pays for their own compute. |
+| **Concurrency Scaling** | A feature (e.g., in Redshift) that automatically spins up additional transient compute capacity to handle bursts of concurrent queries. |
+
 ---
 
 ## Hands-on Lab
@@ -211,6 +241,34 @@ def compare_warehouse_costs(
     - Snowflake Medium: $4/credit, ~8 credits/hour
     """
     pass
+
+# EXPECTED RESULT
+# Scenario: 200 queries/day, 500 GB scanned/query, assume avg_query_seconds = 30
+#           and a 30-day month.
+#
+# Arithmetic:
+#   Total GB scanned/day   = 200 queries * 500 GB           = 100,000 GB/day
+#   Total TB scanned/month = 100,000 GB/day * 30 days / 1024 = 2,929.69 TB/month
+#
+#   BigQuery on-demand = 2,929.69 TB * $6.25/TB             = $18,310.56/mo
+#   BigQuery flat-rate  = $2,000/mo (100 slots, fixed regardless of volume)
+#
+#   Snowflake Medium:
+#     total query-seconds/month = 200 queries/day * 30 sec/query * 30 days
+#                                = 180,000 seconds = 50 compute-hours
+#     credits consumed          = 50 hours * 8 credits/hour = 400 credits
+#     cost                      = 400 credits * $4/credit   = $1,600.00/mo
+#
+# compare_warehouse_costs(200, 500, 30) ->
+# {
+#     "bigquery_on_demand": 18310.56,
+#     "bigquery_flat_rate": 2000.00,
+#     "snowflake_medium": 1600.00,
+# }
+#
+# Takeaway: at this volume (~2,930 TB/mo scanned), BOTH flat-rate BigQuery and
+# Snowflake crush pay-per-scan pricing — this is exactly the "Flat Rate vs
+# Pay-Per-Query" decision point described in Senior-Level Insights above.
 ```
 
 ### Exercise 2: Optimization Audit
@@ -275,4 +333,4 @@ Choose Snowflake when: (1) you need data sharing with external partners without 
 - ✅ **Optimization**: Partition + cluster, avoid SELECT *, use materialized views, right-size compute
 - ✅ **Cost**: Separate compute from storage, auto-suspend, monitor continuously
 
-**Tomorrow → Day 124**: **dbt at Scale** — incremental models, snapshots, macros, and patterns that turn your warehouse into a maintainable analytics engine.
+**Tomorrow → Day 129**: **dbt at Scale** — incremental models, snapshots, macros, and patterns that turn your warehouse into a maintainable analytics engine.

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_128_Cloud_Data_Warehouses/quiz.json
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_128_Cloud_Data_Warehouses/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 128,
+    "questions": [
+        {
+            "id": "d128q01",
+            "type": "multiple_choice",
+            "question": "What does 'compute-storage separation' mean in cloud data warehouses, and why does it matter for cost?",
+            "options": [
+                "Storage and compute must always be purchased together as a bundle",
+                "Data is stored independently of compute resources, so you pay for storage continuously but only pay for compute while queries actually run",
+                "It means data is replicated across compute nodes to avoid using storage at all",
+                "It eliminates the need to pay for storage entirely"
+            ],
+            "answer": 1,
+            "explanation": "Compute-storage separation lets data sit cheaply in object storage 24/7, while compute resources spin up only when a query runs and shut down afterward. This avoids paying for idle compute and allows each to scale independently."
+        },
+        {
+            "id": "d128q02",
+            "type": "multiple_choice",
+            "question": "Why is `SELECT *` particularly expensive in BigQuery compared to a traditional row-oriented database?",
+            "options": [
+                "BigQuery charges a flat fee per query regardless of columns selected, so it doesn't matter",
+                "BigQuery uses columnar storage and bills per TB scanned, so `SELECT *` reads and bills for every column even if only a few are needed",
+                "`SELECT *` triggers a full table lock in BigQuery",
+                "BigQuery does not support `SELECT *` syntax"
+            ],
+            "answer": 1,
+            "explanation": "BigQuery's columnar storage means each column can be scanned independently. SELECT * forces a scan of every column, and since billing is per TB scanned, this can be 10-50x more expensive than selecting only needed columns."
+        },
+        {
+            "id": "d128q03",
+            "type": "multiple_choice",
+            "question": "A table is partitioned by DATE(order_date) and clustered by region, category. How do partitioning and clustering work together to reduce scanned bytes?",
+            "options": [
+                "Partitioning sorts rows within each cluster; clustering skips entire date ranges",
+                "They do the same thing — using both is redundant",
+                "Partitioning lets the engine skip entire date partitions outside the WHERE clause; clustering then sorts data within each partition so fewer blocks are read for region/category filters",
+                "Clustering only works on numeric columns, not strings like region"
+            ],
+            "answer": 2,
+            "explanation": "Partitioning prunes whole partitions (coarse filtering, typically by date). Clustering sorts data within each partition by the clustering columns, allowing the engine to skip blocks within a partition too (fine filtering) — using both together compounds the savings."
+        },
+        {
+            "id": "d128q04",
+            "type": "multiple_choice",
+            "question": "A company needs to share live data with 100+ external partners without copying it, and wants the option to run on AWS, GCP, or Azure depending on the client. Which warehouse is the better fit, and why?",
+            "options": [
+                "BigQuery, because Analytics Hub is the most mature data-sharing product on the market",
+                "Redshift, because Concurrency Scaling supports external sharing natively",
+                "Snowflake, because of its mature Secure Data Sharing/Marketplace and multi-cloud portability across AWS, GCP, and Azure",
+                "Any warehouse works equally well since data sharing is a commodity feature"
+            ],
+            "answer": 2,
+            "explanation": "Snowflake's Secure Data Sharing and Marketplace are purpose-built and mature for external data sharing, and Snowflake runs unmodified across all three major clouds — both directly address the stated requirements. BigQuery only runs on GCP and its sharing tooling (Analytics Hub) is newer."
+        },
+        {
+            "id": "d128q05",
+            "type": "multiple_choice",
+            "question": "A team's BigQuery bill jumped from $1,000/month to $9,000/month with no change in business activity. What should be investigated FIRST?",
+            "options": [
+                "Immediately switch to Snowflake without further analysis",
+                "Query logs/job history for recently run queries that scan unusually large amounts of data (e.g., new SELECT * queries or unpartitioned table scans), and check if any queries are now running on a much more frequent schedule",
+                "Delete all data older than 30 days",
+                "Increase the on-demand pricing tier"
+            ],
+            "answer": 1,
+            "explanation": "The standard cost investigation starts with query/job history: identify which queries scan the most data (often SELECT * on large unpartitioned tables) and check whether previously-occasional queries are now running on a much tighter schedule. This pinpoints the root cause before reaching for a platform change."
+        }
+    ]
+}

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_129_dbt_at_Scale/README.md
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_129_dbt_at_Scale/README.md
@@ -28,7 +28,7 @@ outcomes:
   - "Enforce data contracts and quality tests in the DAG"
 ---
 
-# 🔧 Day 124: dbt at Scale — Incremental Models, Snapshots, Advanced Patterns
+# 🔧 Day 129: dbt at Scale — Incremental Models, Snapshots, Advanced Patterns
 
 > *"dbt is the tool that turns your data warehouse from a pile of SQL files into a tested, documented, version-controlled analytics engine."*
 
@@ -81,6 +81,8 @@ FROM {{ source('raw', 'orders') }}
     WHERE _loaded_at > (SELECT MAX(_loaded_at) FROM {{ this }})
 {% endif %}
 ```
+
+dbt compiles this model differently depending on whether the table already exists. On the very first run there is nothing to compare against, so `is_incremental()` evaluates to `False` and dbt compiles a plain `CREATE TABLE AS SELECT` over the full source — no `WHERE` clause is added. On every subsequent run the table already exists, so `is_incremental()` evaluates to `True` and dbt compiles a `MERGE` that filters the source down to only the new rows, using `{{ this }}` to refer to the model's own already-built table so it can look up the current max `_loaded_at`.
 
 ```yaml
 # Why incremental matters:
@@ -250,9 +252,37 @@ With 500+ models, you need governance:
 
 ---
 
+## Glossary
+
+| Term | Definition |
+| --- | --- |
+| **Incremental Model** | A dbt materialization that, after the first run, only processes new or changed rows instead of rebuilding the full table. |
+| **unique_key** | The column (or combination of columns) dbt uses to identify a row when merging incremental updates, ensuring no duplicates. |
+| **Merge Strategy** | The `incremental_strategy` (e.g., `merge`, `append`, `delete+insert`) that determines how new rows are combined with the existing table. `merge` updates matching rows and inserts new ones. |
+| **on_schema_change** | A config that tells dbt what to do when the source schema changes between runs (e.g., `sync_all_columns` to add/remove columns automatically). |
+| **Snapshot** | A dbt feature that captures the state of a mutable source table over time, recording when each row version was valid. |
+| **SCD Type 2** | "Slowly Changing Dimension Type 2" — a modeling pattern that preserves full history of a record by adding new rows (with valid_from/valid_to) instead of overwriting old values. |
+| **Jinja Macro** | A reusable, parameterized block of Jinja templating logic (similar to a function) that generates SQL at compile time. |
+| **Data Contract (`contract: enforced`)** | A dbt 1.5+ feature where a model's declared column names/types/constraints are validated against its actual output at build time, failing the build on mismatch. |
+| **Surrogate Key** | A generated, warehouse-internal key (often a hash of natural key columns via `dbt_utils.generate_surrogate_key`) used to uniquely identify a row when no reliable natural key exists. |
+| **Staging/Intermediate/Marts layering** | dbt's standard project structure: staging models clean raw sources 1:1, intermediate models apply business logic/joins, and marts models produce final business-facing fact/dimension tables. |
+
+---
+
 ## Hands-on Lab
 
 ### Exercise 1: Build an Incremental Model
+
+Sample raw source table `raw.events` (a clickstream events table):
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `event_id` | string | unique identifier per event |
+| `event_date` | date | calendar date the event occurred, used for daily partitioning |
+| `user_id` | string | identifies the user who triggered the event |
+| `event_type` | string | e.g., `page_view`, `click`, `purchase` |
+| `properties` | json/struct | event-specific payload (page, button_id, amount, etc.) |
+| `_loaded_at` | timestamp | when the row landed in the raw table — used to detect "new" rows |
 
 ```sql
 -- TODO: Write an incremental model for a clickstream events table.
@@ -261,6 +291,38 @@ With 500+ models, you need governance:
 -- 2. Partition by event_date (daily)
 -- 3. Use a 2-day lookback window for late-arriving events
 -- 4. Add a test to verify no duplicate event_ids
+```
+
+```sql
+# EXPECTED RESULT — compiled SQL on a subsequent (incremental) run:
+
+{{
+    config(
+        materialized='incremental',
+        unique_key='event_id',
+        incremental_strategy='merge',
+        partition_by={"field": "event_date", "data_type": "date", "granularity": "day"}
+    )
+}}
+
+SELECT
+    event_id,
+    event_date,
+    user_id,
+    event_type,
+    properties,
+    _loaded_at
+FROM {{ source('raw', 'events') }}
+
+{% if is_incremental() %}
+    -- 2-day lookback window: re-scan the last 2 days so late-arriving
+    -- events are still picked up, then let the merge on unique_key
+    -- de-duplicate against rows already in the table.
+    WHERE _loaded_at > (SELECT MAX(_loaded_at) - INTERVAL '2 days' FROM {{ this }})
+{% endif %}
+
+-- Plus, in the model's .yml: a `dbt_utils.unique_combination_of_columns`
+-- or a plain `unique` test on `event_id` to assert no duplicate event_ids.
 ```
 
 ### Exercise 2: Snapshot Customer Changes
@@ -321,4 +383,4 @@ A data contract (`contract: enforced: true`) specifies exact column names, types
 - ✅ **Data contracts**: Enforce schema stability for downstream consumers
 - ✅ **Project structure**: staging → intermediate → marts with clear naming conventions
 
-**Tomorrow → Day 125**: **Orchestration** — Apache Airflow, Prefect, Dagster — scheduling and managing your data pipelines.
+**Tomorrow → Day 130**: **Orchestration** — Apache Airflow, Prefect, Dagster — scheduling and managing your data pipelines.

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_129_dbt_at_Scale/quiz.json
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_129_dbt_at_Scale/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 129,
+    "questions": [
+        {
+            "id": "d129q01",
+            "type": "multiple_choice",
+            "question": "A staging model processes a 100M-row orders table. Why would you choose an incremental model over a full refresh?",
+            "options": [
+                "Incremental models are easier to write in Jinja",
+                "Incremental models only process new/changed rows, drastically reducing run time and bytes scanned on each run",
+                "Incremental models automatically generate dbt tests",
+                "Full refresh models cannot use the merge strategy"
+            ],
+            "answer": 1,
+            "explanation": "Incremental models scan and process only the rows that changed since the last run (e.g., 10K new rows vs. 100M), which saves both runtime and warehouse compute cost (e.g., bytes scanned in BigQuery)."
+        },
+        {
+            "id": "d129q02",
+            "type": "multiple_choice",
+            "question": "What do dbt snapshots add to a source table to implement SCD Type 2 history tracking?",
+            "options": [
+                "A single 'is_current' boolean column",
+                "dbt_valid_from and dbt_valid_to columns that record when each row version was active",
+                "A surrogate key generated from dbt_utils.generate_surrogate_key",
+                "A materialized view that overwrites old rows with new values"
+            ],
+            "answer": 1,
+            "explanation": "dbt snapshots use the SCD Type 2 pattern: each time a tracked column changes, the old row is closed out with a dbt_valid_to timestamp and a new row is inserted with dbt_valid_from set, preserving full history."
+        },
+        {
+            "id": "d129q03",
+            "type": "multiple_choice",
+            "question": "In the macro below, what does `{% if not loop.last %} UNION ALL {% endif %}` accomplish inside a Jinja for-loop over regions?",
+            "options": [
+                "It unions every region's table twice for redundancy",
+                "It adds UNION ALL between SELECT statements but omits a trailing UNION ALL after the final region",
+                "It deletes duplicate rows across regions",
+                "It only runs the loop once regardless of region count"
+            ],
+            "answer": 1,
+            "explanation": "loop.last is a Jinja loop variable that is True only on the final iteration. Skipping UNION ALL on the last iteration avoids generating invalid trailing SQL after the last SELECT."
+        },
+        {
+            "id": "d129q04",
+            "type": "multiple_choice",
+            "question": "A model has `config: contract: enforced: true` with a defined column list. What happens if a column is renamed in the model's SELECT statement without updating the contract?",
+            "options": [
+                "dbt silently renames the column in the warehouse to match",
+                "The build fails at compile/run time because the model's output no longer matches the declared contract",
+                "dbt automatically updates the YAML contract to match the new column name",
+                "Nothing — contracts are only checked during dbt docs generate"
+            ],
+            "answer": 1,
+            "explanation": "Data contracts enforce that a model's actual output (column names, types, constraints) matches what's declared in the YAML. A mismatch causes the build to fail, preventing silent schema drift from breaking downstream consumers."
+        },
+        {
+            "id": "d129q05",
+            "type": "multiple_choice",
+            "question": "Why does the late-arriving data pattern use `MAX(_loaded_at) - INTERVAL '3 days'` instead of just `MAX(_loaded_at)` in the incremental WHERE clause?",
+            "options": [
+                "It makes the query run faster by scanning fewer partitions",
+                "It re-checks a window of already-loaded data to catch rows that arrived late (e.g., a payment settling days after the order), which a plain MAX(_loaded_at) cutoff would miss",
+                "It is required syntax for the merge incremental_strategy",
+                "It prevents the model from ever being fully refreshed"
+            ],
+            "answer": 1,
+            "explanation": "A lookback window re-scans recent history (e.g., the last 3 days) on every incremental run so that rows which arrive late relative to their logical event time are still picked up and merged in, not silently dropped."
+        }
+    ]
+}

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_130_Orchestration/README.md
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_130_Orchestration/README.md
@@ -27,7 +27,7 @@ outcomes:
   - "Implement retry logic, alerting, and idempotent tasks"
 ---
 
-# 🎼 Day 125: Orchestration — Apache Airflow, Prefect, Dagster
+# 🎼 Day 130: Orchestration — Apache Airflow, Prefect, Dagster
 
 > *"An orchestrator doesn't run your code faster — it runs it reliably, on schedule, and wakes you up when something breaks."*
 
@@ -209,6 +209,35 @@ Airflow is over-engineering for: (1) simple cron jobs that run one script, (2) r
 
 ---
 
+## Pitfalls
+
+- ⚠️ **Top-level code in DAG files runs on every scheduler heartbeat.** Any DB query, API call, or heavy import placed at the top level of a DAG file (outside a task function) executes every time the scheduler parses the DAG folder — roughly every ~30 seconds by default — for every DAG in the folder, not just when the DAG actually runs. A single slow API call at import time can grind the entire scheduler to a halt.
+- ⚠️ **Scheduler and DAG-parsing bottlenecks.** Hundreds of DAG files with slow top-level code, or a handful of DAGs with thousands of tasks each, slow down the parsing loop and can delay scheduling decisions across the whole deployment, not just the offending DAG.
+- ⚠️ **Forgetting `catchup=False` causes backfill storms.** If `start_date` is in the past and `catchup` is left at its default (`True`), Airflow queues a run for every missed interval since `start_date` — easily hundreds of historical runs firing at once and overwhelming workers.
+- ⚠️ **Sensors in default "poke" mode waste worker slots.** A sensor in poke mode occupies a full worker slot for its entire wait duration, repeatedly checking a condition. Use `mode="reschedule"` or a deferrable operator so the sensor releases the worker slot between checks.
+- ⚠️ **Missing `execution_timeout` lets a hung task block everything downstream.** Without a timeout, a stuck task (e.g., a network call that never returns) can occupy its worker slot indefinitely, starving downstream tasks and other DAGs of capacity. Always set `execution_timeout` on tasks that call external systems.
+
+---
+
+## Glossary
+
+| Term | Definition |
+| --- | --- |
+| **DAG** | Directed Acyclic Graph — the set of tasks and their dependencies, with no cycles, that defines a pipeline's execution order. |
+| **Operator** | A template for a single unit of work in Airflow (e.g., `PythonOperator`, `BigQueryInsertJobOperator`); instantiating one creates a task. |
+| **Sensor** | A special operator that waits/polls for a condition (a file landing, a partition appearing) before letting downstream tasks proceed. |
+| **Task Instance** | A specific run of a task for a specific DAG run/execution date — the unit that has its own state (running, success, failed, retry). |
+| **Scheduler** | The orchestrator process that parses DAG files, evaluates schedules, and decides which task instances to queue for execution. |
+| **Idempotency** | The property that running a task once or many times with the same input produces the same end state — critical for safe retries and re-runs. |
+| **Retry / retry_delay** | Configuration controlling how many times a failed task is automatically retried and how long to wait between attempts. |
+| **SLA** | Service Level Agreement — a deadline by which a task or DAG run is expected to complete; breaches can trigger alerts. |
+| **Backfill** | Running a DAG for historical (past) schedule intervals, typically to populate data that predates the DAG's deployment. |
+| **catchup** | A DAG-level setting controlling whether Airflow automatically backfills every missed interval since `start_date` (`True`) or only runs going forward (`False`). |
+| **Trigger Rule** | A task setting (e.g., `all_success`, `all_done`) that determines under what upstream conditions a task is allowed to run. |
+| **XCom** | "Cross-communication" — Airflow's mechanism for passing small pieces of data between tasks in a DAG run. |
+
+---
+
 ## Hands-on Lab
 
 ### Exercise 1: Design a Pipeline DAG
@@ -228,6 +257,32 @@ Airflow is over-engineering for: (1) simple cron jobs that run one script, (2) r
 # TODO: Write this as an Airflow DAG with proper dependencies
 # TODO: Add retry logic (3 retries, 5 min delay) for extract tasks
 # TODO: Add an SLA of 2 hours for the entire DAG
+```
+
+```python
+# EXPECTED RESULT
+
+extract_args = {
+    "retries": 3,
+    "retry_delay": timedelta(minutes=5),
+}
+
+with DAG(
+    dag_id="customer_analytics_pipeline",
+    sla_miss_callback=alert_on_sla_miss,  # fires if the DAG run exceeds the SLA
+    ...
+) as dag:
+
+    extract_orders = PythonOperator(task_id="extract_orders", default_args=extract_args, ...)
+    extract_customers = PythonOperator(task_id="extract_customers", default_args=extract_args, ...)
+    join_data = PythonOperator(task_id="join_data", sla=timedelta(hours=2), ...)
+    compute_metrics = PythonOperator(task_id="compute_metrics", ...)
+    run_ml_model = PythonOperator(task_id="run_ml_model", ...)
+    update_dashboard = PythonOperator(task_id="update_dashboard", ...)
+    send_report = PythonOperator(task_id="send_report", ...)
+
+    # Dependency chain:
+    [extract_orders, extract_customers] >> join_data >> [compute_metrics, run_ml_model] >> update_dashboard >> send_report
 ```
 
 ### Exercise 2: Make It Idempotent
@@ -251,12 +306,53 @@ def load(input_path, db):
         db.execute("INSERT INTO orders VALUES (%s)", row)  # Bug 3: ???
 ```
 
+```python
+# EXPECTED RESULT — all 3 bugs identified and fixed
+
+# Bug 1: open(output_path, "a") APPENDS to the existing file on every run.
+# Re-running `extract` after a retry or backfill duplicates the raw JSON
+# on disk instead of replacing it. Fix: open in write mode ("w").
+def extract(api_url, output_path):
+    data = requests.get(api_url).json()
+    with open(output_path, "w") as f:  # FIXED: "w" overwrites instead of appending
+        json.dump(data, f)
+
+# Bug 2: Same append bug in transform — re-running appends another copy
+# of the cleaned records to output_path. Fix: also use "w".
+def transform(input_path, output_path):
+    data = json.load(open(input_path))
+    clean = [d for d in data if d["status"] != "cancelled"]
+    with open(output_path, "w") as f:  # FIXED: "w" overwrites instead of appending
+        json.dump(clean, f)
+
+# Bug 3: Plain INSERT with no dedup — re-running `load` inserts duplicate
+# rows for the same orders. Fix: delete-then-insert or upsert on conflict.
+def load(input_path, db):
+    data = json.load(open(input_path))
+    for row in data:
+        db.execute(
+            """
+            INSERT INTO orders VALUES (%s)
+            ON CONFLICT (order_id) DO UPDATE SET
+                customer_id = EXCLUDED.customer_id,
+                total_amount = EXCLUDED.total_amount,
+                status = EXCLUDED.status
+            """,
+            row,
+        )  # FIXED: upsert makes re-runs idempotent
+```
+
 ### Exercise 3: Orchestrator Selection
 
 For each scenario, choose Airflow, Prefect, or Dagster and justify:
 1. A 3-person startup that needs to schedule 5 dbt jobs and 3 Python scripts.
 2. A bank with 200 data engineers, strict audit requirements, and existing Kubernetes.
 3. A data mesh organization with 10 domain teams each owning their own data products.
+
+**Expected result:**
+1. **Prefect** — a tiny team needs the fastest path to a working schedule with minimal infrastructure overhead; Prefect's decorator-based flows and managed Prefect Cloud option get 5 dbt jobs and 3 scripts running with almost no operational burden.
+2. **Airflow** — the bank's scale (200 engineers), strict audit/compliance needs, and existing Kubernetes investment favor Airflow's mature ecosystem, extensive logging/auditability, and native KubernetesExecutor support.
+3. **Dagster** — a data mesh with many domain teams benefits from Dagster's software-defined assets model, which lets each team own and reason about its data products as first-class, testable assets rather than opaque task scripts.
 
 ---
 
@@ -297,4 +393,4 @@ Separate warehouses provide: (1) cost attribution — each team's compute is tra
 - ✅ **Dagster**: Software-defined assets, best for data mesh and domain-oriented architectures
 - ✅ **Idempotency**: The golden rule — every task must produce the same result on re-run
 
-**Tomorrow → Day 126**: **Streaming Pipelines** — Kafka, Pub/Sub, Kinesis — when batch isn't fast enough.
+**Tomorrow → Day 131**: **Streaming Pipelines** — Kafka, Pub/Sub, Kinesis — when batch isn't fast enough.

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_130_Orchestration/quiz.json
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_130_Orchestration/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 130,
+    "questions": [
+        {
+            "id": "d130q01",
+            "type": "multiple_choice",
+            "question": "Why must a workflow orchestration graph be a DAG (Directed Acyclic Graph) rather than allowing cycles?",
+            "options": [
+                "Cycles use too much memory in the scheduler database",
+                "A cycle (A depends on B depends on A) creates a deadlock — no task could ever start because each is waiting on the other, so the acyclic constraint guarantees a valid execution order exists",
+                "Airflow's UI cannot render graphs with cycles",
+                "Cycles are allowed, but only in Prefect and Dagster, not Airflow"
+            ],
+            "answer": 1,
+            "explanation": "The 'acyclic' constraint exists because cyclic dependencies have no valid topological execution order — each task would wait on the other indefinitely."
+        },
+        {
+            "id": "d130q02",
+            "type": "multiple_choice",
+            "question": "A load task does `db.execute(\"INSERT INTO sales VALUES (%s)\", data)` with no dedup logic. Why is this NOT idempotent?",
+            "options": [
+                "INSERT statements always fail on the second run",
+                "Re-running the task after a retry or backfill will insert the same data again, creating duplicate rows instead of producing the same end state",
+                "INSERT is idempotent by default in all SQL databases",
+                "It is idempotent because it uses parameterized queries"
+            ],
+            "answer": 1,
+            "explanation": "Idempotency means running a task once or many times yields the same result. A plain INSERT with no MERGE/UPSERT or delete-then-insert pattern duplicates rows every time the task is retried or re-run."
+        },
+        {
+            "id": "d130q03",
+            "type": "multiple_choice",
+            "question": "A task has `retries=3` and `retry_delay=timedelta(minutes=5)` but no `execution_timeout`. What risk does this leave unaddressed?",
+            "options": [
+                "The task will retry too quickly and overwhelm the source system",
+                "If the task hangs (e.g., a stuck API call) it can run indefinitely, blocking downstream tasks and tying up a worker slot — execution_timeout is needed to force a failure so retries can kick in",
+                "Retries will not be logged without execution_timeout",
+                "The DAG will fail to parse"
+            ],
+            "answer": 1,
+            "explanation": "retries/retry_delay only help after a task fails. Without execution_timeout, a hung task never fails on its own — it can occupy a worker slot and block downstream tasks indefinitely."
+        },
+        {
+            "id": "d130q04",
+            "type": "multiple_choice",
+            "question": "A DAG has `start_date=datetime(2024,1,1)` and is deployed today with `catchup=True` left at its default. What happens?",
+            "options": [
+                "Airflow only runs the DAG for today's interval",
+                "Airflow queues a run for every missed scheduled interval since the start_date — potentially hundreds of historical runs — which can overwhelm the scheduler and workers",
+                "Airflow ignores start_date entirely when catchup is True",
+                "The DAG fails to deploy until catchup is set explicitly"
+            ],
+            "answer": 1,
+            "explanation": "catchup=True (Airflow's default) backfills every missed interval since start_date. For most analytics pipelines that should only process current data, this causes an unexpected backfill storm — set catchup=False."
+        },
+        {
+            "id": "d130q05",
+            "type": "multiple_choice",
+            "question": "A bank with 200 data engineers, strict audit requirements, and an existing Kubernetes platform needs to pick an orchestrator. Which is the best fit and why?",
+            "options": [
+                "Prefect, because it is the fastest to set up for a small team",
+                "Airflow, because of its maturity, large enterprise adoption, extensive auditability/logging ecosystem, and strong Kubernetes-native deployment options (e.g., KubernetesExecutor)",
+                "Dagster, because software-defined assets are required by financial regulators",
+                "No orchestrator is needed; cron jobs are sufficient at this scale"
+            ],
+            "answer": 1,
+            "explanation": "Airflow's market dominance, mature ecosystem, and native Kubernetes executor support make it the standard choice for large, compliance-heavy enterprises with existing K8s infrastructure."
+        }
+    ]
+}

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_131_Streaming_Pipelines/README.md
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_131_Streaming_Pipelines/README.md
@@ -27,7 +27,7 @@ outcomes:
   - "Implement windowed aggregations for real-time analytics"
 ---
 
-# 🌊 Day 126: Streaming Pipelines — Kafka, Pub/Sub, Kinesis
+# 🌊 Day 131: Streaming Pipelines — Kafka, Pub/Sub, Kinesis
 
 > *"Batch is an answer to yesterday's question. Streaming is an answer in real-time — while the question still matters."*
 
@@ -58,6 +58,8 @@ Kafka, Pub/Sub, and Kinesis are the messaging highways that let you build real-t
 ```
 
 ### 2. Apache Kafka Deep Dive
+
+The example below uses `confluent-kafka`, the most widely used Python client for Apache Kafka (a thin wrapper over the high-performance C `librdkafka` library). It shows the two halves of every Kafka integration: a `Producer` that publishes events to a topic, and a `Consumer` that reads them back as part of a consumer group — the same pattern you'll reuse for any real-time pipeline.
 
 ```python
 from confluent_kafka import Producer, Consumer
@@ -214,9 +216,28 @@ def process_session(event, gap_seconds=1800):
 
 Most organizations need **both**: streaming for real-time use cases (alerts, dashboards, ML inference) and batch for complex analytics (training, reporting, reconciliation).
 
+In practice, the decision usually comes down to a concrete freshness number rather than a qualitative feel. If the end-to-end freshness requirement is **under 60 seconds**, true streaming (Kafka/Flink, or Kafka Streams/ksqlDB) is necessary — nothing else can hit that latency. If **1–15 minutes** is tolerable, Spark Structured Streaming in micro-batch mode (e.g., a 5-minute trigger interval) is usually sufficient and far simpler to operate than a fully streaming stack. If **more than 15 minutes** is acceptable, plain scheduled batch is simpler and cheaper — don't reach for streaming infrastructure you don't need. The reasoning is operational: streaming infrastructure (brokers, consumer groups, exactly-once coordination, 24/7 on-call) carries a fixed cost and complexity overhead that only pays for itself once the latency requirement can no longer be met by amortizing work over a batch window.
+
 ### The Lambda Architecture Trap
 
 Don't build two separate pipelines (batch + streaming) that compute the same metrics differently. Instead, use the **Kappa architecture**: stream events into a data lake, then use batch queries on the historical stream data for complex analytics.
+
+---
+
+## Glossary
+
+| Term | Definition |
+| --- | --- |
+| **Topic** | A named, durable stream of events in Kafka/Pub/Sub — conceptually similar to a table, but append-only and consumed via subscription. |
+| **Partition** | A topic is split into ordered, independently consumable partitions to enable parallelism; events with the same key are routed to the same partition. |
+| **Offset** | The position of a message within a partition; consumers track their offset to know what has already been processed. |
+| **Consumer Group** | A set of consumers that share the work of reading a topic — each partition is assigned to exactly one consumer within the group at a time. |
+| **Producer/Broker** | The producer publishes events into the system; the broker (a Kafka server) stores, replicates, and serves those events to consumers. |
+| **At-Least-Once / Exactly-Once delivery** | At-least-once guarantees a message is delivered at least once (possible duplicates); exactly-once guarantees no loss and no duplicates, at the cost of additional coordination and latency. |
+| **Tumbling/Sliding/Session Window** | Tumbling windows are fixed, non-overlapping time buckets; sliding windows are fixed-size but overlapping; session windows are dynamically sized based on activity gaps. |
+| **Backpressure** | The condition where consumers can't keep up with producer throughput, requiring buffering, throttling, or scaling to avoid data loss or unbounded queue growth. |
+| **Idempotent Producer** | A Kafka producer configuration that prevents duplicate messages from being written even if the producer retries a send (e.g., after a network blip). |
+| **Lambda/Kappa Architecture** | Lambda runs separate batch and streaming pipelines for the same metrics (risking inconsistency); Kappa unifies them by treating the stream as the single source of truth, replaying it for batch-style analytics. |
 
 ---
 
@@ -234,6 +255,37 @@ Don't build two separate pipelines (batch + streaming) that compute the same met
 # TODO: Design the topic structure, partition keys,
 # consumer groups, and delivery guarantees for each use case
 streaming_design = {}
+```
+
+```python
+# EXPECTED RESULT
+
+streaming_design = {
+    "fraud_detection": {
+        "topic": "payments",
+        "partition_key": "account_id",  # keeps a single account's events ordered
+        "consumer_group": "fraud-detection-service",
+        "delivery_guarantee": "exactly-once",  # money is involved; duplicates/loss are unacceptable
+    },
+    "live_dashboard": {
+        "topic": "orders",
+        "partition_key": "region",  # enables per-region aggregation in parallel
+        "consumer_group": "dashboard-aggregator",
+        "delivery_guarantee": "at-least-once",  # dashboards tolerate occasional double-counts, fixed on next refresh
+    },
+    "inventory_updates": {
+        "topic": "orders",  # same topic as dashboard, different consumer group
+        "partition_key": "product_id",  # ensures stock decrements for a product are ordered
+        "consumer_group": "inventory-service",
+        "delivery_guarantee": "at-least-once",  # idempotent decrement logic absorbs duplicates
+    },
+    "recommendations": {
+        "topic": "user-clicks",
+        "partition_key": "session_id",  # keeps a user's session events together for the recommender
+        "consumer_group": "recommendation-engine",
+        "delivery_guarantee": "at-most-once",  # losing an occasional click event doesn't materially hurt recommendation quality
+    },
+}
 ```
 
 ### Exercise 2: Partition Key Selection
@@ -258,6 +310,28 @@ streaming_design = {}
 def tumbling_window_counter(events: list, window_seconds: int = 60, grace_seconds: int = 10):
     """Process a list of events and return per-window, per-type counts."""
     pass
+```
+
+```python
+# Sample input events (window_seconds=60, grace_seconds=10)
+# Window 0 covers t=[0, 60); Window 1 covers t=[60, 120)
+events = [
+    {"timestamp": 5,  "event_type": "page_view"},
+    {"timestamp": 30, "event_type": "click"},
+    {"timestamp": 58, "event_type": "page_view"},
+    {"timestamp": 65, "event_type": "click"},
+    # Late-arriving event: logically belongs to window 0 (t=55) but is
+    # processed/arrives at t=63 — still within the 10s grace period
+    # after window 0 closes at t=60, so it is still counted in window 0.
+    {"timestamp": 55, "event_type": "page_view", "arrival_time": 63},
+]
+
+# EXPECTED RESULT
+tumbling_window_counter(events, window_seconds=60, grace_seconds=10)
+# {
+#     0: {"page_view": 3, "click": 1},   # includes the late event at t=55 (arrived at t=63, within grace)
+#     1: {"click": 1},                   # event at t=65
+# }
 ```
 
 ---
@@ -299,4 +373,4 @@ A tumbling window has a fixed, non-overlapping duration (e.g., "count per 1-minu
 - ✅ **Windowing**: Tumbling (fixed), sliding (overlapping), session (activity-based) — for streaming aggregations
 - ✅ **Decision**: Use streaming for <1s latency needs; batch for complex analytics; most platforms need both
 
-**Tomorrow → Day 127**: **Lakehouse Architecture** — Databricks, Unity Catalog, Delta Live Tables — merging the best of data lakes and warehouses.
+**Tomorrow → Day 132**: **Lakehouse Architecture** — Databricks, Unity Catalog, Delta Live Tables — merging the best of data lakes and warehouses.

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_131_Streaming_Pipelines/quiz.json
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_131_Streaming_Pipelines/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 131,
+    "questions": [
+        {
+            "id": "d131q01",
+            "type": "multiple_choice",
+            "question": "A Kafka topic has 6 partitions and a consumer group has 3 consumers. What happens, and what happens if a consumer fails?",
+            "options": [
+                "Each consumer reads all 6 partitions; on failure, nothing changes",
+                "Each consumer is assigned 2 partitions; if one consumer fails, its partitions are reassigned to the surviving consumers (rebalancing)",
+                "Only one consumer is active at a time; the other two are idle standbys",
+                "Partitions are split evenly only if the consumer count divides evenly into the partition count, otherwise the group fails to start"
+            ],
+            "answer": 1,
+            "explanation": "A consumer group divides partitions across its members for parallel processing. If a consumer dies, the group rebalances and reassigns its partitions to the remaining consumers, providing both parallelism and fault tolerance."
+        },
+        {
+            "id": "d131q02",
+            "type": "multiple_choice",
+            "question": "Why does exactly-once delivery typically have higher latency than at-least-once delivery?",
+            "options": [
+                "Exactly-once always requires a slower network protocol",
+                "Exactly-once requires transactional coordination (idempotent producer, transactional writes, read-committed consumers, atomic offset commits) that adds overhead at-least-once doesn't need",
+                "Exactly-once is only available with at-most-once semantics, which inherently doubles latency",
+                "There is no latency difference; the difference is only in storage cost"
+            ],
+            "answer": 1,
+            "explanation": "Exactly-once relies on Kafka transactions and idempotent producers plus read-committed isolation, adding coordination overhead. At-least-once with idempotent consumers is simpler and faster, which is why most pipelines prefer it."
+        },
+        {
+            "id": "d131q03",
+            "type": "multiple_choice",
+            "question": "A team is on GCP, wants zero infrastructure management, and doesn't have in-house Kafka expertise. Which should they choose, and why?",
+            "options": [
+                "Kafka, because it has the largest open-source community",
+                "Google Pub/Sub, because it's fully serverless/managed, integrates natively with GCP, and requires no broker administration",
+                "Kafka, because Pub/Sub cannot guarantee message ordering under any configuration",
+                "Neither — they should build a custom queue on top of Cloud Storage"
+            ],
+            "answer": 1,
+            "explanation": "Pub/Sub is a fully managed, serverless messaging service well suited to teams that want to avoid operating Kafka brokers themselves and are already on GCP. Kafka is preferable when exactly-once semantics, very low latency, or fine-grained replication control are required."
+        },
+        {
+            "id": "d131q04",
+            "type": "multiple_choice",
+            "question": "A partition key of `user_id` is used for clickstream events, but one celebrity user generates 90% of all traffic. What problem does this create and how is it typically solved?",
+            "options": [
+                "This is the 'cold partition' problem; solved by increasing replication_factor",
+                "This is the 'hot partition' problem; solved by adding a random suffix to the key, using a composite key (e.g., user_id + hour), or using a key-less/random partitioning strategy when ordering isn't required",
+                "This is a consumer group rebalancing bug; solved by adding more brokers",
+                "This is expected behavior and requires no remediation since Kafka auto-balances hot keys"
+            ],
+            "answer": 1,
+            "explanation": "A hot partition occurs when one key dominates traffic, overloading the single partition (and its consumer) that key maps to. Common fixes include salting the key, using a composite key, or dropping strict per-key ordering in favor of even distribution."
+        },
+        {
+            "id": "d131q05",
+            "type": "multiple_choice",
+            "question": "What is the key difference between a tumbling window and a session window in stream processing?",
+            "options": [
+                "Tumbling windows overlap; session windows never overlap",
+                "Tumbling windows have a fixed, non-overlapping duration (e.g., every 60 seconds); session windows have a dynamic duration based on activity, closing after a period of inactivity (e.g., 30 minutes of no events)",
+                "Session windows are only used for batch processing, not streaming",
+                "There is no difference; both terms describe the same windowing strategy"
+            ],
+            "answer": 1,
+            "explanation": "Tumbling windows are fixed-size, non-overlapping intervals (e.g., 'count events per minute'). Session windows have variable length, closing a session once a gap of inactivity (the session gap) is exceeded — ideal for grouping bursty user activity."
+        }
+    ]
+}

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_132_Lakehouse_Architecture/README.md
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_132_Lakehouse_Architecture/README.md
@@ -27,7 +27,7 @@ outcomes:
   - "Build a declarative ETL pipeline with Delta Live Tables"
 ---
 
-# 🏠 Day 127: Lakehouse Architecture — Databricks, Unity Catalog, Delta Live Tables
+# 🏠 Day 132: Lakehouse Architecture — Databricks, Unity Catalog, Delta Live Tables
 
 > *"The lakehouse ended the data lake vs. data warehouse debate — by combining the best of both into a single platform."*
 
@@ -56,6 +56,17 @@ The **lakehouse** is both: store everything cheaply in open formats (like a data
 | **Unstructured Data**  | ✅ Yes                    | ❌ No               | ✅ Yes                 |
 | **Cost**               | 💰 Low                    | 💰💰💰 High           | 💰💰 Medium             |
 | **Governance**         | ❌ Manual                 | ✅ Built-in         | ✅ Unity Catalog       |
+
+### Choosing a Table Format: Delta Lake vs. Iceberg vs. Apache Hudi
+
+The table above names "Delta Lake / Iceberg" as the open storage format for a lakehouse, but doesn't say which one to pick — or where Apache Hudi fits in. The three open table formats overlap heavily but optimize for different workloads:
+
+| Dimension | Delta Lake | Apache Iceberg | Apache Hudi |
+| --- | --- | --- | --- |
+| **Primary strength** | Deep integration with ACID transactions, time travel, and DLT-style declarative pipelines | Multi-engine interoperability and flexible partition evolution without rewriting data | Fast, incremental upserts and native change-data-capture (CDC) |
+| **Best engine/ecosystem fit** | Databricks / Spark-first shops | Engine-agnostic: Trino, Snowflake, BigQuery, Spark, Flink | Spark/Flink shops doing heavy streaming writes |
+| **Write pattern** | Batch-heavy, with good streaming reads | Batch-heavy, schema/partition evolution over time | Streaming-upsert-heavy, frequent small writes |
+| **Choose this when...** | You're standardized on Databricks/Spark and want batch + streaming reads from one format. | You need multiple query engines reading the same tables and expect partitioning schemes to change. | You're ingesting high-frequency CDC streams and need the most efficient incremental upserts (e.g., near-real-time database replication into the lake). |
 
 ### 2. Databricks Architecture
 
@@ -187,6 +198,25 @@ Databricks uses Delta Lake (open source) on open storage (S3/GCS/ADLS). Your dat
 
 ---
 
+## Glossary
+
+| Term | Definition |
+| --- | --- |
+| **Lakehouse** | An architecture that combines data lake storage (cheap, open formats) with data warehouse features (ACID transactions, schema enforcement, fast SQL) in a single platform. |
+| **Delta Lake** | An open-source storage layer that adds ACID transactions, schema enforcement, and time travel on top of Parquet files in object storage. |
+| **Unity Catalog** | Databricks' centralized governance layer providing a three-level namespace, fine-grained access control, lineage tracking, and data discovery across workspaces. |
+| **Delta Live Tables (DLT)** | A declarative framework for building ETL pipelines in Databricks; you define the desired tables and Databricks handles incremental processing and quality checks. |
+| **Photon Engine** | Databricks' native C++ vectorized query engine that accelerates SQL and DataFrame workloads 3-12x over standard Spark, at no extra cost on supported clusters. |
+| **ACID Transaction** | A database operation guaranteed to be Atomic, Consistent, Isolated, and Durable — ensuring concurrent reads/writes don't corrupt or partially apply data. |
+| **Schema Enforcement** | The system rejects writes that don't match the expected table schema, preventing silent data corruption from malformed or unexpected columns. |
+| **Medallion Architecture** | A data design pattern with three layers — bronze (raw), silver (cleaned/validated), gold (business-ready aggregates) — used to progressively refine data quality. |
+| **Row-Level Security** | An access control mechanism that filters which rows a user can see in a table based on their identity or group membership (e.g., analysts only see their own region). |
+| **Column Masking** | A governance technique that obscures or redacts sensitive column values (e.g., emails, SSNs) for users who lack the required permission group. |
+| **Auto Loader** | A Databricks feature (`cloudFiles` format) that incrementally and efficiently processes new files landing in cloud storage using cloud-native notifications instead of file listing. |
+| **Three-Level Namespace** | Unity Catalog's `catalog.schema.table` addressing scheme, which allows the same governance model to span multiple workspaces and environments. |
+
+---
+
 ## Hands-on Lab
 
 ### Exercise 1: Design a Unity Catalog Namespace
@@ -201,6 +231,32 @@ Databricks uses Delta Lake (open source) on open storage (S3/GCS/ADLS). Your dat
 # TODO: Design the catalog/schema hierarchy and access matrix
 # Include: which teams can read/write which schemas
 # Consider: PII columns, row-level security by region
+```
+
+```python
+# EXPECTED RESULT — Access matrix (schema x team -> permission)
+#
+# Catalog: prod_retail
+# Schemas: bronze, silver, gold, finance, features
+#
+# | Schema    | Data Engineering | Marketing Analytics | Finance        | ML Team        |
+# |-----------|------------------|----------------------|----------------|----------------|
+# | bronze    | ALL PRIVILEGES   | NO ACCESS            | NO ACCESS      | SELECT         |
+# | silver    | ALL PRIVILEGES   | SELECT (row-filtered)| SELECT (full)  | SELECT         |
+# | gold      | ALL PRIVILEGES   | SELECT (row-filtered)| SELECT (full)  | SELECT         |
+# | finance   | SELECT           | NO ACCESS            | ALL PRIVILEGES | NO ACCESS      |
+# | features  | ALL PRIVILEGES   | NO ACCESS            | NO ACCESS      | ALL PRIVILEGES |
+#
+# Row-level security by region:
+# - silver.customers and gold.daily_revenue have a ROW FILTER on `region`.
+# - Marketing Analytics sees only their assigned region's rows (e.g., "NA-analysts" -> region = 'NA').
+# - Finance and Data Engineering are in the 'global-analysts' group and bypass the filter (see all regions).
+#
+# PII column masking:
+# - silver.customers.email, silver.customers.phone, silver.customers.ssn use MASK functions.
+# - Only Finance (in the 'pii-access' group) sees unmasked values; Marketing Analytics and ML Team see masked values.
+# - bronze schema is considered pre-validation and is restricted entirely from Marketing Analytics
+#   to avoid exposure to unmasked, unvalidated PII.
 ```
 
 ### Exercise 2: DLT Quality Expectations
@@ -268,4 +324,4 @@ A traditional warehouse (Snowflake, BigQuery) may be better when: (1) your data 
 - ✅ **Delta Live Tables** provides declarative ETL with built-in data quality expectations
 - ✅ **Photon engine** delivers 3-12x SQL performance improvement over vanilla Spark
 
-**Tomorrow → Day 128**: **Data Contracts and Quality** — Great Expectations, Soda, and the discipline of treating data like a product.
+**Tomorrow → Day 133**: **Data Contracts and Quality** — Great Expectations, Soda, and the discipline of treating data like a product.

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_132_Lakehouse_Architecture/quiz.json
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_132_Lakehouse_Architecture/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 132,
+    "questions": [
+        {
+            "id": "d132q01",
+            "type": "multiple_choice",
+            "question": "Which combination of capabilities does the lakehouse architecture add on top of cheap, open object storage to compete with a traditional data warehouse?",
+            "options": [
+                "Proprietary file formats and vendor-managed compute only",
+                "ACID transactions, schema enforcement, and fast SQL performance",
+                "Unlimited free storage with no governance layer",
+                "Manual schema validation scripts run nightly"
+            ],
+            "answer": 1,
+            "explanation": "The lakehouse combines data lake cost/flexibility with data warehouse-grade ACID transactions, schema enforcement, and fast SQL (via engines like Photon) — without needing a proprietary storage format."
+        },
+        {
+            "id": "d132q02",
+            "type": "multiple_choice",
+            "question": "In Delta Live Tables, what does `@dlt.expect_or_drop(\"valid_amount\", \"total_amount > 0\")` do?",
+            "options": [
+                "Halts the entire pipeline if any row fails the check",
+                "Logs a warning but keeps rows that fail the check",
+                "Silently drops only the rows that fail the check, keeping the pipeline running",
+                "Converts failing rows to null values instead of dropping them"
+            ],
+            "answer": 2,
+            "explanation": "expect_or_drop removes (drops) rows that violate the expectation while letting the rest of the pipeline continue. expect just warns and keeps the row; expect_or_fail halts the whole pipeline."
+        },
+        {
+            "id": "d132q03",
+            "type": "multiple_choice",
+            "question": "What does Unity Catalog provide that simple database-level GRANT statements do not?",
+            "options": [
+                "Faster SQL query execution via the Photon engine",
+                "Centralized cross-workspace governance, column masking, row-level security, lineage, and audit logging",
+                "The ability to run GRANT statements without SQL syntax",
+                "Automatic conversion of CSV files into Delta tables"
+            ],
+            "answer": 1,
+            "explanation": "Unity Catalog acts as a governance layer above individual databases/workspaces: one set of permissions spans dev/staging/prod, plus features like row filters, column masks, and lineage that plain GRANT statements lack."
+        },
+        {
+            "id": "d132q04",
+            "type": "multiple_choice",
+            "question": "Why is Databricks Auto Loader (the `cloudFiles` format) preferred over manually listing files in cloud storage for streaming ingestion?",
+            "options": [
+                "It compresses files before loading them to save storage costs",
+                "It uses cloud-native notifications (e.g., S3 SNS/SQS) for constant-time new-file detection instead of slow, expensive directory listing at scale",
+                "It automatically writes data in JSON instead of Parquet",
+                "It eliminates the need for any schema definition"
+            ],
+            "answer": 1,
+            "explanation": "Auto Loader relies on cloud notification services to detect new files as they land, which scales to millions/billions of files. Manual file listing gets slower and more expensive as file counts grow."
+        },
+        {
+            "id": "d132q05",
+            "type": "multiple_choice",
+            "question": "In which scenario would a traditional cloud data warehouse (e.g., Snowflake, BigQuery) likely be a better fit than a lakehouse?",
+            "options": [
+                "The team needs to run both ML feature engineering and BI dashboards off the same raw data",
+                "The data is a mix of structured tables, images, and unstructured logs",
+                "The data is 100% structured/tabular, there are no ML workloads, and the team wants a fully managed system with no Spark expertise required",
+                "The company needs fine-grained row-level and column-level governance across many teams"
+            ],
+            "answer": 2,
+            "explanation": "A traditional warehouse shines for purely structured data, no ML need, no in-house Spark skills, and a preference for a fully managed, zero-ops system. The lakehouse advantage emerges with mixed data types, ML+BI on one copy of data, or large-scale governance needs."
+        }
+    ]
+}

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_133_Data_Contracts_and_Quality/README.md
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_133_Data_Contracts_and_Quality/README.md
@@ -27,7 +27,7 @@ outcomes:
   - "Define and monitor data SLAs for production pipelines"
 ---
 
-# ✅ Day 128: Data Contracts and Quality — Great Expectations, Soda, SLAs
+# ✅ Day 133: Data Contracts and Quality — Great Expectations, Soda, SLAs
 
 > *"Bad data doesn't just produce wrong reports — it erodes trust. And once business users stop trusting the data, they stop using it. That's the real cost."*
 
@@ -96,6 +96,8 @@ contract:
 ```
 
 ### 2. Great Expectations — Build Expectation Suites
+
+Great Expectations follows a consistent workflow regardless of the data source: you get a **Context** (the project configuration), register a **datasource** pointing at your data, attach an **expectation suite** (a named collection of rules), and then **validate** a batch of data against that suite. The code below walks through each of those four steps in order — context, datasource, suite, validate — building up the suite one expectation at a time before running it.
 
 ```python
 import great_expectations as gx
@@ -238,9 +240,35 @@ def check_freshness_sla(table: str, last_updated: datetime) -> dict:
 
 Data contracts aren't just technical documents — they're agreements between teams. The producing team commits to quality guarantees; the consuming team agrees on change notification periods. Breaking changes need 14-day notice. This reduces the "I changed the column name and broke 5 dashboards" problem.
 
+### Getting Organizational Buy-In for Data Contracts
+
+Data contracts fail to gain traction when they're pitched as an abstract "data quality initiative" — engineering leadership doesn't fund abstractions. Make the pitch concrete instead:
+
+- **Start with a pilot, not a mandate.** Pick the single table with the highest incident rate (check your incident tracker or Slack #data-alerts channel) and write one contract for it. A working example beats a company-wide policy doc nobody reads.
+- **Frame the pitch in hours, not quality scores.** Don't say "this improves data quality." Say "analysts spent 12 hours last month debugging a schema change that a contract would have caught in CI." Dollars and hours move budget conversations; abstract quality scores don't.
+- **Get ownership written into sprint commitments.** A contract with no enforcement is a wish list. Push to get "maintain `orders` contract SLA" written into the producing team's OKRs or sprint capacity — otherwise it's the first thing dropped under deadline pressure.
+- **Use a recent incident as the forcing function.** If a dashboard broke last week because a column was silently renamed, that incident is your leverage — reference it directly when asking for contract sign-off. Lessons attached to real pain land; lessons attached to hypotheticals don't.
+
 ### Quality as a Feature, Not a Tax
 
 Teams that treat data quality as an afterthought build "data quality tax" — cleaning bad data becomes 60% of analysts' time. Teams that build quality into the pipeline (expectations in DLT, Soda checks in CI/CD) spend 10% on quality and 90% on insights.
+
+---
+
+## Glossary
+
+| Term | Definition |
+| --- | --- |
+| **Data Contract** | A formal, version-controlled agreement between a data producer and its consumers specifying schema, quality guarantees, freshness, and change-management policy. |
+| **SLA/SLO** | Service Level Agreement / Service Level Objective — a measurable commitment (e.g., "99.5% availability," "fresh within 2 hours") that defines acceptable performance for a data asset. |
+| **Expectation Suite** | A named, reusable collection of Great Expectations rules (e.g., not-null, uniqueness, value ranges) applied together to validate a dataset. |
+| **Freshness** | A measure of how recent the data in a table is relative to when it should have been updated, typically monitored against a maximum allowed delay. |
+| **Completeness** | A data quality dimension measuring whether expected rows and non-null values are present (e.g., minimum row count, maximum null rate). |
+| **Accuracy** | A data quality dimension measuring whether values are correct and free of duplication or error (e.g., duplicate rate below a threshold). |
+| **Schema Drift** | An unexpected change in a table's structure (added/removed/renamed/retyped columns) that can silently break downstream consumers. |
+| **Soda** | A SQL-native, YAML-configured data quality tool used to define and run checks (freshness, volume, nulls, anomalies) against warehouse tables. |
+| **Great Expectations** | A Python-based data validation framework providing hundreds of built-in "expectations" for asserting properties of a dataset. |
+| **Breaking Change Notice Period** | The minimum advance notice (e.g., 14 days) a data producer must give consumers before making a change that could break downstream pipelines or dashboards. |
 
 ---
 
@@ -263,6 +291,34 @@ Teams that treat data quality as an afterthought build "data quality tax" — cl
 # 3. Currency must be one of: USD, EUR, GBP, JPY
 # 4. Transaction_date must be within last 365 days
 # 5. Row count anomaly detection (compare to 7-day average)
+
+# Sample data to validate against (assume "today" = 2026-06-22, 7-day avg row count = 6):
+sample_transactions = [
+    {"transaction_id": "TXN1001", "amount": 250.00,      "currency": "USD", "transaction_date": "2026-06-20"},
+    {"transaction_id": "TXN1002", "amount": -75.50,       "currency": "EUR", "transaction_date": "2026-06-21"},
+    {"transaction_id": None,      "amount": 1200.00,      "currency": "GBP", "transaction_date": "2026-06-19"},
+    {"transaction_id": "TXN1004", "amount": 2_500_000.00, "currency": "USD", "transaction_date": "2026-06-18"},
+    {"transaction_id": "TXN1005", "amount": 99.99,        "currency": "BTC", "transaction_date": "2026-06-15"},
+    {"transaction_id": "TXN1006", "amount": 42.00,        "currency": "JPY", "transaction_date": "2023-01-10"},
+]
+```
+
+```python
+# EXPECTED RESULT — pass/fail per expectation
+#
+# | transaction_id | not_null + unique | amount in [-1M, 1M] | currency in {USD,EUR,GBP,JPY} | date within 365 days | Notes                         |
+# |-----------------|--------------------|----------------------|----------------------------------|------------------------|--------------------------------|
+# | TXN1001         | PASS               | PASS                 | PASS                              | PASS                   | Fully valid record             |
+# | TXN1002         | PASS               | PASS                 | PASS                              | PASS                   | Valid refund (negative amount) |
+# | None            | FAIL (null id)     | PASS                 | PASS                              | PASS                   | Null transaction_id            |
+# | TXN1004         | PASS               | FAIL (out of range)  | PASS                              | PASS                   | Amount exceeds 1M cap          |
+# | TXN1005         | PASS               | PASS                 | FAIL (invalid currency)           | PASS                   | "BTC" not in allowed list      |
+# | TXN1006         | PASS               | PASS                 | PASS                              | FAIL (stale date)      | Date is >365 days old (2023)   |
+#
+# Row-count anomaly check: 6 rows received vs. a 7-day average of 6 -> 0% deviation -> PASS (no anomaly).
+# If only 2 rows had arrived instead of 6, that's a ~67% deviation -> FAIL (anomaly flagged, likely an upstream ingestion gap).
+#
+# Overall suite result: FAILED (3 of 6 records violate at least one expectation: null id, amount range, invalid currency, and stale date).
 ```
 
 ### Exercise 3: SLA Dashboard Design
@@ -314,4 +370,4 @@ Data quality checks are deterministic rules: "this column must not be null," "va
 - ✅ **Data SLAs** define freshness, completeness, and accuracy guarantees with monitoring
 - ✅ **Quality is a feature**: Build it into the pipeline, don't bolt it on afterward
 
-**Tomorrow → Day 129**: **Cloud Security and Compliance** — VPC, encryption, PII handling, and the regulations every data engineer must know.
+**Tomorrow → Day 134**: **Cloud Security and Compliance** — VPC, encryption, PII handling, and the regulations every data engineer must know.

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_133_Data_Contracts_and_Quality/quiz.json
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_133_Data_Contracts_and_Quality/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 133,
+    "questions": [
+        {
+            "id": "d133q01",
+            "type": "multiple_choice",
+            "question": "Who should own a data contract for a given table?",
+            "options": [
+                "Only the consuming analytics team, since they define the requirements",
+                "Co-owned: the producing team commits to the guarantees, and consuming teams specify their requirements, version-controlled and validated in CI/CD",
+                "No one — data contracts are informal and don't need an owner",
+                "The platform/infrastructure team, regardless of who produces or consumes the data"
+            ],
+            "answer": 1,
+            "explanation": "A data contract is a co-owned agreement: the producing team commits to meeting schema/quality/freshness guarantees, while consuming teams specify what they need. Best practice is to version-control it in Git and validate it automatically in CI/CD."
+        },
+        {
+            "id": "d133q02",
+            "type": "multiple_choice",
+            "question": "When should you prefer Great Expectations over dbt tests for a data quality check?",
+            "options": [
+                "Always — Great Expectations should fully replace dbt tests in every pipeline",
+                "Never — dbt tests cover every validation use case",
+                "For complex validations before data enters the warehouse, such as schema drift detection, distribution checks, anomaly detection, and non-dbt environments",
+                "Only when the table has fewer than 1,000 rows"
+            ],
+            "answer": 2,
+            "explanation": "dbt tests are ideal for in-warehouse checks that live inside the transformation DAG (uniqueness, not-null, referential integrity). Great Expectations is better suited for richer pre-warehouse validation like schema drift, distribution checks, anomaly detection, and environments outside dbt."
+        },
+        {
+            "id": "d133q03",
+            "type": "multiple_choice",
+            "question": "How is a freshness SLA typically monitored?",
+            "options": [
+                "By manually checking the table once a week",
+                "By comparing MAX(updated_at) or similar timestamp against the current time and alerting if the gap exceeds the SLA threshold",
+                "By counting the total number of rows in the table",
+                "By checking whether the table's schema has changed"
+            ],
+            "answer": 1,
+            "explanation": "Freshness SLAs guarantee how recent data should be (e.g., 'updated within 2 hours'). Monitoring compares the latest timestamp in the data against the current time; if the gap exceeds the SLA, an alert fires. Soda's freshness() check or a custom query implements this."
+        },
+        {
+            "id": "d133q04",
+            "type": "multiple_choice",
+            "question": "What is the key difference between deterministic data quality checks and anomaly detection?",
+            "options": [
+                "Deterministic checks only work on numeric columns; anomaly detection only works on text columns",
+                "Deterministic checks are rule-based and catch known failure modes (e.g., 'must not be null'); anomaly detection uses statistical methods to catch unknown/unexpected issues (e.g., row count deviating from a historical baseline)",
+                "Anomaly detection replaces the need for any rule-based checks",
+                "There is no meaningful difference; both terms describe the same technique"
+            ],
+            "answer": 1,
+            "explanation": "Rule-based checks catch known, well-defined problems (nulls, ranges, duplicates). Anomaly detection uses statistics (e.g., standard deviations from a rolling average) to flag unexpected patterns that no one explicitly wrote a rule for. Both are needed together."
+        },
+        {
+            "id": "d133q05",
+            "type": "multiple_choice",
+            "question": "Your data quality dashboard shows a sudden 15% spike in null email addresses for a customer table. What is the correct triage approach?",
+            "options": [
+                "Silently filter out the null records so the dashboard looks clean again",
+                "Ignore it since it's a small percentage increase",
+                "Investigate the source system and ETL pipeline for recent changes, check whether the producing team is aware via the data contract, and avoid silently hiding the records while you investigate",
+                "Immediately delete the affected rows from the production table"
+            ],
+            "answer": 2,
+            "explanation": "The correct response is to investigate root cause (source app change, ETL bug), check contract awareness with the producing team, and only apply a temporary, visible fix (not a silent filter) while the real issue is resolved. Hiding the problem masks a signal you need to fix it permanently."
+        }
+    ]
+}

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_134_Cloud_Security_and_Compliance/README.md
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_134_Cloud_Security_and_Compliance/README.md
@@ -28,7 +28,7 @@ outcomes:
   - "Map compliance requirements to technical controls"
 ---
 
-# 🔒 Day 129: Cloud Security and Compliance — VPC, Encryption, PII
+# 🔒 Day 134: Cloud Security and Compliance — VPC, Encryption, PII
 
 > *"Security isn't a feature you add at the end — it's a constraint you design around from day one. The cost of a data breach is $4.88M average (IBM 2024). The cost of doing it right is a fraction of that."*
 
@@ -179,6 +179,8 @@ def tokenize_ssn(ssn: str) -> str:
 
 ### 4. Compliance Frameworks
 
+Each regulatory framework has its own scope, requirements, and technical controls — but the underlying infrastructure (encryption, access control, audit logging) is shared across all of them. Mapping each framework into a single structure lets you cross-check one technical control, like encryption, against every applicable regulation at once, instead of researching each framework's requirements from scratch every time an auditor asks.
+
 ```python
 compliance_matrix = {
     "GDPR": {
@@ -246,6 +248,25 @@ db_password = os.environ["DB_PASSWORD"]
 
 ---
 
+## Glossary
+
+| Term | Definition |
+| --- | --- |
+| **VPC** | Virtual Private Cloud — an isolated, software-defined network within a cloud provider where you control IP ranges, subnets, and routing. |
+| **Subnet** | A subdivision of a VPC's IP range, typically scoped to public (internet-facing) or private (internal-only) resources. |
+| **Security Group** | A virtual firewall attached to resources (e.g., EC2 instances, RDS) that controls inbound and outbound traffic at the instance level. |
+| **CMK (Customer Managed Keys)** | Encryption keys that the customer creates, owns, and controls the lifecycle/rotation/permissions of (as opposed to provider-managed default keys), used for encrypting data at rest via services like AWS KMS or GCP CMEK. |
+| **SSE-KMS** | Server-Side Encryption with AWS Key Management Service — an S3 encryption mode where AWS manages encryption using a KMS key (which can be a CMK) instead of leaving data unencrypted or using only the default S3 key. |
+| **TLS** | Transport Layer Security — the cryptographic protocol that encrypts data in transit between clients and servers (e.g., HTTPS, database SSL connections). |
+| **PII** | Personally Identifiable Information — any data that can identify a specific individual, such as name, SSN, email, or phone number. |
+| **Quasi-Identifier** | A data attribute (e.g., name, email, DOB, zip code) that isn't uniquely identifying alone but can identify a person when combined with other quasi-identifiers. |
+| **Tokenization** | Replacing sensitive data with a non-sensitive placeholder token (e.g., showing only the last 4 digits of an SSN) that has no exploitable value if exposed. |
+| **GDPR/DSAR** | General Data Protection Regulation — EU privacy law; a DSAR (Data Subject Access Request) is a formal request from an individual to access, correct, or delete their personal data. |
+| **SOC 2** | A compliance framework (Service Organization Control 2) auditing a company's controls across security, availability, confidentiality, processing integrity, and privacy. |
+| **Secrets Manager** | A dedicated service (e.g., AWS Secrets Manager, HashiCorp Vault) for securely storing, rotating, and auditing access to credentials instead of hardcoding them in code or config files. |
+
+---
+
 ## Hands-on Lab
 
 ### Exercise 1: VPC Security Design
@@ -257,6 +278,55 @@ db_password = os.environ["DB_PASSWORD"]
 # - Redshift cluster (accessible from Airflow + BI tool on VPN)
 # - S3 access (via VPC endpoint, no internet traversal)
 # Draw the subnet layout and security group rules.
+```
+
+```python
+# EXPECTED RESULT — subnet / security group layout (mirrors the vpc_architecture pattern above)
+expected_vpc_design = {
+    "vpc": {"cidr": "10.0.0.0/16"},
+    "subnets": {
+        "public": {
+            "cidr": "10.0.1.0/24",
+            "purpose": "NAT Gateway only (no compute placed here)",
+            "internet_access": True,
+        },
+        "private_app": {
+            "cidr": "10.0.10.0/24",
+            "purpose": "Airflow workers (need outbound internet for PyPI via NAT)",
+            "internet_access": "Via NAT Gateway only (outbound)",
+        },
+        "private_data": {
+            "cidr": "10.0.20.0/24",
+            "purpose": "PostgreSQL metadata DB, Redshift cluster",
+            "internet_access": False,
+        },
+    },
+    "security_groups": {
+        "airflow_sg": {
+            "outbound": [
+                {"port": 5432, "destination": "postgres_sg"},   # metadata DB
+                {"port": 5439, "destination": "redshift_sg"},   # Redshift
+                {"port": 443, "destination": "0.0.0.0/0"},      # PyPI via NAT
+            ],
+        },
+        "postgres_sg": {
+            "inbound": [{"port": 5432, "source": "airflow_sg"}],
+            "outbound": [],  # no internet access at all
+        },
+        "redshift_sg": {
+            "inbound": [
+                {"port": 5439, "source": "airflow_sg"},
+                {"port": 5439, "source": "vpn_cidr"},  # BI tool over VPN
+            ],
+            "outbound": [],
+        },
+    },
+    "vpc_endpoints": {
+        "s3_gateway_endpoint": "Attached to private_app and private_data route tables; S3 traffic never leaves the AWS network or touches the NAT Gateway.",
+    },
+}
+# Key result: PostgreSQL and Redshift have zero direct internet exposure;
+# only Airflow's outbound PyPI traffic and the BI tool's VPN access cross a controlled boundary.
 ```
 
 ### Exercise 2: PII Handling Pipeline
@@ -275,6 +345,30 @@ def classify_and_mask(df, pii_config: dict):
     pass
 ```
 
+```python
+# Sample input rows
+sample_rows = [
+    {"email": "john.doe@company.com", "phone": "555-123-4567", "name": "John Doe",   "ssn": "123-45-6789", "address": "12 Main St, Springfield"},
+    {"email": "amy.lee@company.com",  "phone": "555-987-6543", "name": "Amy Lee",    "ssn": "987-65-4321", "address": "45 Oak Ave, Riverdale"},
+    {"email": "raj.patel@company.com","phone": "555-222-3333", "name": "Raj Patel",  "ssn": "456-78-9012", "address": "9 Elm St, Lakeview"},
+]
+
+# EXPECTED RESULT — masked output for each row
+expected_output = [
+    {"email": "j***e@company.com", "phone": "***-***-4567", "name": "J***",  "ssn": "***-**-6789", "address": "a1b2c3d4e5f60718"},  # hash_pii(address)
+    {"email": "a***e@company.com", "phone": "***-***-6543", "name": "A***",  "ssn": "***-**-4321", "address": "f9e8d7c6b5a40392"},
+    {"email": "r***l@company.com", "phone": "***-***-3333", "name": "R***",  "ssn": "***-**-9012", "address": "3c4d5e6f7a8b9c0d"},
+]
+# Notes:
+# - email uses mask_email(): first + last char of local part kept, rest replaced with ***
+# - phone shows only last 4 digits, rest replaced with ***-***- prefix
+# - name keeps first initial + "***" (no last-name leakage)
+# - ssn uses tokenize_ssn(): last 4 digits visible, rest replaced
+# - address is one-way hashed via hash_pii() — same input always produces the same hash,
+#   so rows can still be grouped/joined on address without exposing the raw value
+#   (actual hex digests above are illustrative; real output depends on the salt used)
+```
+
 ### Exercise 3: GDPR Deletion Request
 
 ```python
@@ -285,6 +379,39 @@ def classify_and_mask(df, pii_config: dict):
 # 3. Handles Delta Lake time travel (historical versions still contain PII)
 # 4. Logs the deletion for compliance audit trail
 # 5. Notifies downstream consumers
+```
+
+```python
+# EXPECTED RESULT — 5-step deletion checklist applied to a concrete example
+#
+# Example user: customer_id = 88231, email = "jane.smith@example.com"
+#
+# 1. DISCOVER:
+#    Search bronze.raw_orders, silver.clean_orders, gold.daily_revenue (aggregated — no row-level PII),
+#    silver.customers, and features.customer_embeddings for customer_id = 88231.
+#    Result: found in bronze.raw_orders (3 rows), silver.clean_orders (3 rows), silver.customers (1 row),
+#    features.customer_embeddings (1 row). gold.daily_revenue is pre-aggregated, no action needed.
+#
+# 2. DELETE OR ANONYMIZE:
+#    DELETE FROM silver.customers WHERE customer_id = 88231;
+#    UPDATE bronze.raw_orders SET customer_email = NULL, customer_name = NULL WHERE customer_id = 88231;
+#    DELETE FROM features.customer_embeddings WHERE customer_id = 88231;
+#
+# 3. HANDLE TIME TRAVEL (Delta Lake):
+#    Old versions of silver.customers still contain customer_id 88231's row.
+#    Run: VACUUM silver.customers RETAIN 0 HOURS (after disabling the safety check),
+#    which permanently removes historical file versions containing the deleted record.
+#
+# 4. LOG FOR AUDIT:
+#    Insert a record into compliance.deletion_log:
+#    {"request_id": "DSAR-2026-0417", "customer_id": 88231, "requested_at": "2026-06-20",
+#     "completed_at": "2026-06-22", "tables_affected": ["bronze.raw_orders", "silver.clean_orders",
+#     "silver.customers", "features.customer_embeddings"], "method": "delete+vacuum"}
+#
+# 5. NOTIFY DOWNSTREAM CONSUMERS:
+#    Send an event/webhook to Marketing Analytics and ML Team (consumers of silver/gold/features)
+#    confirming customer_id 88231 has been purged, so cached extracts or model training sets
+#    referencing that ID are invalidated/refreshed.
 ```
 
 ---
@@ -326,4 +453,4 @@ Code repositories are shared, forked, and sometimes accidentally made public —
 - ✅ **Compliance**: GDPR (erasure + consent), SOC 2 (controls audit), HIPAA (PHI encryption)
 - ✅ **Secrets**: Never in code — use Secrets Manager, Vault, or KMS
 
-**Tomorrow → Day 130**: **Cost Engineering** — optimizing cloud spend, query costs, and building a FinOps practice.
+**Tomorrow → Day 135**: **Cost Engineering** — optimizing cloud spend, query costs, and building a FinOps practice.

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_134_Cloud_Security_and_Compliance/quiz.json
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_134_Cloud_Security_and_Compliance/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 134,
+    "questions": [
+        {
+            "id": "d134q01",
+            "type": "multiple_choice",
+            "question": "What is the difference between encryption at rest and encryption in transit?",
+            "options": [
+                "They are the same thing implemented with different algorithms",
+                "Encryption at rest protects stored data (e.g., on disk); encryption in transit protects data moving between systems (e.g., API calls); both are required for compliance",
+                "Encryption in transit is only needed for internal traffic, not external APIs",
+                "Encryption at rest replaces the need for encryption in transit"
+            ],
+            "answer": 1,
+            "explanation": "At-rest encryption (e.g., SSE-KMS, AES-256 on RDS) protects data stored on disk from being read if the storage medium is compromised. In-transit encryption (TLS) protects data moving across networks from interception. Compliance frameworks typically require both."
+        },
+        {
+            "id": "d134q02",
+            "type": "multiple_choice",
+            "question": "A public S3 bucket containing customer data is discovered. What is the correct first step in incident response?",
+            "options": [
+                "Wait until the next scheduled security review to address it",
+                "Immediately remove public access (block public access at the bucket level), then investigate access logs and notify security/legal",
+                "Delete the entire bucket immediately without investigation",
+                "Email the affected customers before doing anything else"
+            ],
+            "answer": 1,
+            "explanation": "The immediate priority is to stop the exposure by blocking public access, then use access logs (e.g., CloudTrail) to assess whether data was accessed by unauthorized parties before notifying security/legal teams, who may need to meet GDPR's 72-hour breach notification requirement."
+        },
+        {
+            "id": "d134q03",
+            "type": "multiple_choice",
+            "question": "How should you handle a GDPR 'right to erasure' request when the affected table is stored in Delta Lake with time travel enabled?",
+            "options": [
+                "Deleting from the current table version is sufficient; old versions don't matter",
+                "Delete/anonymize the current table, then run VACUUM with zero retention (or use pseudonymization with a deletable key mapping) to remove the data from historical versions too",
+                "GDPR erasure requests cannot be honored if time travel is enabled",
+                "Simply rename the table to hide the data from auditors"
+            ],
+            "answer": 1,
+            "explanation": "Delta Lake's time travel retains old versions that still contain the deleted user's data. A full erasure requires deleting/anonymizing the current data AND running VACUUM with zero retention to purge historical file versions, or using a pseudonymization scheme where deleting the key mapping anonymizes all historical references."
+        },
+        {
+            "id": "d134q04",
+            "type": "multiple_choice",
+            "question": "What problem do VPC endpoints solve for data platforms accessing services like S3 or Secrets Manager?",
+            "options": [
+                "They reduce the cost of compute instances",
+                "They provide private connectivity to AWS services without traffic leaving the AWS network, avoiding the latency, cost, and security exposure of routing through a NAT Gateway and the public internet",
+                "They automatically encrypt all data at rest",
+                "They replace the need for IAM permissions entirely"
+            ],
+            "answer": 1,
+            "explanation": "Without a VPC endpoint, private-subnet resources reach S3 via a NAT Gateway and the public internet, adding cost, latency, and exposure. Gateway-type VPC endpoints for services like S3 are free and keep traffic entirely within the AWS network."
+        },
+        {
+            "id": "d134q05",
+            "type": "multiple_choice",
+            "question": "Why should secrets (database passwords, API keys) never be hardcoded in application code or committed to Git, even temporarily?",
+            "options": [
+                "It only matters if the repository is public from the start",
+                "Git history permanently retains old commits, so a secret committed once remains exposed even after later removal, unless the repo history itself is rewritten; dedicated secrets managers provide rotation, access control, and audit logging instead",
+                "Hardcoded secrets are fine as long as they're in environment variables inside the Docker image",
+                "Secrets managers are more expensive than hardcoding and provide no real security benefit"
+            ],
+            "answer": 1,
+            "explanation": "Even if a secret is later deleted from the current code, it remains accessible in Git history indefinitely unless history is rewritten. Dedicated secrets managers (AWS Secrets Manager, Vault) avoid this entirely by providing encryption, rotation, fine-grained access control, and audit logging outside of source code."
+        }
+    ]
+}

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_135_Cost_Engineering/README.md
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_135_Cost_Engineering/README.md
@@ -27,7 +27,7 @@ outcomes:
   - "Reduce data warehouse query costs by 50-80%"
 ---
 
-# 💰 Day 130: Cost Engineering — FinOps for Data Platforms
+# 💰 Day 135: Cost Engineering — FinOps for Data Platforms
 
 > *"The cloud is only expensive if you don't manage it. The most successful data teams treat cost as a first-class metric alongside latency and quality."*
 
@@ -44,6 +44,8 @@ FinOps (Financial Operations) is the discipline that brings engineering, finance
 ## The Technical Deep Dive
 
 ### 1. FinOps Principles
+
+The FinOps Foundation's Inform → Optimize → Operate model is the industry-standard framework for organizing cost discipline across an engineering org — it's the same maturity progression used by FinOps practitioners at companies of every size. The dict below mirrors that structure directly: each top-level key is a pillar, each `principle` is the goal of that pillar, and each `actions` list is the concrete practice that makes the principle real rather than aspirational.
 
 ```python
 finops_pillars = {
@@ -203,6 +205,23 @@ storage_optimization = {
 
 ---
 
+## Glossary
+
+| Term | Definition |
+| --- | --- |
+| **FinOps** | The operating model that brings engineering, finance, and business together to treat cloud spend as a managed, optimizable metric rather than a fixed overhead line item. |
+| **Unit Economics** | Cost expressed per unit of business value — e.g., cost per pipeline run, cost per GB processed, cost per dashboard query — so spend can be compared apples-to-apples as usage grows. |
+| **Reserved Instance** | A 1- or 3-year compute commitment that trades flexibility for a 40-72% discount versus on-demand pricing; best for predictable, 24/7 workloads. |
+| **Spot Instance** | Spare cloud capacity sold at a 60-90% discount that can be reclaimed with as little as 2 minutes' notice; suitable only for fault-tolerant or checkpointed workloads. |
+| **Auto-Scaling** | Automatically adjusting compute capacity (up or down) to match real-time demand, avoiding paying for idle resources during off-peak hours. |
+| **Cost Attribution / Tagging** | Labeling every cloud resource with metadata (team, project, environment, cost center) so spend can be traced back to the owning team or initiative. |
+| **Partition Pruning** | A query engine skipping irrelevant partitions (e.g., other dates) when a query filters on the partition column, dramatically reducing scanned data and cost. |
+| **Materialized View** | A pre-computed, stored query result that the warehouse automatically routes matching queries to, avoiding repeated full computation. |
+| **Storage Tiering** | Moving data through progressively cheaper storage classes (e.g., S3 Standard → Standard-IA → Glacier) as it ages and is accessed less frequently. |
+| **Budget Alert** | An automated notification triggered when spend crosses a defined threshold (e.g., 80% of budget), enabling intervention before a hard overage. |
+
+---
+
 ## Hands-on Lab
 
 ### Exercise 1: Cost Analysis
@@ -219,6 +238,20 @@ monthly_bill = {
     "Data transfer (egress)": 2000,# 20TB/month cross-region
 }
 # Total: $36,000/month
+
+# EXPECTED RESULT — top 3 optimization opportunities (ranked by estimated savings):
+# 1. Right-size the EC2 fleet (40% avg utilization): consolidating/downsizing
+#    20 instances to match real load typically saves 30-50% of the EC2 line
+#    → ~$4,000-6,000/month saved.
+# 2. Fix BigQuery SELECT * + add partitioning/clustering (1.3 TB/day scanned):
+#    partition pruning + column selection commonly cuts scanned bytes 80-90%
+#    → BigQuery line drops from $8,000 to roughly $1,000-1,600/month
+#    (~$6,400-7,000/month saved).
+# 3. Archive the cold 80% of S3 Standard data (160 TB untouched in 90+ days):
+#    moving it to S3 Glacier Instant/Deep Archive cuts that portion's storage
+#    cost by 80-95% → ~$3,000-3,500/month saved on the $5,000 S3 line.
+# Combined estimated savings: roughly $13,000-16,500/month (~40-45% of the
+# $36,000 total bill) before touching Redshift, NAT, or egress.
 ```
 
 ### Exercise 2: Unit Economics Dashboard
@@ -232,6 +265,13 @@ monthly_bill = {
 # 5. Reserved vs on-demand utilization
 ```
 
+**Expected result:** a dashboard spec (mockup or wireframe is fine) with these concrete fields per panel —
+- **Cost per pipeline run**: a table/bar chart with columns `pipeline_name | compute_cost | storage_cost | query_cost | total_cost | run_timestamp`, refreshed daily.
+- **Cost per 1M records**: a single trend line of `total_cost / (records_processed / 1_000_000)`, so a spike is visible even if total volume also grew.
+- **30-day cost trend**: a time series with a shaded anomaly band (e.g., ±2 standard deviations from a 30-day rolling mean) so deviations are visually flagged, not just listed.
+- **Top 10 expensive queries**: a ranked table with `query_id | bytes_scanned | cost | run_count | avg_cost_per_run`, sorted descending by weekly total cost.
+- **Reserved vs on-demand utilization**: a stacked bar or gauge showing `% reserved capacity used` vs `% on-demand spend`, with a target line (e.g., 80%+ reserved coverage for steady-state workloads).
+
 ### Exercise 3: FinOps Culture Implementation
 
 ```markdown
@@ -242,6 +282,13 @@ monthly_bill = {
 4. Monthly review cadence (who attends? What do we review?)
 5. Optimization targets (what's our cost efficiency goal?)
 ```
+
+**Expected result — minimum content checklist with measurable targets:**
+1. **Mandatory tag fields** explicitly named: `team`, `project`, `environment`, `cost_center` (at minimum) on every provisioned resource, enforced via policy (e.g., an SCP that denies untagged resource creation).
+2. **Budget alert thresholds** stated as specific percentages with named recipient roles — e.g., 80% of monthly budget triggers a warning to the team's eng lead; 100% triggers a hard alert to the eng lead **and** the FinOps/finance partner.
+3. **A PR-review cost-impact rule** with a concrete, numeric trigger — e.g., "any new or modified scheduled query estimated to scan >100 GB/run, or any new always-on compute resource, requires explicit cost sign-off in the PR before merge."
+4. **A monthly review cadence** naming actual attendees (e.g., data eng lead, finance/FinOps partner, platform lead) and what's reviewed (top 10 cost movers, unit economics trend, budget-vs-actual per team).
+5. **At least one numeric optimization target for the quarter** — e.g., "reduce cost-per-TB-scanned by 30% by end of Q1" or "reach 85%+ reserved-instance coverage for 24/7 workloads by end of quarter."
 
 ---
 
@@ -283,4 +330,4 @@ A single inefficient query can cost $10,000/month if it runs hourly. A full tabl
 - ✅ **Storage**: Lifecycle policies + compression + cleanup = 60-90% savings
 - ✅ **Culture**: Cost in PRs, budget alerts, monthly reviews, unit economics dashboards
 
-**Tomorrow → Day 131**: **Platform Engineering** — Terraform, IaC, and building self-serve data infrastructure.
+**Tomorrow → Day 136**: **Platform Engineering** — Terraform, IaC, and building self-serve data infrastructure.

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_135_Cost_Engineering/quiz.json
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_135_Cost_Engineering/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 135,
+    "questions": [
+        {
+            "id": "d135q01",
+            "type": "multiple_choice",
+            "question": "What does 'unit economics' measure for a data platform, and why is it more useful than a raw monthly bill?",
+            "options": [
+                "Cost per unit of business value (e.g., cost per pipeline run, cost per GB processed) — it converts abstract spend into an actionable, comparable metric",
+                "The total dollar amount spent on cloud infrastructure each month, regardless of usage",
+                "The number of engineers required to operate the data platform",
+                "The price charged to customers for each dashboard they view"
+            ],
+            "answer": 0,
+            "explanation": "Unit economics normalizes cost against a unit of output (per pipeline run, per TB processed, per query). A rising total bill might just mean more usage, but a rising cost *per unit* signals real inefficiency worth investigating."
+        },
+        {
+            "id": "d135q02",
+            "type": "multiple_choice",
+            "question": "Your team spends $10,000/month on BigQuery on-demand, scanning 1.6 TB/day. BigQuery flat-rate starts at ~$2,000/month for 100 slots. What's the correct decision process?",
+            "options": [
+                "Switch to flat-rate immediately since $2,000 is always cheaper than $10,000",
+                "Never switch — on-demand is always cheaper for analytics workloads",
+                "Run a side-by-side test to confirm 100 slots provide enough concurrency for your query volume before committing, since flat-rate has a fixed capacity ceiling",
+                "Switch to flat-rate only if your data is stored in Parquet format"
+            ],
+            "answer": 2,
+            "explanation": "The dollar comparison looks favorable, but flat-rate slots are a fixed concurrency resource. If 100 slots can't handle your query volume/concurrency, queries queue or slow down. Testing before committing avoids trading cost savings for a performance regression."
+        },
+        {
+            "id": "d135q03",
+            "type": "multiple_choice",
+            "question": "Which workload is the best fit for spot instances?",
+            "options": [
+                "A production PostgreSQL database serving live application traffic",
+                "An Airflow scheduler that must run continuously",
+                "A checkpointed Spark batch job that can resume if interrupted",
+                "A user-facing API with strict latency SLAs"
+            ],
+            "answer": 2,
+            "explanation": "Spot instances can be reclaimed with ~2 minutes' notice, so they're only safe for fault-tolerant or checkpoint-capable workloads like batch Spark jobs, CI/CD, and dev/test — never for production databases or always-on, user-facing services."
+        },
+        {
+            "id": "d135q04",
+            "type": "multiple_choice",
+            "question": "What is the single most impactful optimization for reducing BigQuery costs, and why?",
+            "options": [
+                "Switching to a different cloud provider",
+                "Partitioning tables by date and filtering on the partition column, which can prune scanned data by 80-95%",
+                "Increasing the number of columns selected in each query",
+                "Running queries more frequently to take advantage of caching"
+            ],
+            "answer": 1,
+            "explanation": "Partition pruning means a query on a year of data can scan one day's partition instead of all 365 — a potential 365x reduction in scanned bytes, which directly drives BigQuery's per-TB-scanned pricing."
+        },
+        {
+            "id": "d135q05",
+            "type": "multiple_choice",
+            "question": "Why should cost impact be reviewed as part of pull requests for data pipeline code, the same way correctness and style are reviewed?",
+            "options": [
+                "Because finance teams require a sign-off line in every PR description",
+                "Because a single inefficient query or missing WHERE clause can silently cost thousands of dollars per month once it's running in production on a schedule",
+                "Because it makes the PR diff easier to read",
+                "Because cloud providers require cost annotations before deployment"
+            ],
+            "answer": 1,
+            "explanation": "An inefficient pattern (full table scan, missing partition filter, unnecessary materialization) that runs on a schedule compounds daily. Reviewing cost impact in PRs catches these issues before they hit production, just as code review catches bugs before they ship."
+        }
+    ]
+}

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_136_Platform_Engineering/README.md
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_136_Platform_Engineering/README.md
@@ -27,7 +27,7 @@ outcomes:
   - "Design a self-serve data platform for domain teams"
 ---
 
-# 🏗️ Day 131: Platform Engineering — Terraform, IaC, Self-Serve Infrastructure
+# 🏗️ Day 136: Platform Engineering — Terraform, IaC, Self-Serve Infrastructure
 
 > *"If you can't reproduce your infrastructure from code, you don't have infrastructure — you have a snowflake that will melt at the worst possible time."*
 
@@ -106,6 +106,8 @@ resource "aws_redshiftserverless_workgroup" "analytics" {
   base_capacity  = 32  # RPUs
 }
 ```
+
+Every configuration choice in the block above is deliberate, not default. `aws_s3_bucket_versioning` is enabled so that an accidental overwrite or delete of a raw data file doesn't mean permanent data loss — it pairs naturally with the lifecycle policies from Day 127, since older versions can themselves be transitioned to cheaper storage tiers or expired on a schedule rather than kept forever. Encryption uses `aws:kms` (SSE-KMS) instead of the simpler AWS-managed SSE-S3 because KMS gives you a customer-managed key: you control key rotation policy, can revoke access independently of S3 permissions, and get a CloudTrail audit log of every encrypt/decrypt call — important for any data lake holding data with compliance requirements. The Terraform `backend "s3"` block stores state remotely for durability (a laptop disk failure shouldn't mean losing the only record of what infrastructure exists) and so the whole team reads and writes the same state file; in practice you'd add a DynamoDB table for state locking so two people can't run `apply` at the same time and corrupt the state. Finally, `base_capacity = 32` RPUs for the Redshift Serverless workgroup is sized for a typical baseline analytics workload — enough concurrency for routine dashboard and ad hoc queries without paying for idle peak capacity — and Redshift Serverless auto-scales beyond that base when query demand spikes, so 32 is a starting point tuned by observed usage, not a hard ceiling.
 
 ### 2. CI/CD for Data Pipelines
 
@@ -222,6 +224,24 @@ locals {
 
 ---
 
+## Glossary
+
+| Term | Definition |
+| --- | --- |
+| **IaC (Infrastructure as Code)** | Defining infrastructure (servers, networks, databases) in versioned code files instead of manual console actions, so it can be reviewed, tested, and reproduced. |
+| **Terraform State** | The file Terraform uses to track the mapping between your code and the real cloud resources it manages — required so Terraform knows what already exists. |
+| **`terraform plan` / `apply`** | `plan` previews changes as a dry run with no side effects; `apply` executes those changes against real infrastructure. |
+| **HCL** | HashiCorp Configuration Language — the declarative syntax used to write Terraform resource definitions (`.tf` files). |
+| **Provider** | A Terraform plugin (e.g., `hashicorp/aws`) that knows how to create, read, update, and delete resources for a specific platform. |
+| **Resource** | A single infrastructure object managed by Terraform, such as `aws_s3_bucket` or `aws_redshiftserverless_workgroup`. |
+| **Module** | A reusable, packaged set of Terraform resources that can be called with different inputs across environments or projects. |
+| **GitOps** | Using the same Git PR review/merge workflow for infrastructure and pipeline changes as for application code — the repo state is the source of truth. |
+| **Remote State Locking** | Using a shared backend (e.g., S3 + DynamoDB) to store Terraform state centrally and prevent two people from applying changes concurrently and corrupting it. |
+| **Self-Serve Platform** | An internal catalog that lets domain teams provision their own infrastructure (pipelines, databases, dashboards) without filing tickets to a central team. |
+| **Guardrail** | An automated constraint (cost limit, encryption requirement, quality check) built into a self-serve platform so teams move fast without bypassing standards. |
+
+---
+
 ## Hands-on Lab
 
 ### Exercise 1: Terraform Data Infrastructure
@@ -233,6 +253,28 @@ locals {
 -- 3. A Redshift Serverless workgroup
 -- 4. Budget alert at $500/month
 -- All resources must have team/project/environment tags
+```
+
+```text
+# EXPECTED RESULT — a representative `terraform plan` summary after writing
+# the configuration above (exact counts depend on how resources are split,
+# but this is the expected shape):
+#
+#   # aws_s3_bucket.data_lake will be created
+#   # aws_s3_bucket_versioning.data_lake will be created
+#   # aws_s3_bucket_server_side_encryption_configuration.data_lake will be created
+#   # aws_s3_bucket_lifecycle_configuration.data_lake will be created
+#   # aws_iam_role.data_engineer will be created
+#   # aws_redshiftserverless_namespace.analytics will be created
+#   # aws_redshiftserverless_workgroup.analytics will be created
+#   # aws_budgets_budget.monthly_alert will be created
+#
+#   Plan: 8 to add, 0 to change, 0 to destroy.
+#
+# Use this as a sanity check: if your plan shows a wildly different resource
+# count (e.g., only 3-4 resources), you likely combined the IAM role/policy
+# into one resource or omitted the lifecycle/budget resources — go back and
+# check the requirements list above.
 ```
 
 ### Exercise 2: CI/CD Pipeline Design
@@ -294,4 +336,4 @@ Platform engineering builds internal infrastructure platforms so domain teams ca
 - ✅ **Environments**: Dev → Staging → Prod with environment-specific sizing and configs
 - ✅ **GitOps**: Infrastructure and pipeline changes go through the same PR review process
 
-**Tomorrow → Day 132**: **Capstone — Cloud Data Pipeline** — build an end-to-end pipeline from ingestion to dashboard.
+**Tomorrow → Day 137**: **Capstone — Cloud Data Pipeline** — build an end-to-end pipeline from ingestion to dashboard.

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_136_Platform_Engineering/quiz.json
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_136_Platform_Engineering/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 136,
+    "questions": [
+        {
+            "id": "d136q01",
+            "type": "multiple_choice",
+            "question": "Why is provisioning cloud infrastructure by clicking through the AWS console considered a problem for data teams, even if it works?",
+            "options": [
+                "Console clicks are slower to type than writing code",
+                "Console-provisioned infrastructure isn't reproducible, can't be reviewed in a PR, and creates 'snowflake' environments that drift from each other",
+                "AWS charges extra for console-based provisioning",
+                "The console cannot create S3 buckets or Redshift clusters"
+            ],
+            "answer": 1,
+            "explanation": "Infrastructure as Code treats infrastructure like application code: versioned, reviewable, and reproducible. Console clicks leave no reviewable trail and produce environments that can't be reliably rebuilt or kept consistent with each other."
+        },
+        {
+            "id": "d136q02",
+            "type": "multiple_choice",
+            "question": "What is Terraform state, and why does remote state (e.g., an S3 backend) matter for a team?",
+            "options": [
+                "State is a log of past terraform commands; remote state just backs it up for auditing",
+                "State tracks the mapping between your Terraform code and real cloud resources; remote, shared state lets a team collaborate safely and avoid losing the only copy",
+                "State is only used for billing reports and has no effect on deployments",
+                "State is automatically regenerated from the cloud provider on every apply, so storage location doesn't matter"
+            ],
+            "answer": 1,
+            "explanation": "Without state, Terraform doesn't know what already exists and would try to recreate everything. Remote state (typically S3, ideally with DynamoDB locking) prevents losing a local-only state file and prevents two people applying changes simultaneously and corrupting infrastructure."
+        },
+        {
+            "id": "d136q03",
+            "type": "multiple_choice",
+            "question": "What is the key difference between `terraform plan` and `terraform apply`?",
+            "options": [
+                "`plan` and `apply` do the same thing; `plan` is just a deprecated alias",
+                "`plan` shows what would change without making changes (a dry run); `apply` actually creates/modifies/destroys resources",
+                "`plan` only works for AWS resources, while `apply` works for any provider",
+                "`apply` must always run before `plan` in a valid workflow"
+            ],
+            "answer": 1,
+            "explanation": "`terraform plan` is a dry run for review; `terraform apply` executes the change. The standard workflow runs `plan` on a PR for human review, then `apply` only after merge/approval."
+        },
+        {
+            "id": "d136q04",
+            "type": "multiple_choice",
+            "question": "Why should data pipelines have a staging environment instead of testing changes directly in production?",
+            "options": [
+                "Staging is required by cloud providers for billing purposes",
+                "Staging environments are always cheaper to run than production",
+                "Staging catches schema changes, performance regressions, and data quality issues before they corrupt production data or break downstream dashboards/models",
+                "Staging environments don't require IAM permissions"
+            ],
+            "answer": 2,
+            "explanation": "Without staging, every change is tested directly against production data. A bad deploy can corrupt reporting data, break ML models, or drive incorrect business decisions — staging exists to catch these issues first."
+        },
+        {
+            "id": "d136q05",
+            "type": "multiple_choice",
+            "question": "What is platform engineering, in the context of a data organization?",
+            "options": [
+                "A team that exclusively writes dbt models for other teams on request",
+                "Building a self-serve internal platform/catalog so domain teams can provision databases, pipelines, and environments themselves, with guardrails for cost, security, and quality built in",
+                "A rebranding of the DevOps title with no functional change",
+                "The practice of manually approving every infrastructure ticket submitted by domain teams"
+            ],
+            "answer": 1,
+            "explanation": "Platform engineering shifts data engineers from being ticket-takers to platform builders: domain teams self-serve through a catalog (new pipeline, new database, new dashboard) while the platform team enforces guardrails like cost limits, encryption/tagging standards, and quality requirements."
+        }
+    ]
+}

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_137_Capstone_Cloud_Data_Pipeline/README.md
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_137_Capstone_Cloud_Data_Pipeline/README.md
@@ -26,7 +26,7 @@ outcomes:
   - "Document architecture decisions and operational runbooks"
 ---
 
-# 🏆 Day 132: Capstone — Cloud Data Pipeline End-to-End
+# 🏆 Day 137: Capstone — Cloud Data Pipeline End-to-End
 
 > *"This capstone integrates every Phase 11 concept: cloud infrastructure, object storage, warehousing, dbt transformations, orchestration, quality gates, security, and cost monitoring — into one production-ready pipeline."*
 
@@ -262,6 +262,37 @@ GROUP BY event_date, region
 # 4. Cost: Daily cloud spend with budget line
 # 5. Volume: Records processed per day trend
 ```
+
+---
+
+## Senior-Level Insights
+
+### How This Exact Pipeline Fails in Production
+
+The milestones above describe what to build. Here's what breaks after it's been running for three months, drawn from the exact components this capstone uses:
+
+- **Milestone 2 (ingestion) — silent record loss on retry.** `ingest_api_data` handles pagination and retries 3x on failure, but if a multi-page pull fails on page 4 of 10 and the retry re-requests the *whole* date range rather than resuming from a per-page checkpoint, you either duplicate pages 1-3 or — worse — the retry logic dedupes by date and skips re-fetching, permanently dropping page 4's records. Idempotency has to be enforced **per page**, not just per run: track which pages succeeded, not just which dates were attempted.
+- **Milestone 3 (dbt incremental) — no lookback window means late data vanishes.** `stg_api_events` filters `WHERE event_timestamp > MAX(event_at)`. A mobile client that batches events offline and uploads them hours or days late will have `event_timestamp` values in the past relative to the watermark — they get silently filtered out forever, because the next run's watermark has already moved past them. The fix is a lookback window (e.g., re-process the last 3-7 days on every run) so late-arriving data has a chance to land.
+- **Milestone 4 (orchestration) — top-level code in the DAG file is a scheduler-wide tax.** Airflow re-parses every DAG file on a fixed interval (the DAG file processing loop) to detect changes. A DB connection check, an API call, or a `Variable.get()` call placed at module level (outside a task/operator) executes on *every parse* of *every scheduler heartbeat* — not once per run. One slow top-level call in this capstone's DAG can measurably slow down scheduling for every other DAG in the same Airflow deployment, not just this pipeline.
+- **Milestone 5 (quality gates) — threshold checks don't catch silent volume collapse.** A Soda check like `row_count > 0` is satisfied even if the upstream API quietly stopped sending 90% of expected events (e.g., a broken auth token that returns an empty-but-valid 200 response for most users). The pipeline reports "healthy," the gate passes, and `fct_daily_metrics` quietly understates revenue for days. Catching this requires an anomaly/baseline check (row count vs. a 30-day rolling average, with a tolerance band) in addition to the simple existence check.
+- **Cost creep — forgotten non-prod copies.** The most common silent budget leak with an architecture like this one isn't a single expensive query — it's a dev or staging Redshift Serverless workgroup and Airflow environment that was spun up to test Milestone 1, sized the same as prod, and left running 24/7 after the project shipped. Nobody notices because it's a small fraction of total spend each month, but it compounds for as long as nobody tears it down — exactly the kind of waste a budget alert (Day 135) is designed to surface, if someone is tagged to actually look at it.
+
+---
+
+## Glossary
+
+| Term | Definition |
+| --- | --- |
+| **ADR (Architecture Decision Record)** | A short document capturing a significant architectural choice, the alternatives considered, and the reasoning — so future engineers understand "why" not just "what." |
+| **Idempotency** | The property that re-running an operation produces the same end state as running it once, even after failures and retries — essential for safe pipeline re-runs. |
+| **Quality Gate** | An automated check (e.g., via Soda or Great Expectations) that blocks data from propagating downstream if it fails validation rules like freshness, null checks, or anomaly detection. |
+| **Runbook** | A documented, step-by-step procedure for diagnosing and resolving common operational failures, used by on-call engineers during incidents. |
+| **SLA** | Service Level Agreement — a measurable commitment (e.g., "dashboards refresh within 2 hours of source data") that defines acceptable reliability and is monitored against. |
+| **Medallion Architecture** | The bronze (raw) → silver (cleaned) → gold (business-ready aggregates) data modeling pattern used to progressively refine data through a pipeline. |
+| **CDC (Change Data Capture)** | A technique for capturing only the rows that changed in a source database since the last extraction, rather than re-reading the entire table. |
+| **Checkpoint** | A saved marker (timestamp, offset, or page number) indicating how far a pipeline has successfully processed, used to resume correctly after a failure. |
+| **Lookback Window** | A deliberate re-processing of recent historical data (e.g., the last 7 days) on every incremental run, so late-arriving records aren't permanently missed. |
+| **Schema-on-Read** | Storing raw data without enforcing a strict schema at write time, deferring structure/validation to query or transformation time — buffers downstream consumers from upstream schema changes. |
 
 ---
 

--- a/content/lessons/Phase_11_Cloud_Data_Engineering/Day_137_Capstone_Cloud_Data_Pipeline/quiz.json
+++ b/content/lessons/Phase_11_Cloud_Data_Engineering/Day_137_Capstone_Cloud_Data_Pipeline/quiz.json
@@ -1,0 +1,70 @@
+{
+    "day": 137,
+    "questions": [
+        {
+            "id": "d137q01",
+            "type": "multiple_choice",
+            "question": "Why is idempotency considered the single most important principle in designing a production data pipeline?",
+            "options": [
+                "It makes the code run faster than non-idempotent alternatives",
+                "Pipelines will inevitably fail and be retried; without idempotency, re-runs create duplicate data, corrupted aggregates, and incorrect business metrics",
+                "It is required by most cloud providers' terms of service",
+                "It eliminates the need for any data quality checks"
+            ],
+            "answer": 1,
+            "explanation": "Failures and retries are a certainty in production, not an edge case. Idempotent design (MERGE/UPSERT loads, partition overwrites, checkpoint-based ingestion) ensures a re-run produces the same correct result instead of duplicating or corrupting data."
+        },
+        {
+            "id": "d137q02",
+            "type": "multiple_choice",
+            "question": "You're presenting this capstone pipeline to a VP with 5 minutes of attention. Which 3 metrics should you lead with?",
+            "options": [
+                "Lines of code written, number of Airflow tasks, and number of dbt models",
+                "Freshness SLA compliance, data quality score, and cost efficiency (cost per unit of volume)",
+                "The specific Python libraries used and the Terraform provider version",
+                "Number of git commits and number of code reviewers"
+            ],
+            "answer": 1,
+            "explanation": "Business leaders care about reliability (is data on time?), accuracy (can it be trusted?), and cost (is it efficient?) — not implementation details. Freshness SLA, quality score, and cost-per-unit metrics translate engineering work into business-relevant terms."
+        },
+        {
+            "id": "d137q03",
+            "type": "multiple_choice",
+            "question": "How does the bronze layer's 'schema-on-read' approach help the pipeline survive an upstream API schema change?",
+            "options": [
+                "It rejects any record that doesn't match a strict predefined schema, forcing the source team to fix it immediately",
+                "It ingests raw data as-is regardless of shape, deferring schema enforcement to the silver layer — so an upstream schema change doesn't break ingestion, only downstream transforms that need updating",
+                "It automatically rewrites the source API's schema to match the warehouse",
+                "It only works if the source system never changes its schema"
+            ],
+            "answer": 1,
+            "explanation": "Bronze stores data close to its raw form, so ingestion keeps working even when the source schema shifts. The blast radius is contained to the staging/silver transformation layer (e.g., needing `on_schema_change` handling in dbt), rather than breaking the entire pipeline."
+        },
+        {
+            "id": "d137q04",
+            "type": "multiple_choice",
+            "question": "If data volume grew from 10GB/day to 10TB/day, what would most likely need to change in this pipeline's implementation?",
+            "options": [
+                "Nothing — the same Python scripts and batch API polling would scale linearly without modification",
+                "Move from single-machine Python ingestion to parallel processing (Spark/Dataflow), consider streaming ingestion, and add partition pruning/clustering and auto-scaling compute — the architecture stays the same, only the implementation scales",
+                "Switch the entire pipeline from a medallion architecture to a single flat table",
+                "Remove all data quality checks to keep up with throughput"
+            ],
+            "answer": 1,
+            "explanation": "At 1000x volume, single-threaded batch ingestion and unpartitioned queries become the bottleneck. The architectural pattern (bronze/silver/gold, orchestration, quality gates) doesn't change — but the implementation must scale: parallel/streaming ingestion, partitioned storage formats (Iceberg/Delta), and auto-scaling compute."
+        },
+        {
+            "id": "d137q05",
+            "type": "multiple_choice",
+            "question": "What role do quality gates (Soda, Great Expectations) play in this pipeline, and what's a key limitation to be aware of?",
+            "options": [
+                "They replace the need for any human review of dbt models",
+                "They automatically check data correctness (freshness, nulls, row counts, anomalies) before data reaches consumers, but a simple threshold check like `row_count > 0` can still pass even if volume silently dropped 90% — anomaly detection against a historical baseline is needed to catch that",
+                "They only check for SQL syntax errors in dbt models",
+                "They are only useful in the bronze layer and provide no value in gold tables"
+            ],
+            "answer": 1,
+            "explanation": "Quality gates act as automated checkpoints that block bad data from propagating to dashboards. But a naive threshold check (row_count > 0) is satisfied by a sharp volume drop — only a baseline/anomaly-detection check catches a silent 90% drop in expected rows."
+        }
+    ]
+}

--- a/docs/gap-analysis/Phase_11_Cloud_Data_Engineering.md
+++ b/docs/gap-analysis/Phase_11_Cloud_Data_Engineering.md
@@ -24,11 +24,11 @@ Phase 11 systematically introduces foundational Cloud Data Engineering concepts 
 
 **Gap task stubs:**
 
-- [ ] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
-- [ ] [P1][O:Glossary] Add a Glossary section to define jargon.
-- [ ] [P1][C:Lab] Lab lacks sample inputs and expected outputs. Example quote: `"TODO: Calculate monthly cloud costs..."`
-- [ ] [P2][B:CodeCtx] Provide a what/why preamble for the `estimate_monthly_cost` block.
-- [ ] [P0][F:Tables] Cloud provider table lacks deep decision guidance. Define AWS/GCP/Azure trade-offs conceptually.
+- [x] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
+- [x] [P1][O:Glossary] Add a Glossary section to define jargon.
+- [x] [P1][C:Lab] Lab lacks sample inputs and expected outputs. Example quote: `"TODO: Calculate monthly cloud costs..."`
+- [x] [P2][B:CodeCtx] Provide a what/why preamble for the `estimate_monthly_cost` block.
+- [x] [P0][F:Tables] Cloud provider table lacks deep decision guidance. Define AWS/GCP/Azure trade-offs conceptually.
 
 ---
 
@@ -39,10 +39,10 @@ Phase 11 systematically introduces foundational Cloud Data Engineering concepts 
 
 **Gap task stubs:**
 
-- [ ] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
-- [ ] [P1][O:Glossary] Add a Glossary section to define jargon.
-- [ ] [P1][C:Lab] Lab lacks expected result. Example quote: `"TODO: Design the S3 bucket structure with..."`
-- [ ] [P2][B:CodeCtx] Code block lacks what/why preamble. Example: `"table_format_comparison = {..."`
+- [x] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
+- [x] [P1][O:Glossary] Add a Glossary section to define jargon.
+- [x] [P1][C:Lab] Lab lacks expected result. Example quote: `"TODO: Design the S3 bucket structure with..."`
+- [x] [P2][B:CodeCtx] Code block lacks what/why preamble. Example: `"table_format_comparison = {..."`
 
 ---
 
@@ -53,11 +53,11 @@ Phase 11 systematically introduces foundational Cloud Data Engineering concepts 
 
 **Gap task stubs:**
 
-- [ ] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
-- [ ] [P1][O:Glossary] Add a Glossary section to define jargon.
-- [ ] [P1][C:Lab] Lab lacks a clear scenario and expected output. Example quote: `"TODO: Write a query that..."`
-- [ ] [P2][B:CodeCtx] Code block lacks what/why preamble. Example: `"from google.cloud import bigquery..."`
-- [ ] [P1][A:Concept] Elaborate on the specific trade-offs when choosing Snowflake over BigQuery.
+- [x] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
+- [x] [P1][O:Glossary] Add a Glossary section to define jargon.
+- [x] [P1][C:Lab] Lab lacks a clear scenario and expected output. Example quote: `"TODO: Write a query that..."`
+- [x] [P2][B:CodeCtx] Code block lacks what/why preamble. Example: `"from google.cloud import bigquery..."`
+- [x] [P1][A:Concept] Elaborate on the specific trade-offs when choosing Snowflake over BigQuery.
 
 ---
 
@@ -68,10 +68,10 @@ Phase 11 systematically introduces foundational Cloud Data Engineering concepts 
 
 **Gap task stubs:**
 
-- [ ] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
-- [ ] [P1][O:Glossary] Add a Glossary section to define jargon.
-- [ ] [P1][C:Lab] Provide sample schemas and expected result. Example quote: `"TODO: Build an incremental model..."`
-- [ ] [P2][B:CodeCtx] Explain the syntax before the code block: `"{% if is_incremental() %}..."`
+- [x] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
+- [x] [P1][O:Glossary] Add a Glossary section to define jargon.
+- [x] [P1][C:Lab] Provide sample schemas and expected result. Example quote: `"TODO: Build an incremental model..."`
+- [x] [P2][B:CodeCtx] Explain the syntax before the code block: `"{% if is_incremental() %}..."`
 
 ---
 
@@ -82,10 +82,10 @@ Phase 11 systematically introduces foundational Cloud Data Engineering concepts 
 
 **Gap task stubs:**
 
-- [ ] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
-- [ ] [P1][O:Glossary] Add a Glossary section to define jargon.
-- [ ] [P1][C:Lab] Lab exercises lack clear expected results. Example quote: `"def create_dag(): ... pass"`
-- [ ] [P0][H:Pitfalls] Add a pitfalls callout about Airflow top-level code and scheduler bottlenecks.
+- [x] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
+- [x] [P1][O:Glossary] Add a Glossary section to define jargon.
+- [x] [P1][C:Lab] Lab exercises lack clear expected results. Example quote: `"def create_dag(): ... pass"`
+- [x] [P0][H:Pitfalls] Add a pitfalls callout about Airflow top-level code and scheduler bottlenecks.
 
 ---
 
@@ -96,11 +96,11 @@ Phase 11 systematically introduces foundational Cloud Data Engineering concepts 
 
 **Gap task stubs:**
 
-- [ ] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
-- [ ] [P1][O:Glossary] Add a Glossary section to define jargon.
-- [ ] [P1][C:Lab] Lab lacks realistic schema/scenario. Example quote: `"TODO: Implement a Kafka producer..."`
-- [ ] [P2][B:CodeCtx] Code block lacks what/why preamble. Example: `"from confluent_kafka import Producer..."`
-- [ ] [P0][A:Concept] Justify the "magic numbers" for when streaming is actually necessary over micro-batching.
+- [x] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
+- [x] [P1][O:Glossary] Add a Glossary section to define jargon.
+- [x] [P1][C:Lab] Lab lacks realistic schema/scenario. Example quote: `"TODO: Implement a Kafka producer..."`
+- [x] [P2][B:CodeCtx] Code block lacks what/why preamble. Example: `"from confluent_kafka import Producer..."`
+- [x] [P0][A:Concept] Justify the "magic numbers" for when streaming is actually necessary over micro-batching.
 
 ---
 
@@ -111,10 +111,10 @@ Phase 11 systematically introduces foundational Cloud Data Engineering concepts 
 
 **Gap task stubs:**
 
-- [ ] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
-- [ ] [P1][O:Glossary] Add a Glossary section to define jargon.
-- [ ] [P1][C:Lab] Lab lacks expected result. Example quote: `"TODO: Design a Lakehouse architecture..."`
-- [ ] [P0][F:Tables] Add decision guidance (when to choose) to the table comparing Delta, Iceberg, and Hudi.
+- [x] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
+- [x] [P1][O:Glossary] Add a Glossary section to define jargon.
+- [x] [P1][C:Lab] Lab lacks expected result. Example quote: `"TODO: Design a Lakehouse architecture..."`
+- [x] [P0][F:Tables] Add decision guidance (when to choose) to the table comparing Delta, Iceberg, and Hudi.
 
 ---
 
@@ -125,11 +125,11 @@ Phase 11 systematically introduces foundational Cloud Data Engineering concepts 
 
 **Gap task stubs:**
 
-- [ ] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
-- [ ] [P1][O:Glossary] Add a Glossary section to define jargon.
-- [ ] [P1][C:Lab] Lab lacks sample data to test expectations on. Example quote: `"TODO: Add expectations for..."`
-- [ ] [P2][B:CodeCtx] Code block lacks what/why preamble. Example: `"import great_expectations as gx..."`
-- [ ] [P1][E:Framing] Add business framing on organizational adoption of data contracts.
+- [x] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
+- [x] [P1][O:Glossary] Add a Glossary section to define jargon.
+- [x] [P1][C:Lab] Lab lacks sample data to test expectations on. Example quote: `"TODO: Add expectations for..."`
+- [x] [P2][B:CodeCtx] Code block lacks what/why preamble. Example: `"import great_expectations as gx..."`
+- [x] [P1][E:Framing] Add business framing on organizational adoption of data contracts.
 
 ---
 
@@ -140,10 +140,10 @@ Phase 11 systematically introduces foundational Cloud Data Engineering concepts 
 
 **Gap task stubs:**
 
-- [ ] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
-- [ ] [P1][O:Glossary] Add a Glossary section to define jargon like CMK.
-- [ ] [P1][C:Lab] Lab exercises lack clear expected results. Example quote: `"TODO: Write an IAM policy..."`
-- [ ] [P2][B:CodeCtx] Code block lacks what/why preamble. Example: `"compliance_matrix = {..."`
+- [x] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
+- [x] [P1][O:Glossary] Add a Glossary section to define jargon like CMK.
+- [x] [P1][C:Lab] Lab exercises lack clear expected results. Example quote: `"TODO: Write an IAM policy..."`
+- [x] [P2][B:CodeCtx] Code block lacks what/why preamble. Example: `"compliance_matrix = {..."`
 
 ---
 
@@ -154,10 +154,10 @@ Phase 11 systematically introduces foundational Cloud Data Engineering concepts 
 
 **Gap task stubs:**
 
-- [ ] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
-- [ ] [P1][O:Glossary] Add a Glossary section to define jargon.
-- [ ] [P1][C:Lab] Lab asks for a text policy rather than a measurable exercise. Provide an expected result metric. Example quote: `"TODO: Write a 1-page FinOps policy..."`
-- [ ] [P2][B:CodeCtx] Code block lacks what/why preamble. Example: `"finops_pillars = {..."`
+- [x] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
+- [x] [P1][O:Glossary] Add a Glossary section to define jargon.
+- [x] [P1][C:Lab] Lab asks for a text policy rather than a measurable exercise. Provide an expected result metric. Example quote: `"TODO: Write a 1-page FinOps policy..."`
+- [x] [P2][B:CodeCtx] Code block lacks what/why preamble. Example: `"finops_pillars = {..."`
 
 ---
 
@@ -168,10 +168,10 @@ Phase 11 systematically introduces foundational Cloud Data Engineering concepts 
 
 **Gap task stubs:**
 
-- [ ] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
-- [ ] [P1][O:Glossary] Add a Glossary section to define jargon.
-- [ ] [P1][C:Lab] Lab lacks clear expected result/Terraform output. Example quote: `"TODO: Write a Terraform module..."`
-- [ ] [P1][A:Concept] Justify the resource configurations in the Terraform code block.
+- [x] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
+- [x] [P1][O:Glossary] Add a Glossary section to define jargon.
+- [x] [P1][C:Lab] Lab lacks clear expected result/Terraform output. Example quote: `"TODO: Write a Terraform module..."`
+- [x] [P1][A:Concept] Justify the resource configurations in the Terraform code block.
 
 ---
 
@@ -182,8 +182,8 @@ Phase 11 systematically introduces foundational Cloud Data Engineering concepts 
 
 **Gap task stubs:**
 
-- [ ] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
-- [ ] [P1][O:Glossary] Add a Glossary section to define jargon.
-- [ ] [P1][I:Senior] Add a "Real senior/production insight" section covering common production failures for this specific architecture.
+- [x] [P0][L:Quiz] Missing `quiz.json` file in lesson directory.
+- [x] [P1][O:Glossary] Add a Glossary section to define jargon.
+- [x] [P1][I:Senior] Add a "Real senior/production insight" section covering common production failures for this specific architecture.
 
 ---

--- a/docs/gap-analysis/Phase_11_Gap_Fulfillment_Report.md
+++ b/docs/gap-analysis/Phase_11_Gap_Fulfillment_Report.md
@@ -1,0 +1,273 @@
+# Gap Fulfillment Report — Phase 11: Cloud Data Engineering
+
+> Converted from the Phase 11 Gap Analysis (`Phase_11_Cloud_Data_Engineering.md`). All gaps listed here have been resolved. See individual lesson `README.md` files for the full updated content.
+
+**Status:** ✅ All gaps resolved
+**Lessons audited:** 12
+**Total gaps filled:** 51
+**Completed:** 2026-06-22
+
+---
+
+## Phase Summary
+
+Phase 11 covers Cloud Data Engineering across 12 lessons (Days 126–137), moving from cloud fundamentals through object storage, data warehouses, dbt at scale, orchestration, streaming, lakehouse architecture, data contracts/quality, security/compliance, cost engineering, platform engineering, and a capstone. The gap audit identified four systemic content gaps affecting every lesson, plus a set of targeted per-lesson concept/table/framing/pitfalls gaps.
+
+**Tier 1 — Systemic (all 12 lessons):**
+
+- [P0][L:Quiz] No lesson had a `quiz.json` file
+- [P1][O:Glossary] No lesson had a dedicated `## Glossary` section
+- [P1][C:Lab] Hands-on Lab exercises were largely thin `TODO` stubs with no sample schemas/data and no expected results
+- [P2][B:CodeCtx] Several flagged code blocks dove straight into Python/SQL/Jinja/HCL without a what/why preamble
+
+**Tier 2 — Targeted per-lesson gaps:**
+
+- [P0] Day 126: AWS/GCP/Azure provider table lacked deep conceptual trade-off justification
+- [P1] Day 128: No elaboration on when to choose Snowflake over BigQuery
+- [P0] Day 130: No Pitfalls callout on Airflow top-level code danger / scheduler bottlenecks
+- [P0] Day 131: No concrete latency thresholds ("magic numbers") for streaming vs. micro-batch vs. batch
+- [P0] Day 132: Delta/Iceberg/Hudi table comparison lacked decision guidance on choosing Hudi over Iceberg
+- [P1] Day 133: No business framing on driving organizational adoption of data contracts
+- [P1] Day 136: Terraform HCL resource choices lacked line-by-line justification
+- [P1] Day 137: Capstone lacked a senior/production-failure insight section
+
+**Recurring gaps resolved:**
+
+- ✅ [L:Quiz] `quiz.json` (5 multiple-choice questions, with explanations) created for ALL 12 lessons
+- ✅ [O:Glossary] Dedicated `## Glossary` section (8–12 term table) added to ALL 12 lessons
+- ✅ [C:Lab] Every Hands-on Lab exercise flagged as missing sample data/expected results now has an explicit `# EXPECTED RESULT` block (or "**Expected result:**" prose/rubric for non-code exercises), with existing TODO/scenario text preserved
+- ✅ [B:CodeCtx] Every flagged code block (Days 126, 127, 128, 129, 131, 133, 134, 135) now has a 1–3 sentence what/why preamble before the fence
+- ✅ [P0][F:Tables] Day 126's provider table gained 3 paragraphs of conceptual trade-off prose; Day 132 gained a new Delta/Iceberg/Hudi decision-guidance subsection
+- ✅ [P0][H:Pitfalls] Day 130's Airflow Pitfalls section added (top-level code, scheduler bottlenecks, catchup storms, poke-mode sensors, missing `execution_timeout`)
+- ✅ [P0][A:Concept] Day 131's streaming-vs-batch latency thresholds added (<60s streaming, 1–15min micro-batch, >15min batch)
+- ✅ [P1][A:Concept] Day 128's Snowflake-vs-BigQuery subsection and Day 136's Terraform justification paragraph added
+- ✅ [P1][E:Framing] Day 133's "Getting Organizational Buy-In for Data Contracts" subsection added
+- ✅ [P1][I:Senior] Day 137's new "Senior-Level Insights" section (production-failure scenarios tied to its own Milestones 1–6) added
+
+**Reconciliation note — Day 132 (Hudi gap):** The gap-analysis doc claimed Day 132's table comparisons "lack clear decision guidance on when to choose Hudi over Iceberg." On inspection, Day 132's only comparison table is "Lakehouse vs. Lake vs. Warehouse" — it never mentions Delta, Iceberg, or Hudi as competing table formats, and Hudi is not mentioned anywhere else in Phase 11 (the actual Delta-vs-Iceberg comparison, without Hudi, lives in Day 127). Rather than fabricate false context about a table that doesn't exist, the resolution adds a new, clearly-scoped "Choosing a Table Format: Delta Lake vs. Iceberg vs. Apache Hudi" subsection directly in Day 132, closing the underlying substantive gap (no Hudi decision guidance existed anywhere in the phase).
+
+**Reconciliation note — Day 134 (IAM-quote mismatch):** The gap-analysis doc's example quote ("TODO: Write an IAM policy...") does not literally appear anywhere in Day 134. The lesson's actual lab has 3 exercises — VPC Security Design, PII Handling Pipeline (`classify_and_mask`), and GDPR Deletion Request — none titled or scoped as "write an IAM policy," though Exercise 1's VPC/security-group design is IAM-adjacent. The resolution closes the underlying substantive gap (exercises lacked concrete expected results) by adding `# EXPECTED RESULT` blocks to all 3 actual exercises rather than inventing a fourth exercise that doesn't exist in the source material.
+
+---
+
+## Day 126 — Cloud Fundamentals
+
+**Path:** `content/lessons/Phase_11_Cloud_Data_Engineering/Day_126_Cloud_Fundamentals/README.md`
+
+**Line count:** 329 → 373
+
+| # | Priority | Tag | Gap Description | Resolution |
+|---|----------|-----|-----------------|------------|
+| 1 | P0 | L:Quiz | Missing `quiz.json` | ✅ Created `quiz.json` with 5 MC questions on cloud fundamentals concepts |
+| 2 | P1 | O:Glossary | No glossary | ✅ Added 12-term glossary between Senior-Level Insights and Hands-on Lab |
+| 3 | P1 | C:Lab | Lab lacks sample inputs/expected outputs (`"TODO: Calculate monthly cloud costs..."`) | ✅ Added `# EXPECTED RESULT` to `estimate_monthly_cost`: compute=$730.00, storage=$471.04, query=$50.00, egress=$92.16, total=$1,343.20 |
+| 4 | P2 | B:CodeCtx | No what/why preamble for `estimate_monthly_cost` | ✅ Added CodeCtx preamble before the function |
+| 5 | P0 | F:Tables | Provider table lacks deep decision guidance | ✅ Added 3 paragraphs after the AWS/GCP/Azure comparison table elaborating conceptual trade-offs |
+
+---
+
+## Day 127 — Object Storage
+
+**Path:** `content/lessons/Phase_11_Cloud_Data_Engineering/Day_127_Object_Storage/README.md`
+
+**Line count:** 310 → 357
+
+| # | Priority | Tag | Gap Description | Resolution |
+|---|----------|-----|-----------------|------------|
+| 1 | P0 | L:Quiz | Missing `quiz.json` | ✅ Created `quiz.json` with 5 MC questions on object storage/medallion architecture |
+| 2 | P1 | O:Glossary | No glossary | ✅ Added 10-term glossary |
+| 3 | P1 | C:Lab | Lab lacks expected result (`"TODO: Design the S3 bucket structure..."`) | ✅ Added `# EXPECTED RESULT` filled-in `data_lake_design` dict for clickstream/orders/product_catalog/reviews |
+| 4 | P2 | B:CodeCtx | `table_format_comparison` dict dropped in without preamble | ✅ Added CodeCtx preamble before the dict |
+
+---
+
+## Day 128 — Cloud Data Warehouses
+
+**Path:** `content/lessons/Phase_11_Cloud_Data_Engineering/Day_128_Cloud_Data_Warehouses/README.md`
+
+**Line count:** 278 → 336
+
+| # | Priority | Tag | Gap Description | Resolution |
+|---|----------|-----|-----------------|------------|
+| 1 | P0 | L:Quiz | Missing `quiz.json` | ✅ Created `quiz.json` with 5 MC questions on BigQuery/Snowflake/Redshift internals |
+| 2 | P1 | O:Glossary | No glossary | ✅ Added 10-term glossary |
+| 3 | P1 | C:Lab | Lab lacks clear scenario/expected output (`"TODO: Write a query that..."`) | ✅ Added `# EXPECTED RESULT` worked cost comparison: BigQuery on-demand ≈$18,310.56/mo, flat-rate=$2,000/mo, Snowflake Medium≈$1,600/mo |
+| 4 | P2 | B:CodeCtx | `from google.cloud import bigquery` dropped in without preamble | ✅ Added CodeCtx preamble before the import block |
+| 5 | P1 | A:Concept | No elaboration on choosing Snowflake over BigQuery | ✅ Added new "Snowflake vs. BigQuery: The Real Trade-offs" subsection |
+
+---
+
+## Day 129 — dbt at Scale
+
+**Path:** `content/lessons/Phase_11_Cloud_Data_Engineering/Day_129_dbt_at_Scale/README.md`
+
+**Line count:** 324 → 386
+
+| # | Priority | Tag | Gap Description | Resolution |
+|---|----------|-----|-----------------|------------|
+| 1 | P0 | L:Quiz | Missing `quiz.json` | ✅ Created `quiz.json` with 5 MC questions on incremental models, SCD Type 2, Jinja, dbt contracts, lookback windows |
+| 2 | P1 | O:Glossary | No glossary | ✅ Added 10-term glossary between Senior-Level Insights and Hands-on Lab |
+| 3 | P1 | C:Lab | Lab needs sample schemas/expected result (`"TODO: Build an incremental model..."`) | ✅ Added sample `raw.events` schema table (6 columns) and an `# EXPECTED RESULT` compiled-SQL block (merge + 2-day lookback + unique test) |
+| 4 | P2 | B:CodeCtx | No explanation before `{% if is_incremental() %}` | ✅ Added preamble explaining first-run vs. subsequent-run compilation and `{{ this }}` |
+
+---
+
+## Day 130 — Orchestration
+
+**Path:** `content/lessons/Phase_11_Cloud_Data_Engineering/Day_130_Orchestration/README.md`
+
+**Line count:** 300 → 396
+
+| # | Priority | Tag | Gap Description | Resolution |
+|---|----------|-----|-----------------|------------|
+| 1 | P0 | L:Quiz | Missing `quiz.json` | ✅ Created `quiz.json` with 5 MC questions on DAG acyclicity, idempotency, `execution_timeout`, catchup, orchestrator selection |
+| 2 | P1 | O:Glossary | No glossary | ✅ Added 12-term glossary, ordered Senior-Level Insights → Pitfalls → Glossary → Hands-on Lab |
+| 3 | P1 | C:Lab | Lab exercises lack expected results (`"def create_dag(): ... pass"`) | ✅ Exercise 1: `# EXPECTED RESULT` dependency chain + retry/SLA config. Exercise 2: identified all 3 idempotency bugs with corrected code. Exercise 3: orchestrator picks + justifications for all 3 scenarios |
+| 4 | P0 | H:Pitfalls | No Pitfalls callout on top-level code/scheduler limits | ✅ Added new `## Pitfalls` (5 bullets: top-level DAG code, scheduler/parsing bottlenecks, catchup backfill storms, poke-mode sensors, missing `execution_timeout`) |
+
+---
+
+## Day 131 — Streaming Pipelines
+
+**Path:** `content/lessons/Phase_11_Cloud_Data_Engineering/Day_131_Streaming_Pipelines/README.md`
+
+**Line count:** 302 → 376
+
+| # | Priority | Tag | Gap Description | Resolution |
+|---|----------|-----|-----------------|------------|
+| 1 | P0 | L:Quiz | Missing `quiz.json` | ✅ Created `quiz.json` with 5 MC questions on consumer groups, exactly-once vs. at-least-once, Pub/Sub vs. Kafka, hot partitions, windowing |
+| 2 | P1 | O:Glossary | No glossary | ✅ Added 10-term glossary |
+| 3 | P1 | C:Lab | Lab lacks realistic schema/scenario (`"TODO: Implement a Kafka producer..."`) | ✅ Exercise 1: `# EXPECTED RESULT` filled `streaming_design` dict for all 4 use cases. Exercise 3: 5 sample input events (incl. one late-arriving within the 10s grace period) + exact per-window/per-type count dict |
+| 4 | P2 | B:CodeCtx | `from confluent_kafka import Producer, Consumer` dropped in without preamble | ✅ Added preamble explaining `confluent-kafka`/`librdkafka` and the producer/consumer pattern |
+| 5 | P0 | A:Concept | No "magic numbers" for when streaming is actually necessary | ✅ Added paragraph after the Batch vs. Streaming table with concrete thresholds: <60s → true streaming, 1–15min → micro-batch, >15min → batch |
+
+---
+
+## Day 132 — Lakehouse Architecture
+
+**Path:** `content/lessons/Phase_11_Cloud_Data_Engineering/Day_132_Lakehouse_Architecture/README.md`
+
+**Line count:** 271 → 327
+
+| # | Priority | Tag | Gap Description | Resolution |
+|---|----------|-----|-----------------|------------|
+| 1 | P0 | L:Quiz | Missing `quiz.json` | ✅ Created `quiz.json` with 5 MC questions on lakehouse vs. lake vs. warehouse, `expect_or_drop`, Unity Catalog, Auto Loader |
+| 2 | P1 | O:Glossary | No glossary | ✅ Added 12-term glossary |
+| 3 | P1 | C:Lab | Lab lacks expected result (`"TODO: Design a Lakehouse architecture..."`) | ✅ Added `# EXPECTED RESULT` schema × team access matrix (5 schemas × 4 teams) plus region-based row-level security/PII masking notes |
+| 4 | P0 | F:Tables | Delta/Iceberg/Hudi table lacks Hudi decision guidance | ✅ Added new "Choosing a Table Format: Delta Lake vs. Iceberg vs. Apache Hudi" subsection (3-column comparison table) — see reconciliation note above |
+
+---
+
+## Day 133 — Data Contracts and Quality
+
+**Path:** `content/lessons/Phase_11_Cloud_Data_Engineering/Day_133_Data_Contracts_and_Quality/README.md`
+
+**Line count:** 317 → 373
+
+| # | Priority | Tag | Gap Description | Resolution |
+|---|----------|-----|-----------------|------------|
+| 1 | P0 | L:Quiz | Missing `quiz.json` | ✅ Created `quiz.json` with 5 MC questions on contract ownership, GX vs. dbt tests, freshness SLAs, anomaly detection |
+| 2 | P1 | O:Glossary | No glossary | ✅ Added 10-term glossary |
+| 3 | P1 | C:Lab | Lab lacks sample data to validate against (`"TODO: Add expectations for..."`) | ✅ Added 6 sample transaction records (each engineered to fail at least one check) with full `# EXPECTED RESULT` pass/fail table |
+| 4 | P2 | B:CodeCtx | `import great_expectations as gx` dropped in without preamble | ✅ Added preamble explaining the Context → datasource → suite → validate workflow |
+| 5 | P1 | E:Framing | No business framing on organizational adoption | ✅ Added new "Getting Organizational Buy-In for Data Contracts" subsection (pilot-table selection, hours-saved framing, OKR ownership, incident-as-forcing-function) |
+
+---
+
+## Day 134 — Cloud Security and Compliance
+
+**Path:** `content/lessons/Phase_11_Cloud_Data_Engineering/Day_134_Cloud_Security_and_Compliance/README.md`
+
+**Line count:** 329 → 456
+
+| # | Priority | Tag | Gap Description | Resolution |
+|---|----------|-----|-----------------|------------|
+| 1 | P0 | L:Quiz | Missing `quiz.json` | ✅ Created `quiz.json` with 5 MC questions on encryption at rest/in transit, public-bucket incident response, GDPR erasure, VPC endpoints, secrets management |
+| 2 | P1 | O:Glossary | No glossary defining jargon like CMK | ✅ Added 12-term glossary (including explicit **CMK (Customer Managed Keys)** entry) after the Secrets Management code block, before Hands-on Lab |
+| 3 | P1 | C:Lab | Lab exercises lack expected results (`"TODO: Write an IAM policy..."`) | ✅ Added `# EXPECTED RESULT` to all 3 actual exercises (VPC design, `classify_and_mask` masking output, GDPR deletion checklist) — see reconciliation note above |
+| 4 | P2 | B:CodeCtx | `compliance_matrix = {...}` dropped in without preamble | ✅ Added preamble explaining the cross-framework control-mapping rationale |
+
+---
+
+## Day 135 — Cost Engineering
+
+**Path:** `content/lessons/Phase_11_Cloud_Data_Engineering/Day_135_Cost_Engineering/README.md`
+
+**Line count:** 286 → 333
+
+| # | Priority | Tag | Gap Description | Resolution |
+|---|----------|-----|-----------------|------------|
+| 1 | P0 | L:Quiz | Missing `quiz.json` | ✅ Created `quiz.json` with 5 MC questions on unit economics, BigQuery on-demand vs. flat-rate, spot instances, partitioning, cost-in-code-review |
+| 2 | P1 | O:Glossary | No glossary | ✅ Added 10-term glossary |
+| 3 | P1 | C:Lab | Lab asks for a text policy with no measurable metric (`"TODO: Write a 1-page FinOps policy..."`) | ✅ Exercise 1: `# EXPECTED RESULT` top-3 optimizations with dollar-range savings. Exercise 2: dashboard field/shape spec. Exercise 3: measurable checklist (mandatory tags, % thresholds with named roles, PR cost-trigger rule, numeric quarterly target) |
+| 4 | P2 | B:CodeCtx | `finops_pillars = {...}` dropped in without preamble | ✅ Added preamble explaining the FinOps Foundation's Inform/Optimize/Operate model |
+
+---
+
+## Day 136 — Platform Engineering
+
+**Path:** `content/lessons/Phase_11_Cloud_Data_Engineering/Day_136_Platform_Engineering/README.md`
+
+**Line count:** 297 → 339
+
+| # | Priority | Tag | Gap Description | Resolution |
+|---|----------|-----|-----------------|------------|
+| 1 | P0 | L:Quiz | Missing `quiz.json` | ✅ Created `quiz.json` with 5 MC questions on IaC vs. console, Terraform state, plan vs. apply, platform engineering |
+| 2 | P1 | O:Glossary | No glossary | ✅ Added 11-term glossary |
+| 3 | P1 | C:Lab | Lab lacks expected Terraform output (`"TODO: Write a Terraform module..."`) | ✅ Added `# EXPECTED RESULT` representative `terraform plan` summary (8 resources, "Plan: 8 to add, 0 to change, 0 to destroy") |
+| 4 | P1 | A:Concept | Terraform HCL resource configs lack justification | ✅ Added 8-line justification paragraph after `main.tf` (S3 versioning, SSE-KMS vs. SSE-S3, S3 backend state, `base_capacity` sizing) |
+
+---
+
+## Day 137 — Capstone: Cloud Data Pipeline
+
+**Path:** `content/lessons/Phase_11_Cloud_Data_Engineering/Day_137_Capstone_Cloud_Data_Pipeline/README.md`
+
+**Line count:** 333 → 364
+
+| # | Priority | Tag | Gap Description | Resolution |
+|---|----------|-----|-----------------|------------|
+| 1 | P0 | L:Quiz | Missing `quiz.json` | ✅ Created `quiz.json` with 5 MC questions on idempotency, VP-facing metrics, bronze schema-on-read, 10GB→10TB scaling, quality gates |
+| 2 | P1 | O:Glossary | No glossary | ✅ Added 10-term glossary (ADR, Idempotency, Quality Gate, Runbook, SLA, Medallion Architecture, CDC, Checkpoint, Lookback Window, Schema-on-Read) |
+| 3 | P1 | I:Senior | No "Real senior/production insight" section | ✅ Added new `## Senior-Level Insights` → "How This Exact Pipeline Fails in Production" (5 concrete failure modes tied to Milestones 2–5, plus a non-prod cost-leak scenario) |
+
+---
+
+## Gap Resolution Statistics
+
+Counts below reflect the 51 official stubs listed in the source gap-analysis document's `[ ]` checklists, now all marked `[x]`.
+
+| Gap Type | Tag | Count | Status |
+|----------|-----|-------|--------|
+| Missing `quiz.json` | L:Quiz | 12 (all lessons) | ✅ All resolved |
+| Missing glossaries | O:Glossary | 12 (all lessons) | ✅ All resolved |
+| Labs without sample data/expected results | C:Lab | 12 (all lessons) | ✅ All resolved |
+| Missing what/why code preambles | B:CodeCtx | 8 (Days 126, 127, 128, 129, 131, 133, 134, 135) | ✅ All resolved |
+| Missing decision tables | F:Tables | 2 (Days 126, 132) | ✅ All resolved |
+| Missing concept explanations | A:Concept | 3 (Days 128, 131, 136) | ✅ All resolved |
+| Missing pitfalls callout | H:Pitfalls | 1 (Day 130) | ✅ All resolved |
+| Missing business framing | E:Framing | 1 (Day 133) | ✅ All resolved |
+| Missing senior/production insight | I:Senior | 1 (Day 137) | ✅ All resolved |
+
+**Total gaps resolved: 51** (matches the 51 `[x]` checkboxes in the source gap-analysis document)
+
+---
+
+## Quality Bar Checklist
+
+| Quality Criterion | Status |
+|-------------------|--------|
+| All 12 lessons now have a `quiz.json` (5 MC questions each, valid JSON, correct day numbering) | ✅ |
+| All 12 lessons now have a dedicated `## Glossary` section (8–12 term table) | ✅ |
+| Every lab exercise flagged for missing sample data/expected results now has an explicit `# EXPECTED RESULT` annotation or rubric | ✅ |
+| Every flagged code block (Days 126, 127, 128, 129, 131, 133, 134, 135) now has a what/why preamble before the fence | ✅ |
+| Day 126's provider table and Day 132's table-format comparison both gained explicit decision guidance | ✅ |
+| Day 130's Airflow Pitfalls section added, correctly ordered Senior-Level Insights → Pitfalls → Glossary → Hands-on Lab | ✅ |
+| Day 131's streaming-vs-batch latency thresholds added with concrete numeric cutoffs | ✅ |
+| Day 133's organizational-adoption framing subsection added | ✅ |
+| Day 136's Terraform resource-by-resource justification added | ✅ |
+| Day 137's capstone gained both a Senior-Level Insights and a Glossary section despite having neither structural anchor beforehand | ✅ |
+| Day 132 (Hudi) and Day 134 (IAM-quote) gap-doc/content mismatches resolved honestly via reconciliation notes rather than fabricated context | ✅ |
+| No existing lesson content deleted — all changes are additive | ✅ |
+| Phase 10 → Phase 11 transition preserved | ✅ |
+| All 51 gap-analysis checkboxes verified checked (`grep -c '\[x\]'` → 51, `'\[ \]'` → 0) | ✅ |


### PR DESCRIPTION
## Summary
- Resolves every gap stub in `docs/gap-analysis/Phase_11_Cloud_Data_Engineering.md` (51 total) across all 12 Phase 11 lessons (Days 126–137)
- Adds a `quiz.json` (5 MC questions) and a `## Glossary` section to every lesson
- Adds `# EXPECTED RESULT` annotations / rubrics to every flagged Hands-on Lab exercise, and what/why preambles to flagged code blocks
- Adds targeted fixes per lesson: Day 126 provider trade-off prose, Day 128 Snowflake-vs-BigQuery subsection, Day 130 Pitfalls callout, Day 131 streaming-vs-batch latency thresholds, Day 132 Delta/Iceberg/Hudi decision table, Day 133 organizational-adoption framing, Day 136 Terraform justification, Day 137 new Senior-Level Insights section
- Converts the source gap-analysis doc into `docs/gap-analysis/Phase_11_Gap_Fulfillment_Report.md`, documenting every gap and its resolution (including two reconciliation notes where the gap doc's literal quotes didn't match actual lesson content: Day 132's Hudi table and Day 134's IAM-policy quote)
- Marks all 51 checkboxes `[x]` in the source gap-analysis document

## Test plan
- [x] Verified all 12 `quiz.json` files parse as valid JSON
- [x] Verified line counts before/after for each lesson README
- [x] Verified `grep -c '\[x\]'` → 51, `'\[ \]'` → 0 in the source gap-analysis doc
- [x] Spot-checked section ordering (Senior-Level Insights → Pitfalls/Glossary → Hands-on Lab) across affected lessons


---
_Generated by [Claude Code](https://claude.ai/code/session_01VVLpgmtZ1Porg7yvpZ4AQB)_