### PR TITLE
Add callout blocks and tap-friendly glossary tooltips to markdown renderer

### DIFF
--- a/docs/markdown-renderer-roadmap.md
+++ b/docs/markdown-renderer-roadmap.md
@@ -1,0 +1,92 @@
+# Markdown Renderer: Feature Roadmap
+
+Brainstormed ideas for evolving `src/components/MarkdownRenderer.tsx` and its
+supporting pieces (`TableOfContents`, glossary tooltips, `CodePlayground`,
+the sanitizer schema, `content-features.css`). The renderer already supports
+Pyodide-backed Python playgrounds, glossary tooltips, image zoom, KaTeX math,
+slugged heading anchors, exercise/mastery-check parsing, and FAQ schema
+generation. This doc tracks what's next.
+
+Status legend: ✅ implemented · 🔲 not yet started
+
+## Callouts / admonitions ✅
+
+Lessons already write semi-structured asides ("Senior-Level Insights", pitfalls,
+pro tips) as plain headings or blockquotes, with no distinct visual treatment.
+GitHub-style `> [!NOTE]` / `[!TIP]` / `[!WARNING]` / `[!DANGER]` / `[!IMPORTANT]`
+markers let authors mark these asides and get distinct colored boxes for free.
+
+Implemented via a remark plugin (`src/utils/remark-callouts.ts`) that detects
+the marker in the first paragraph of a blockquote and re-tags the node as
+`<div class="callout callout-{type}" data-callout="{type}">`, styled in
+`markdown.css`.
+
+## Mobile-tappable glossary tooltips ✅
+
+The glossary tooltip (`content-features.css` `.glossary-term`) was hover-only,
+which is dead on touch devices — a real gap given this is a learning site
+likely read on phones. Glossary terms are now rendered via a small
+`GlossaryTerm` component (`src/components/GlossaryTerm.tsx`) that renders a
+`<button>` supporting tap-to-toggle (with outside-tap/Escape dismiss), while
+still supporting `:hover` on pointer devices.
+
+## Mermaid diagrams 🔲
+
+No diagram support exists today, yet phases like Data Engineering / Cloud /
+Analytics Engineering would benefit from architecture and pipeline diagrams.
+Add a `mermaid` code-block detector in `CodeComponent` (parallel to the
+existing Python/Pyodide path) that lazy-loads `mermaid` and renders sanitized
+SVG client-side.
+
+## Runnable SQL blocks 🔲
+
+The Python "▶ Try It" playground (via Pyodide) is a flagship feature, but
+Phases 7–9 are SQL-heavy with zero interactivity for SQL snippets. `sql.js`
+(WASM SQLite) could power an equivalent "▶ Try It" for ` ```sql ` blocks,
+reusing the existing `CodeBlock` UI shell.
+
+## Mastery Check upgrade: from "click to reveal" to actual self-test 🔲
+
+Mastery Check questions are currently just `<details>` reveal toggles. Since
+`progressStore`/`gamificationStore` already exist, this is a natural
+extension point:
+
+- Track per-question "got it / review again" feedback, persisted to a store.
+- Surface a small "3/5 mastered" badge in the TOC or lesson header.
+- Surface lessons with low mastery scores for revisiting (lightweight
+  spaced-repetition nudge) on the home/progress pages.
+
+## Code block QoL 🔲
+
+- **Diff highlighting**: support ` ```python diff ` or `+`/`-` prefixed lines
+  rendered with green/red backgrounds — useful for refactor-style lessons.
+- **Download/copy whole lesson's code**: a "Copy all snippets" or "Download
+  as .py" button per lesson.
+- **Per-exercise "copy starter code"**, prefilling the playground directly.
+- **Line highlighting** via a ` ```python {3,7-9} ` meta string convention to
+  draw attention to specific lines in Deep Dive sections.
+
+## Reading-mode / navigation polish 🔲
+
+- **Heading anchor click-to-copy**: make `.heading-anchor-link` copy the full
+  URL and fire the existing `toastSuccess` (pattern already used in
+  `Lesson.tsx`), instead of just navigating the hash.
+- **Sticky "answered X/Y mastery checks" mini progress bar** while scrolling,
+  complementing the existing `nearBottom`/`reading-mode` logic.
+- **In-page search ("/" to search this lesson)** with match highlighting and
+  next/prev jump.
+
+## Table & image polish 🔲
+
+- Add a subtle fade/gradient edge indicator when a table overflows
+  horizontally inside `TableComponent`'s scroll wrapper.
+- Render `ImageWithZoom`'s `alt` text as a visible `<figcaption>` below the
+  image — many lesson diagrams currently have no visible caption at all.
+
+## Content-authoring safety nets 🔲
+
+A lint rule (could live in `scripts/validate-content`) that checks every
+`### Exercise N` has a `**Goal**` and code block, and every `### Question N`
+has a `<details>` block — `findInteractiveBlocks` already encodes these
+structural assumptions; validating them at build time would prevent silently
+unparsed exercises.

--- a/src/components/GlossaryTerm.tsx
+++ b/src/components/GlossaryTerm.tsx
@@ -1,0 +1,58 @@
+/**
+ * Glossary Term
+ *
+ * An inline glossary term that reveals its definition in a tooltip.
+ * Supports hover (pointer devices) and tap-to-toggle (touch/mobile), since
+ * hover-only tooltips are unreachable on touch screens.
+ */
+
+import { useState, useRef, useEffect } from 'react'
+
+interface GlossaryTermProps {
+  /** The literal matched text as it appears in the source (preserves casing). */
+  text: string
+  /** The glossary definition shown in the tooltip. */
+  definition: string
+}
+
+export default function GlossaryTerm({ text, definition }: GlossaryTermProps) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      className={`glossary-term${open ? ' glossary-term-active' : ''}`}
+      data-definition={definition}
+      aria-expanded={open}
+      aria-label={`${text}: glossary term, tap for definition`}
+      onClick={(event) => {
+        event.stopPropagation()
+        setOpen((prev) => !prev)
+      }}
+    >
+      {text}
+    </button>
+  )
+}

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -26,9 +26,11 @@ import type { Content, Heading, Html, Nodes, Paragraph, Root, Strong } from 'mda
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import SyntaxHighlighter from '../utils/prism'
 import CopyButton from './CopyButton'
+import GlossaryTerm from './GlossaryTerm'
 import { glossaryTerms, getGlossaryRegex } from '../utils/glossary'
 import { getSecureLinkAttributes } from '../utils/linkSafety'
 import { rehypeSlugCustom } from '../utils/rehype-slug-custom'
+import { remarkCallouts } from '../utils/remark-callouts'
 
 const COLLAPSE_THRESHOLD = 20
 const COLLAPSED_LINE_COUNT = 15
@@ -335,11 +337,7 @@ function addGlossaryTooltips(text: string): (string | JSX.Element)[] {
       const definition = glossaryDefinitionsByLowerTerm[termLower]
 
       if (definition) {
-        parts.push(
-          <span key={`gl-${keyIdx++}`} className="glossary-term" data-definition={definition}>
-            {match[0]}
-          </span>,
-        )
+        parts.push(<GlossaryTerm key={`gl-${keyIdx++}`} text={match[0]} definition={definition} />)
       } else {
         parts.push(match[0])
       }
@@ -692,7 +690,7 @@ const lessonSanitizerSchema: RehypeSanitizeOptions = {
   attributes: {
     a: ['href', 'title', 'target', 'rel'],
     code: ['className'],
-    div: ['className'],
+    div: ['className', 'dataCallout'],
     img: [
       'src',
       'alt',
@@ -727,7 +725,7 @@ const rehypePlugins: NonNullable<ComponentProps<typeof ReactMarkdown>['rehypePlu
   rehypeKatex,
 ]
 
-const remarkPlugins = [remarkGfm, remarkMath]
+const remarkPlugins = [remarkGfm, remarkMath, remarkCallouts]
 
 function InteractiveContent({
   content,

--- a/src/components/__tests__/MarkdownRenderer.test.tsx
+++ b/src/components/__tests__/MarkdownRenderer.test.tsx
@@ -333,8 +333,49 @@ It prints:
 
     const glossaryTerm = container.querySelector('.glossary-term')
     expect(glossaryTerm).toBeTruthy()
+    expect(glossaryTerm?.tagName).toBe('BUTTON')
     expect(glossaryTerm?.textContent).toBe('function')
     expect(glossaryTerm?.getAttribute('data-definition')).toBeTruthy()
+  })
+
+  it('toggles a glossary tooltip open and closed on tap, for touch devices', () => {
+    const content = 'This is a function.'
+    act(() => {
+      root.render(<MarkdownRenderer content={content} />)
+    })
+
+    const glossaryTerm = container.querySelector<HTMLButtonElement>('.glossary-term')!
+    expect(glossaryTerm.getAttribute('aria-expanded')).toBe('false')
+
+    act(() => {
+      glossaryTerm.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(glossaryTerm.getAttribute('aria-expanded')).toBe('true')
+    expect(glossaryTerm.classList.contains('glossary-term-active')).toBe(true)
+
+    act(() => {
+      glossaryTerm.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(glossaryTerm.getAttribute('aria-expanded')).toBe('false')
+    expect(glossaryTerm.classList.contains('glossary-term-active')).toBe(false)
+  })
+
+  it('closes an open glossary tooltip on outside pointerdown', () => {
+    const content = 'This is a function.'
+    act(() => {
+      root.render(<MarkdownRenderer content={content} />)
+    })
+
+    const glossaryTerm = container.querySelector<HTMLButtonElement>('.glossary-term')!
+    act(() => {
+      glossaryTerm.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(glossaryTerm.getAttribute('aria-expanded')).toBe('true')
+
+    act(() => {
+      document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    })
+    expect(glossaryTerm.getAttribute('aria-expanded')).toBe('false')
   })
 
   it('renders glossary tooltips identically for repeated mixed-case terms', () => {
@@ -358,8 +399,48 @@ It prints:
       root.render(<MarkdownRenderer content={content} />)
     })
 
-    expect(container.querySelector('p')?.innerHTML).toBe(
-      'A <span class="glossary-term" data-definition="A reusable block of code that performs a specific task.">function</span> takes an <span class="glossary-term" data-definition="A value passed to a function when it is called.">argument</span> and another function.',
+    const paragraph = container.querySelector('p')
+    expect(paragraph?.textContent).toBe('A function takes an argument and another function.')
+
+    const glossaryTerms = paragraph?.querySelectorAll('.glossary-term')
+    expect(glossaryTerms).toHaveLength(2)
+    expect(glossaryTerms?.[0]?.tagName).toBe('BUTTON')
+    expect(glossaryTerms?.[0]?.textContent).toBe('function')
+    expect(glossaryTerms?.[0]?.getAttribute('data-definition')).toBe(
+      'A reusable block of code that performs a specific task.',
+    )
+    expect(glossaryTerms?.[1]?.tagName).toBe('BUTTON')
+    expect(glossaryTerms?.[1]?.textContent).toBe('argument')
+    expect(glossaryTerms?.[1]?.getAttribute('data-definition')).toBe(
+      'A value passed to a function when it is called.',
+    )
+  })
+
+  it('renders GitHub-style alert blockquotes as styled callouts', () => {
+    const content = ['> [!WARNING]', '> Watch out for this edge case.'].join('\n')
+    act(() => {
+      root.render(<MarkdownRenderer content={content} />)
+    })
+
+    expect(container.querySelector('blockquote')).toBeNull()
+
+    const callout = container.querySelector('.callout')
+    expect(callout).toBeTruthy()
+    expect(callout?.tagName).toBe('DIV')
+    expect(callout?.classList.contains('callout-warning')).toBe(true)
+    expect(callout?.getAttribute('data-callout')).toBe('warning')
+    expect(callout?.textContent?.trim()).toBe('Watch out for this edge case.')
+  })
+
+  it('renders a plain blockquote unchanged when there is no callout marker', () => {
+    const content = '> Just a regular pull quote.'
+    act(() => {
+      root.render(<MarkdownRenderer content={content} />)
+    })
+
+    expect(container.querySelector('.callout')).toBeNull()
+    expect(container.querySelector('blockquote')?.textContent?.trim()).toBe(
+      'Just a regular pull quote.',
     )
   })
 })

--- a/src/styles/content-features.css
+++ b/src/styles/content-features.css
@@ -357,9 +357,16 @@
 /* --- Glossary Tooltips --- */
 .glossary-term {
   position: relative;
+  display: inline;
+  margin: 0;
+  padding: 0;
+  border: none;
   border-bottom: 1px dashed var(--accent-tertiary);
-  cursor: help;
+  border-radius: 0;
+  background: transparent;
+  font: inherit;
   color: inherit;
+  cursor: help;
 }
 
 .glossary-term::after {
@@ -387,7 +394,8 @@
     transform var(--transition-fast);
 }
 
-.glossary-term:hover::after {
+.glossary-term:hover::after,
+.glossary-term.glossary-term-active::after {
   opacity: 1;
   transform: translateX(-50%) translateY(0) scale(1);
 }
@@ -398,8 +406,16 @@
   transform: translateX(0) translateY(4px) scale(0.95);
 }
 
-.glossary-term:first-child:hover::after {
+.glossary-term:first-child:hover::after,
+.glossary-term:first-child.glossary-term-active::after {
   transform: translateX(0) translateY(0) scale(1);
+}
+
+/* Touch devices can't hover — make the tap target's intent clear */
+@media (hover: none) {
+  .glossary-term {
+    cursor: pointer;
+  }
 }
 
 @media (max-width: 768px) {

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -165,6 +165,80 @@
   margin-bottom: 0;
 }
 
+/* Callouts — GitHub-style alert blockquotes: > [!NOTE], [!TIP], [!IMPORTANT], [!WARNING], [!DANGER] */
+.markdown-body .callout {
+  margin: 1.5rem 0;
+  padding: 0.85rem 1rem 0.9rem 1.1rem;
+  border: 1px solid var(--border-card);
+  border-left: 3px solid var(--callout-accent, var(--accent-primary));
+  border-radius: var(--radius-md);
+  background: var(--callout-bg, var(--bg-secondary));
+  font-style: normal;
+}
+
+.markdown-body .callout p {
+  margin: 0.35rem 0 0;
+  color: var(--text-primary);
+}
+
+.markdown-body .callout p:first-child {
+  margin-top: 0;
+}
+
+.markdown-body .callout::before {
+  display: block;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--callout-accent, var(--accent-primary));
+}
+
+.markdown-body .callout-note {
+  --callout-accent: #3b82f6;
+  --callout-bg: rgba(59, 130, 246, 0.08);
+}
+
+.markdown-body .callout-note::before {
+  content: 'ℹ️ Note';
+}
+
+.markdown-body .callout-tip {
+  --callout-accent: #22c55e;
+  --callout-bg: rgba(34, 197, 94, 0.08);
+}
+
+.markdown-body .callout-tip::before {
+  content: '💡 Tip';
+}
+
+.markdown-body .callout-important {
+  --callout-accent: #a855f7;
+  --callout-bg: rgba(168, 85, 247, 0.08);
+}
+
+.markdown-body .callout-important::before {
+  content: '📌 Important';
+}
+
+.markdown-body .callout-warning {
+  --callout-accent: #f59e0b;
+  --callout-bg: rgba(245, 158, 11, 0.08);
+}
+
+.markdown-body .callout-warning::before {
+  content: '⚠️ Warning';
+}
+
+.markdown-body .callout-danger {
+  --callout-accent: #ef4444;
+  --callout-bg: rgba(239, 68, 68, 0.08);
+}
+
+.markdown-body .callout-danger::before {
+  content: '🚫 Danger';
+}
+
 .markdown-body hr {
   border: none;
   border-top: 1px solid var(--border-card);

--- a/src/utils/remark-callouts.ts
+++ b/src/utils/remark-callouts.ts
@@ -1,0 +1,44 @@
+import { visit } from 'unist-util-visit'
+import type { Blockquote, Paragraph, Root } from 'mdast'
+
+export type CalloutType = 'note' | 'tip' | 'important' | 'warning' | 'danger'
+
+const CALLOUT_MARKER = /^\[!(NOTE|TIP|IMPORTANT|WARNING|DANGER)\]\s*/i
+
+/**
+ * Detects GitHub-style alert blockquotes (`> [!NOTE]`, `> [!TIP]`, etc.) and
+ * re-tags them as `<div class="callout callout-{type}" data-callout="{type}">`
+ * so they render as styled boxes instead of plain pull-quotes. The label and
+ * icon are added entirely in CSS via the `data-callout` attribute.
+ */
+export function remarkCallouts() {
+  return (tree: Root) => {
+    visit(tree, 'blockquote', (node: Blockquote) => {
+      const firstChild = node.children[0]
+      if (!firstChild || firstChild.type !== 'paragraph') return
+
+      const paragraph = firstChild as Paragraph
+      const firstInline = paragraph.children[0]
+      if (!firstInline || firstInline.type !== 'text') return
+
+      const match = CALLOUT_MARKER.exec(firstInline.value)
+      if (!match) return
+
+      const type = match[1]!.toLowerCase() as CalloutType
+      firstInline.value = firstInline.value.slice(match[0].length)
+
+      if (firstInline.value === '' && paragraph.children.length === 1) {
+        node.children.shift()
+      }
+
+      node.data = {
+        ...node.data,
+        hName: 'div',
+        hProperties: {
+          className: ['callout', `callout-${type}`],
+          dataCallout: type,
+        },
+      }
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- GitHub-style alert blockquotes (`> [!NOTE]`, `[!TIP]`, `[!WARNING]`, `[!DANGER]`, `[!IMPORTANT]`) now render as styled callout boxes via a new `remarkCallouts` plugin (`src/utils/remark-callouts.ts`), styled in `markdown.css`.
- Glossary term tooltips were hover-only and unreachable on touch devices. They're now rendered via a new `GlossaryTerm` component (`src/components/GlossaryTerm.tsx`) — a tappable button that toggles the tooltip, with outside-tap/Escape dismiss, while still supporting `:hover` on pointer devices.
- Documented the full markdown-renderer feature brainstorm (mermaid diagrams, runnable SQL blocks, mastery-check self-testing, code-block QoL, etc.) in `docs/markdown-renderer-roadmap.md` for future work.

## Test plan
- [x] `npx vitest run` — all 644 tests pass, including new callout-rendering and glossary tap/dismiss tests
- [x] `npm run typecheck` — clean
- [x] Manually traced the remark→rehype pipeline for sanitizer compatibility (`div`/`data-callout` added to the sanitizer schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KL8RWwzXKgYbrAYHbB2pmu


---
_Generated by [Claude Code](https://claude.ai/code/session_01KL8RWwzXKgYbrAYHbB2pmu)_