### PR TITLE
Implement Code block QoL: diff/line highlighting, lesson code actions, copy starter code

### DIFF
--- a/docs/markdown-renderer-roadmap.md
+++ b/docs/markdown-renderer-roadmap.md
@@ -56,15 +56,27 @@ extension point:
 - Surface lessons with low mastery scores for revisiting (lightweight
   spaced-repetition nudge) on the home/progress pages.
 
-## Code block QoL 🔲
+## Code block QoL ✅
 
-- **Diff highlighting**: support ` ```python diff ` or `+`/`-` prefixed lines
-  rendered with green/red backgrounds — useful for refactor-style lessons.
-- **Download/copy whole lesson's code**: a "Copy all snippets" or "Download
-  as .py" button per lesson.
-- **Per-exercise "copy starter code"**, prefilling the playground directly.
-- **Line highlighting** via a ` ```python {3,7-9} ` meta string convention to
-  draw attention to specific lines in Deep Dive sections.
+- **Diff highlighting**: a remark plugin (`src/utils/remark-code-meta.ts`)
+  reads the fence's meta string for a `diff` keyword (or a bare ` ```diff `
+  language) and tags the mdast `code` node with `data-diff`. `CodeBlock` (in
+  `MarkdownRenderer.tsx`) uses `react-syntax-highlighter`'s `lineProps` to
+  color `+`/`-` prefixed lines green/red (skipping unified-diff `+++`/`---`
+  file headers) and shows a small "diff" badge when the language itself isn't
+  `diff`.
+- **Download/copy whole lesson's code**: `src/utils/lessonCodeBlocks.ts`
+  extracts every runnable `python`/`py` fence from a lesson's markdown
+  (skipping `diff`-flagged ones), and `LessonCodeActions`
+  (`src/components/LessonCodeActions.tsx`) renders "Copy all snippets" and
+  "Download as .py" buttons in the lesson header.
+- **Per-exercise "copy starter code"**: `ExerciseWidget` now has a "Copy
+  starter code" button (via the shared `CopyButton`) that copies the original
+  `starterCode` prop, independent of any live edits in the playground.
+- **Line highlighting**: the same `remarkCodeMeta` plugin parses a
+  ` ```python {3,7-9} ` meta range and tags the node with
+  `data-highlight-lines`, which `CodeBlock` turns into highlighted lines via
+  `lineProps`.
 
 ## Reading-mode / navigation polish 🔲
 

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -20,6 +20,8 @@ interface CopyButtonProps {
   showEmoji?: boolean
   /** Optional aria-label for accessibility. */
   ariaLabel?: string
+  /** Optional custom button label, shown instead of the default "Copy" text. */
+  label?: string
 }
 
 /**
@@ -37,11 +39,12 @@ export default function CopyButton({
   className = 'code-block-copy',
   showEmoji = false,
   ariaLabel,
+  label,
 }: CopyButtonProps) {
   const [copied, setCopied] = useState(false)
   const timeoutRef = useRef<number | null>(null)
 
-  const label = ariaLabel || (showEmoji ? 'Copy to clipboard' : 'Copy code')
+  const accessibleLabel = ariaLabel || (showEmoji ? 'Copy to clipboard' : 'Copy code')
 
   const handleCopy = useCallback(() => {
     navigator.clipboard
@@ -76,8 +79,8 @@ export default function CopyButton({
       type="button"
       className={`${className} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2`}
       onClick={handleCopy}
-      aria-label={copied ? 'Code copied to clipboard' : label}
-      title={label}
+      aria-label={copied ? 'Code copied to clipboard' : accessibleLabel}
+      title={accessibleLabel}
     >
       {copied ? (
         <>
@@ -85,10 +88,10 @@ export default function CopyButton({
         </>
       ) : showEmoji ? (
         <>
-          <span aria-hidden="true">📋</span> Copy
+          <span aria-hidden="true">📋</span> {label ?? 'Copy'}
         </>
       ) : (
-        'Copy'
+        (label ?? 'Copy')
       )}
       <span className="sr-only" aria-live="polite" aria-atomic="true">
         {copied ? 'Code copied to clipboard' : ''}

--- a/src/components/ExerciseWidget.tsx
+++ b/src/components/ExerciseWidget.tsx
@@ -203,6 +203,12 @@ export default function ExerciseWidget({
           🧪
         </span>
         <h3 className="exercise-widget__title">{title}</h3>
+        <CopyButton
+          text={starterCode}
+          className="exercise-widget__copy-starter-btn"
+          ariaLabel="Copy starter code for this exercise"
+          label="Copy starter code"
+        />
       </div>
 
       {goal && (

--- a/src/components/LessonCodeActions.tsx
+++ b/src/components/LessonCodeActions.tsx
@@ -1,0 +1,73 @@
+/**
+ * Lesson Code Actions
+ *
+ * Lesson-level controls for working with all of a lesson's Python code at once.
+ *
+ * Key Responsibilities:
+ * - Extract every runnable `python`/`py` snippet from the lesson's markdown.
+ * - Offer a "Copy all snippets" button (via the shared `CopyButton`).
+ * - Offer a "Download as .py" button that saves the combined snippets as a file.
+ */
+
+import { useCallback, useMemo } from 'react'
+import CopyButton from './CopyButton'
+import { extractLessonCodeBlocks, joinLessonCodeBlocks } from '../utils/lessonCodeBlocks'
+import { toastSuccess } from '../utils/toast'
+
+interface LessonCodeActionsProps {
+  /** The lesson's raw markdown content to extract code blocks from. */
+  content: string
+  /** The lesson's day token, used to name the downloaded file. */
+  day: string
+}
+
+/**
+ * Renders "Copy all snippets" and "Download as .py" buttons for a lesson,
+ * combining every Python code block found in its content. Renders nothing
+ * if the lesson has no Python code blocks.
+ *
+ * @param {LessonCodeActionsProps} props - The component properties.
+ * @returns {React.ReactElement | null} The rendered controls, or null if there's no code to act on.
+ */
+export default function LessonCodeActions({ content, day }: LessonCodeActionsProps) {
+  const combinedCode = useMemo(() => {
+    const blocks = extractLessonCodeBlocks(content)
+    return blocks.length > 0 ? joinLessonCodeBlocks(blocks) : ''
+  }, [content])
+
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([combinedCode], { type: 'text/x-python' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = `day-${day}-snippets.py`
+    document.body.appendChild(anchor)
+    anchor.click()
+    document.body.removeChild(anchor)
+    URL.revokeObjectURL(url)
+    toastSuccess('Downloaded lesson code ✓')
+  }, [combinedCode, day])
+
+  if (!combinedCode) return null
+
+  return (
+    <div className="lesson-code-actions">
+      <CopyButton
+        text={combinedCode}
+        className="lesson-code-action-btn"
+        ariaLabel="Copy all code snippets from this lesson"
+        label="Copy all snippets"
+        showEmoji
+      />
+      <button
+        type="button"
+        className="lesson-code-action-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+        onClick={handleDownload}
+        aria-label="Download all code snippets from this lesson as a .py file"
+        title="Download as .py"
+      >
+        <span aria-hidden="true">⬇</span> Download .py
+      </button>
+    </div>
+  )
+}

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -11,7 +11,17 @@
  * - Render code blocks with syntax highlighting and copy buttons.
  */
 
-import { useState, useEffect, memo, JSX, useMemo, type ComponentProps, lazy, Suspense } from 'react'
+import {
+  useState,
+  useEffect,
+  useCallback,
+  memo,
+  JSX,
+  useMemo,
+  type ComponentProps,
+  lazy,
+  Suspense,
+} from 'react'
 import { createPortal } from 'react-dom'
 import ReactMarkdown, { Components, ExtraProps } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -31,6 +41,7 @@ import { glossaryTerms, getGlossaryRegex } from '../utils/glossary'
 import { getSecureLinkAttributes } from '../utils/linkSafety'
 import { rehypeSlugCustom } from '../utils/rehype-slug-custom'
 import { remarkCallouts } from '../utils/remark-callouts'
+import { remarkCodeMeta } from '../utils/remark-code-meta'
 
 const COLLAPSE_THRESHOLD = 20
 const COLLAPSED_LINE_COUNT = 15
@@ -53,7 +64,17 @@ const customTheme = {
   },
 }
 
-function CodeBlock({ className, children }: { className?: string; children: React.ReactNode }) {
+function CodeBlock({
+  className,
+  children,
+  isDiff,
+  highlightLines,
+}: {
+  className?: string
+  children: React.ReactNode
+  isDiff?: boolean
+  highlightLines?: number[]
+}) {
   const match = /language-(\w+)/.exec(className || '')
   const lang = match ? match[1]! : ''
   const code = String(children).replace(/\n$/, '')
@@ -64,6 +85,27 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
   const isLong = lines.length > COLLAPSE_THRESHOLD
   const [collapsed, setCollapsed] = useState(isLong)
   const [wrapLines, setWrapLines] = useState(true)
+
+  const highlightLineSet = useMemo(() => new Set(highlightLines ?? []), [highlightLines])
+
+  const getLineProps = useCallback(
+    (lineNumber: number): { className?: string } => {
+      const lineClasses: string[] = []
+      if (highlightLineSet.has(lineNumber)) {
+        lineClasses.push('code-block-line--highlighted')
+      }
+      if (isDiff) {
+        const sourceLine = lines[lineNumber - 1] ?? ''
+        if (sourceLine.startsWith('+') && !sourceLine.startsWith('+++')) {
+          lineClasses.push('code-block-line--diff-add')
+        } else if (sourceLine.startsWith('-') && !sourceLine.startsWith('---')) {
+          lineClasses.push('code-block-line--diff-remove')
+        }
+      }
+      return lineClasses.length > 0 ? { className: lineClasses.join(' ') } : {}
+    },
+    [highlightLineSet, isDiff, lines],
+  )
 
   if (!match) {
     return <code className={className}>{children}</code>
@@ -78,7 +120,10 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
       data-wrap={wrapLines ? 'true' : 'false'}
     >
       <div className="code-block-header">
-        <span className="code-block-lang">{lang}</span>
+        <span className="code-block-lang">
+          {lang}
+          {isDiff && lang !== 'diff' && <span className="code-block-diff-badge">diff</span>}
+        </span>
         <div style={{ display: 'flex', gap: '0.4rem', alignItems: 'center' }}>
           <button
             type="button"
@@ -108,6 +153,8 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
           language={lang}
           PreTag="div"
           wrapLongLines={wrapLines}
+          wrapLines
+          lineProps={getLineProps}
           showLineNumbers={lines.length > 3}
           lineNumberStyle={{
             minWidth: '2.5em',
@@ -172,10 +219,21 @@ function CodeBlock({ className, children }: { className?: string; children: Reac
 }
 
 const CodeComponent = (props: JSX.IntrinsicElements['code'] & ExtraProps) => {
-  const { children, className, ...rest } = props
+  const { children, className, node, ...rest } = props
   const match = /language-(\w+)/.exec(className || '')
   if (match) {
-    return <CodeBlock className={className}>{children}</CodeBlock>
+    const properties = node?.properties as Record<string, unknown> | undefined
+    const isDiff = properties?.dataDiff === 'true'
+    const highlightLinesAttr = properties?.dataHighlightLines
+    const highlightLines =
+      typeof highlightLinesAttr === 'string' && highlightLinesAttr.length > 0
+        ? highlightLinesAttr.split(',').map((n) => parseInt(n, 10))
+        : undefined
+    return (
+      <CodeBlock className={className} isDiff={isDiff} highlightLines={highlightLines}>
+        {children}
+      </CodeBlock>
+    )
   }
   return (
     <code className={className} {...rest}>
@@ -689,7 +747,7 @@ const lessonSanitizerSchema: RehypeSanitizeOptions = {
   ],
   attributes: {
     a: ['href', 'title', 'target', 'rel'],
-    code: ['className'],
+    code: ['className', 'dataDiff', 'dataHighlightLines'],
     div: ['className', 'dataCallout'],
     img: [
       'src',
@@ -725,7 +783,7 @@ const rehypePlugins: NonNullable<ComponentProps<typeof ReactMarkdown>['rehypePlu
   rehypeKatex,
 ]
 
-const remarkPlugins = [remarkGfm, remarkMath, remarkCallouts]
+const remarkPlugins = [remarkGfm, remarkMath, remarkCallouts, remarkCodeMeta]
 
 function InteractiveContent({
   content,

--- a/src/components/__tests__/CopyButton.test.tsx
+++ b/src/components/__tests__/CopyButton.test.tsx
@@ -169,4 +169,22 @@ describe('CopyButton', () => {
     const button = container.querySelector('button')
     expect(button?.textContent).toContain('📋 Copy')
   })
+
+  it('renders a custom label when provided', () => {
+    act(() => {
+      root?.render(<CopyButton text="some code" label="Copy all snippets" />)
+    })
+
+    const button = container.querySelector('button')
+    expect(button?.textContent).toContain('Copy all snippets')
+  })
+
+  it('renders a custom label alongside the emoji', () => {
+    act(() => {
+      root?.render(<CopyButton text="some code" showEmoji label="Copy starter code" />)
+    })
+
+    const button = container.querySelector('button')
+    expect(button?.textContent).toContain('📋 Copy starter code')
+  })
 })

--- a/src/components/__tests__/LessonCodeActions.test.tsx
+++ b/src/components/__tests__/LessonCodeActions.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot, Root } from 'react-dom/client'
+import LessonCodeActions from '../LessonCodeActions'
+import { toastSuccess } from '../../utils/toast'
+
+vi.mock('../../utils/toast', () => ({
+  toastSuccess: vi.fn(),
+}))
+
+describe('LessonCodeActions', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    })
+    URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+    URL.revokeObjectURL = vi.fn()
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    document.body.removeChild(container)
+    vi.restoreAllMocks()
+  })
+
+  it('renders nothing when the lesson has no python code blocks', () => {
+    act(() => {
+      root.render(<LessonCodeActions content="# Just text, no code." day="1" />)
+    })
+
+    expect(container.querySelector('.lesson-code-actions')).toBeNull()
+  })
+
+  it('copies all python snippets joined together', async () => {
+    const content = '```python\nprint("a")\n```\nSome text.\n```python\nprint("b")\n```'
+    act(() => {
+      root.render(<LessonCodeActions content={content} day="1" />)
+    })
+
+    const copyButton = container.querySelector(
+      'button[aria-label="Copy all code snippets from this lesson"]',
+    )
+    expect(copyButton).toBeTruthy()
+
+    await act(async () => {
+      copyButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      '# --- Snippet 1 ---\nprint("a")\n\n# --- Snippet 2 ---\nprint("b")',
+    )
+  })
+
+  it('downloads the combined snippets as a .py file named after the lesson day', async () => {
+    const content = '```python\nprint("a")\n```'
+    act(() => {
+      root.render(<LessonCodeActions content={content} day="7B" />)
+    })
+
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    const downloadButton = container.querySelector(
+      'button[aria-label="Download all code snippets from this lesson as a .py file"]',
+    ) as HTMLButtonElement
+
+    await act(async () => {
+      downloadButton.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(clickSpy).toHaveBeenCalled()
+    expect(URL.createObjectURL).toHaveBeenCalled()
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+    expect(toastSuccess).toHaveBeenCalledWith('Downloaded lesson code ✓')
+    clickSpy.mockRestore()
+  })
+})

--- a/src/components/__tests__/MarkdownRenderer.test.tsx
+++ b/src/components/__tests__/MarkdownRenderer.test.tsx
@@ -163,6 +163,70 @@ describe('MarkdownRenderer', () => {
     expect(highlighterProps?.customStyle?.overflowX).toBe('hidden')
   })
 
+  it('shows a diff badge and colors +/- lines for `diff`-flagged fences', () => {
+    const content = '```python diff\n print("a")\n+print("b")\n-print("c")\n```'
+    act(() => {
+      root.render(<MarkdownRenderer content={content} />)
+    })
+
+    const codeBlock = container.querySelector('.code-block-wrapper')
+    expect(codeBlock?.querySelector('.code-block-diff-badge')?.textContent).toBe('diff')
+
+    const [highlighterPropsRaw] = syntaxHighlighterMock.mock.calls.at(-1) ?? []
+    const lineProps = (highlighterPropsRaw as { lineProps?: (n: number) => { className?: string } })
+      .lineProps
+    expect(lineProps).toBeTruthy()
+    expect(lineProps?.(1)).toEqual({})
+    expect(lineProps?.(2).className).toBe('code-block-line--diff-add')
+    expect(lineProps?.(3).className).toBe('code-block-line--diff-remove')
+  })
+
+  it('treats a bare ```diff fence as diff mode without showing a badge', () => {
+    const content = '```diff\n+print("b")\n-print("c")\n```'
+    act(() => {
+      root.render(<MarkdownRenderer content={content} />)
+    })
+
+    const codeBlock = container.querySelector('.code-block-wrapper')
+    expect(codeBlock?.querySelector('.code-block-diff-badge')).toBeNull()
+
+    const [highlighterPropsRaw] = syntaxHighlighterMock.mock.calls.at(-1) ?? []
+    const lineProps = (highlighterPropsRaw as { lineProps?: (n: number) => { className?: string } })
+      .lineProps
+    expect(lineProps?.(1).className).toBe('code-block-line--diff-add')
+    expect(lineProps?.(2).className).toBe('code-block-line--diff-remove')
+  })
+
+  it('does not color unified-diff file header lines (+++/---)', () => {
+    const content = '```diff\n+++ b/file.py\n--- a/file.py\n+print("b")\n```'
+    act(() => {
+      root.render(<MarkdownRenderer content={content} />)
+    })
+
+    const [highlighterPropsRaw] = syntaxHighlighterMock.mock.calls.at(-1) ?? []
+    const lineProps = (highlighterPropsRaw as { lineProps?: (n: number) => { className?: string } })
+      .lineProps
+    expect(lineProps?.(1)).toEqual({})
+    expect(lineProps?.(2)).toEqual({})
+    expect(lineProps?.(3).className).toBe('code-block-line--diff-add')
+  })
+
+  it('highlights specified lines via a `{a,b-c}` meta range', () => {
+    const content = '```python {2,4-5}\nline1\nline2\nline3\nline4\nline5\n```'
+    act(() => {
+      root.render(<MarkdownRenderer content={content} />)
+    })
+
+    const [highlighterPropsRaw] = syntaxHighlighterMock.mock.calls.at(-1) ?? []
+    const lineProps = (highlighterPropsRaw as { lineProps?: (n: number) => { className?: string } })
+      .lineProps
+    expect(lineProps?.(1)).toEqual({})
+    expect(lineProps?.(2).className).toBe('code-block-line--highlighted')
+    expect(lineProps?.(3)).toEqual({})
+    expect(lineProps?.(4).className).toBe('code-block-line--highlighted')
+    expect(lineProps?.(5).className).toBe('code-block-line--highlighted')
+  })
+
   it('renders "Try It" button for Python code blocks', async () => {
     const content = '```python\nprint("hello")\n```'
     act(() => {

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -44,6 +44,7 @@ import Breadcrumb from '../components/Breadcrumb'
 import BackToTop from '../components/BackToTop'
 import TableOfContents from '../components/TableOfContents'
 import PrerequisitePills from '../components/PrerequisitePills'
+import LessonCodeActions from '../components/LessonCodeActions'
 import RelatedLessons from '../components/RelatedLessons'
 import { useSwipe } from '../hooks/useSwipe'
 import { toastInfo, toastSuccess } from '../utils/toast'
@@ -331,6 +332,8 @@ export default function Lesson() {
                   ))}
                 </div>
               )}
+
+              <LessonCodeActions content={lesson.content} day={String(lesson.day)} />
 
               <PrerequisitePills lesson={lesson} />
             </div>

--- a/src/styles/interactive.css
+++ b/src/styles/interactive.css
@@ -276,6 +276,25 @@
   color: var(--text-heading);
 }
 
+.exercise-widget__copy-starter-btn {
+  margin-left: auto;
+  padding: 0.3rem 0.6rem;
+  background: transparent;
+  border: 1px solid var(--border-card);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  transition: all var(--transition-fast);
+}
+
+.exercise-widget__copy-starter-btn:hover {
+  color: var(--accent-primary);
+  border-color: var(--accent-primary);
+}
+
 .exercise-widget__goal {
   padding: 0.5rem 0.75rem 0;
   font-size: 0.8125rem;

--- a/src/styles/lesson.css
+++ b/src/styles/lesson.css
@@ -162,6 +162,35 @@
   gap: 0.4rem;
 }
 
+.lesson-code-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.lesson-code-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.85rem;
+  background: transparent;
+  border: 1px solid var(--border-card);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  transition: all var(--transition-fast);
+}
+
+.lesson-code-action-btn:hover {
+  color: var(--accent-primary);
+  border-color: var(--accent-primary);
+}
+
 .lesson-tag {
   padding: 0.2rem 0.55rem;
   border: 1px solid var(--border-subtle);

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -684,6 +684,45 @@
   word-break: normal !important;
 }
 
+/* ===== CODE BLOCK: DIFF + LINE HIGHLIGHTING ===== */
+/* Driven by fence meta conventions: ` ```diff `, ` ```python diff `, ` ```python {3,7-9} ` */
+
+.code-block-diff-badge {
+  margin-left: 0.4rem;
+  padding: 0.05rem 0.35rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--accent-tertiary);
+  background: color-mix(in srgb, var(--accent-tertiary) 12%, transparent);
+}
+
+.code-block-line--highlighted {
+  display: block;
+  margin: 0 -1rem;
+  padding: 0 1rem;
+  background: color-mix(in srgb, var(--accent-primary) 10%, transparent);
+  border-left: 2px solid var(--accent-primary);
+}
+
+.code-block-line--diff-add {
+  display: block;
+  margin: 0 -1rem;
+  padding: 0 1rem;
+  background: rgba(34, 197, 94, 0.14);
+  border-left: 2px solid #22c55e;
+}
+
+.code-block-line--diff-remove {
+  display: block;
+  margin: 0 -1rem;
+  padding: 0 1rem;
+  background: rgba(239, 68, 68, 0.14);
+  border-left: 2px solid #ef4444;
+}
+
 /* ===== IMAGE ZOOM / LIGHTBOX ===== */
 
 .zoomable-image {

--- a/src/utils/__tests__/lessonCodeBlocks.test.ts
+++ b/src/utils/__tests__/lessonCodeBlocks.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { extractLessonCodeBlocks, joinLessonCodeBlocks } from '../lessonCodeBlocks'
+
+describe('extractLessonCodeBlocks', () => {
+  it('extracts python and py fenced code blocks in order', () => {
+    const content = [
+      '# Lesson',
+      '```python',
+      'print("a")',
+      '```',
+      'Some text.',
+      '```py',
+      'print("b")',
+      '```',
+    ].join('\n')
+
+    expect(extractLessonCodeBlocks(content)).toEqual(['print("a")', 'print("b")'])
+  })
+
+  it('ignores code blocks in other languages', () => {
+    const content = '```bash\necho hi\n```\n```python\nprint("a")\n```'
+    expect(extractLessonCodeBlocks(content)).toEqual(['print("a")'])
+  })
+
+  it('skips diff-flagged python fences', () => {
+    const content = '```python diff\n+print("a")\n```\n```python\nprint("b")\n```'
+    expect(extractLessonCodeBlocks(content)).toEqual(['print("b")'])
+  })
+
+  it('returns an empty array when there are no python code blocks', () => {
+    expect(extractLessonCodeBlocks('# Just text\nNo code here.')).toEqual([])
+  })
+})
+
+describe('joinLessonCodeBlocks', () => {
+  it('joins blocks with numbered snippet headers', () => {
+    const joined = joinLessonCodeBlocks(['print("a")', 'print("b")'])
+    expect(joined).toBe('# --- Snippet 1 ---\nprint("a")\n\n# --- Snippet 2 ---\nprint("b")')
+  })
+
+  it('returns an empty string for no blocks', () => {
+    expect(joinLessonCodeBlocks([])).toBe('')
+  })
+})

--- a/src/utils/__tests__/remark-code-meta.test.ts
+++ b/src/utils/__tests__/remark-code-meta.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import type { Code, Root } from 'mdast'
+import { parseHighlightLines, remarkCodeMeta } from '../remark-code-meta'
+
+function parseCodeNode(markdown: string): Code {
+  const processor = unified().use(remarkParse).use(remarkCodeMeta)
+  const tree = processor.runSync(processor.parse(markdown)) as Root
+  const code = tree.children.find((node): node is Code => node.type === 'code')
+  if (!code) throw new Error('no code node found')
+  return code
+}
+
+describe('parseHighlightLines', () => {
+  it('parses comma-separated line numbers', () => {
+    expect(parseHighlightLines('1,3,5')).toEqual([1, 3, 5])
+  })
+
+  it('expands ranges', () => {
+    expect(parseHighlightLines('7-9')).toEqual([7, 8, 9])
+  })
+
+  it('handles reversed ranges', () => {
+    expect(parseHighlightLines('9-7')).toEqual([7, 8, 9])
+  })
+
+  it('dedupes and sorts mixed specs', () => {
+    expect(parseHighlightLines('5, 1-3, 3')).toEqual([1, 2, 3, 5])
+  })
+
+  it('ignores empty segments', () => {
+    expect(parseHighlightLines('1,,3')).toEqual([1, 3])
+  })
+})
+
+describe('remarkCodeMeta', () => {
+  it('flags a bare ```diff fence as diff mode', () => {
+    const code = parseCodeNode('```diff\n+a\n-b\n```')
+    const hProperties = code.data?.hProperties as Record<string, unknown> | undefined
+    expect(hProperties?.dataDiff).toBe('true')
+    expect(hProperties?.dataHighlightLines).toBeUndefined()
+  })
+
+  it('flags ```python diff via the diff keyword in meta', () => {
+    const code = parseCodeNode('```python diff\nprint("a")\n```')
+    const hProperties = code.data?.hProperties as Record<string, unknown> | undefined
+    expect(hProperties?.dataDiff).toBe('true')
+  })
+
+  it('sets dataHighlightLines from a {a,b-c} meta range', () => {
+    const code = parseCodeNode('```python {2,4-5}\nline1\nline2\nline3\n```')
+    const hProperties = code.data?.hProperties as Record<string, unknown> | undefined
+    expect(hProperties?.dataHighlightLines).toBe('2,4,5')
+    expect(hProperties?.dataDiff).toBeUndefined()
+  })
+
+  it('combines diff and highlight-line flags in one meta string', () => {
+    const code = parseCodeNode('```python diff {1}\n+a\n```')
+    const hProperties = code.data?.hProperties as Record<string, unknown> | undefined
+    expect(hProperties?.dataDiff).toBe('true')
+    expect(hProperties?.dataHighlightLines).toBe('1')
+  })
+
+  it('leaves plain fences untouched', () => {
+    const code = parseCodeNode('```python\nprint("a")\n```')
+    expect(code.data?.hProperties).toBeUndefined()
+  })
+})

--- a/src/utils/lessonCodeBlocks.ts
+++ b/src/utils/lessonCodeBlocks.ts
@@ -1,0 +1,47 @@
+/**
+ * Lesson Code Block Extraction
+ *
+ * Pulls runnable Python snippets out of a lesson's raw markdown content for the
+ * "Copy all snippets" / "Download as .py" lesson-level actions.
+ *
+ * Key Responsibilities:
+ * - Extract `python`/`py` fenced code blocks, skipping `diff`-flagged fences
+ *   (illustrative diffs aren't valid, runnable Python).
+ * - Join extracted blocks into a single downloadable/copyable script.
+ */
+
+const PYTHON_CODE_FENCE = /```(?:python|py)([^\n]*)\n([\s\S]*?)```/g
+const DIFF_KEYWORD = /\bdiff\b/i
+
+/**
+ * Extracts all runnable `python`/`py` fenced code blocks from a lesson's markdown
+ * content, in document order. Fences flagged as `diff` (e.g. ` ```python diff `)
+ * are skipped since they illustrate a change rather than runnable code.
+ *
+ * @param {string} content - The lesson's raw markdown content.
+ * @returns {string[]} The extracted code blocks, trimmed of trailing newlines.
+ */
+export function extractLessonCodeBlocks(content: string): string[] {
+  const blocks: string[] = []
+  PYTHON_CODE_FENCE.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = PYTHON_CODE_FENCE.exec(content)) !== null) {
+    const meta = match[1] ?? ''
+    if (DIFF_KEYWORD.test(meta)) continue
+
+    const code = match[2]?.replace(/\n$/, '')
+    if (code) blocks.push(code)
+  }
+  return blocks
+}
+
+/**
+ * Joins extracted code blocks into a single script, separating each snippet
+ * with a numbered comment header.
+ *
+ * @param {string[]} blocks - The code blocks to join, in document order.
+ * @returns {string} The combined script text.
+ */
+export function joinLessonCodeBlocks(blocks: string[]): string {
+  return blocks.map((block, index) => `# --- Snippet ${index + 1} ---\n${block}`).join('\n\n')
+}

--- a/src/utils/prism.ts
+++ b/src/utils/prism.ts
@@ -16,6 +16,7 @@ import json from 'react-syntax-highlighter/dist/esm/languages/prism/json'
 import markdown from 'react-syntax-highlighter/dist/esm/languages/prism/markdown'
 import typescript from 'react-syntax-highlighter/dist/esm/languages/prism/typescript'
 import javascript from 'react-syntax-highlighter/dist/esm/languages/prism/javascript'
+import diff from 'react-syntax-highlighter/dist/esm/languages/prism/diff'
 
 SyntaxHighlighter.registerLanguage('python', python)
 SyntaxHighlighter.registerLanguage('bash', bash)
@@ -23,11 +24,12 @@ SyntaxHighlighter.registerLanguage('json', json)
 SyntaxHighlighter.registerLanguage('markdown', markdown)
 SyntaxHighlighter.registerLanguage('typescript', typescript)
 SyntaxHighlighter.registerLanguage('javascript', javascript)
+SyntaxHighlighter.registerLanguage('diff', diff)
 
 /**
  * A configured instance of `react-syntax-highlighter` using PrismLight.
  * This exported component has language definitions for python, bash, json,
- * markdown, typescript, and javascript pre-registered to minimize bundle size.
+ * markdown, typescript, javascript, and diff pre-registered to minimize bundle size.
  *
  * @type {React.ComponentType}
  * @returns {React.ComponentType} The SyntaxHighlighter component.

--- a/src/utils/remark-code-meta.ts
+++ b/src/utils/remark-code-meta.ts
@@ -1,0 +1,67 @@
+import { visit } from 'unist-util-visit'
+import type { Code, Root } from 'mdast'
+
+const DIFF_KEYWORD = /\bdiff\b/i
+const LINE_RANGE_SPEC = /\{([\d,\-\s]+)\}/
+
+/**
+ * Expands a `{3,7-9}`-style line range spec into a sorted list of distinct
+ * 1-indexed line numbers.
+ */
+export function parseHighlightLines(spec: string): number[] {
+  const lines = new Set<number>()
+
+  for (const part of spec.split(',')) {
+    const trimmed = part.trim()
+    if (!trimmed) continue
+
+    const rangeMatch = trimmed.match(/^(\d+)\s*-\s*(\d+)$/)
+    if (rangeMatch) {
+      const start = parseInt(rangeMatch[1]!, 10)
+      const end = parseInt(rangeMatch[2]!, 10)
+      const [from, to] = start <= end ? [start, end] : [end, start]
+      for (let n = from; n <= to; n++) lines.add(n)
+      continue
+    }
+
+    if (/^\d+$/.test(trimmed)) {
+      lines.add(parseInt(trimmed, 10))
+    }
+  }
+
+  return Array.from(lines).sort((a, b) => a - b)
+}
+
+/**
+ * Parses a fenced code block's meta/info string (the text following the
+ * language on the opening fence, e.g. ` ```python diff` or ` ```python {3,7-9}`)
+ * for the "code block QoL" conventions: a `diff` keyword enabling +/- line
+ * coloring, and a `{...}` range enabling line highlighting.
+ */
+export function remarkCodeMeta() {
+  return (tree: Root) => {
+    visit(tree, 'code', (node: Code) => {
+      const meta = node.meta ?? ''
+
+      // A bare ` ```diff ` fence is diff-mode by language alone; ` ```python diff `
+      // (or any other language) opts in via the `diff` keyword in the meta string.
+      const isDiff = node.lang === 'diff' || DIFF_KEYWORD.test(meta)
+      const rangeMatch = meta.match(LINE_RANGE_SPEC)
+      const highlightLines = rangeMatch ? parseHighlightLines(rangeMatch[1]!) : []
+
+      if (!isDiff && highlightLines.length === 0) return
+
+      const hProperties: Record<string, string> = {}
+      if (isDiff) hProperties.dataDiff = 'true'
+      if (highlightLines.length > 0) hProperties.dataHighlightLines = highlightLines.join(',')
+
+      node.data = {
+        ...node.data,
+        hProperties: {
+          ...(node.data?.hProperties as Record<string, unknown> | undefined),
+          ...hProperties,
+        },
+      }
+    })
+  }
+}

--- a/src/utils/remark-code-meta.ts
+++ b/src/utils/remark-code-meta.ts
@@ -57,10 +57,7 @@ export function remarkCodeMeta() {
 
       node.data = {
         ...node.data,
-        hProperties: {
-          ...(node.data?.hProperties as Record<string, unknown> | undefined),
-          ...hProperties,
-        },
+        hProperties,
       }
     })
   }


### PR DESCRIPTION
## Summary
Implements the [Code block QoL](https://github.com/saint2706/Coding-For-MBA/blob/main/docs/markdown-renderer-roadmap.md#code-block-qol-) section of the markdown renderer roadmap:

- **Diff highlighting**: a new remark plugin (`src/utils/remark-code-meta.ts`) reads a fence's `diff` keyword (` ```python diff `) or a bare ` ```diff ` language and tags the code node so `CodeBlock` colors `+`/`-` lines green/red via `react-syntax-highlighter`'s `lineProps` (skipping unified-diff `+++`/`---` headers), with a small "diff" badge when the language itself isn't `diff`.
- **Line highlighting**: the same plugin parses a ` ```python {3,7-9} ` meta range and highlights those lines.
- **Download/copy whole lesson's code**: new `LessonCodeActions` component extracts every runnable Python snippet from a lesson (`src/utils/lessonCodeBlocks.ts`) and offers "Copy all snippets" / "Download as .py" buttons in the lesson header.
- **Per-exercise "copy starter code"**: `ExerciseWidget` now has a "Copy starter code" button that copies the original starter code, independent of live playground edits.

`CopyButton` gained an optional `label` prop to support custom button text for the new use cases. `docs/markdown-renderer-roadmap.md` is updated to mark the section ✅.

## Test plan
- [x] `npx tsc --noEmit -p .` passes
- [x] `npx prettier --check` passes
- [x] Full test suite passes (92 files / 669 tests), including new tests for `remark-code-meta`, `lessonCodeBlocks`, `LessonCodeActions`, diff/highlight behavior in `MarkdownRenderer`, and the new `CopyButton` label prop


---
_Generated by [Claude Code](https://claude.ai/code/session_01VtM94cuMYp8Gag6rBQHBzX)_