### PR TITLE
Add Mermaid diagrams to Phase 1-3 lessons

### DIFF
--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_09_Conditionals/README.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_09_Conditionals/README.md
@@ -107,6 +107,21 @@ print(f"Grade: {grade}")  # Grade: B
 
 **Important**: Only ONE branch executes. Python stops at the first `True` condition.
 
+```mermaid
+flowchart TD
+    A[score] --> B{score >= 90?}
+    B -- Yes --> C[grade = A]
+    B -- No --> D{score >= 80?}
+    D -- Yes --> E[grade = B]
+    D -- No --> F{score >= 70?}
+    F -- Yes --> G[grade = C]
+    F -- No --> H{score >= 60?}
+    H -- Yes --> I[grade = D]
+    H -- No --> J[grade = F]
+```
+
+Each diamond is one `elif` check. Python walks down the chain and stops at the first `True` branch — that's why **order matters** (see Mastery Check Question 2).
+
 ### Multiple Conditions
 
 ```python

--- a/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_10_Loops/README.md
+++ b/content/lessons/Phase_01_Algorithmic_Thinking_Python_Foundations/Day_10_Loops/README.md
@@ -187,6 +187,23 @@ for i in range(5):
     print(i)  # 0, 1, 3, 4
 ```
 
+```mermaid
+flowchart TD
+    A[i = 0] --> B{i < 5?}
+    B -- No --> Z[Loop ends]
+    B -- Yes --> C{i == 2?}
+    C -- Yes --> D[continue: skip rest of body]
+    D --> H[i += 1]
+    C -- No --> E{i == 4?}
+    E -- Yes --> F[break: exit loop now]
+    F --> Z
+    E -- No --> G[print i]
+    G --> H
+    H --> B
+```
+
+`continue` jumps straight back to the loop condition; `break` exits the loop entirely, skipping any remaining iterations.
+
 ### Else Clause on Loops
 
 ```python

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_13_Higher_Order_Functions/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_13_Higher_Order_Functions/README.md
@@ -146,6 +146,20 @@ total_plus_10 = reduce(lambda acc, x: acc + x, numbers, 10)
 # 25
 ```
 
+### Chaining Them Into a Pipeline
+
+`map`, `filter`, and `reduce` compose into a data pipeline, where each stage transforms the output of the one before it:
+
+```mermaid
+flowchart LR
+    A[Raw sales records] --> B["filter(): keep amount >= 4000"]
+    B --> C["map(): attach 10% bonus"]
+    C --> D["reduce(): sum all bonuses"]
+    D --> E[Total bonus pool]
+```
+
+This is exactly the shape of Exercise 1 below — filter the rows you care about, transform each one, then collapse to a single number.
+
 ### Lambda Functions
 
 Anonymous, inline functions:

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_18_Classes_and_Objects/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_18_Classes_and_Objects/README.md
@@ -201,6 +201,24 @@ for animal in animals:
     print(animal.speak())
 ```
 
+```mermaid
+classDiagram
+    class Animal {
+        +String name
+        +speak()
+    }
+    class Dog {
+        +speak()
+    }
+    class Cat {
+        +speak()
+    }
+    Animal <|-- Dog
+    Animal <|-- Cat
+```
+
+`Dog` and `Cat` both inherit from `Animal` and override `speak()` — the same method call produces different behavior depending on the instance (polymorphism).
+
 ### Dunder (Magic) Methods
 
 ```python
@@ -461,6 +479,26 @@ order.add_item("Mouse", 2, 29)
 print(order.process())
 print(f"Items: {len(order.items)}, Total: ${order.total:.2f}")
 ```
+
+```mermaid
+classDiagram
+    class Order {
+        +String customer
+        +String status
+        +add_item()
+        +total()
+        +process()
+    }
+    class OrderItem {
+        +String product_name
+        +int quantity
+        +float unit_price
+        +subtotal()
+    }
+    Order "1" *-- "many" OrderItem : items
+```
+
+An `Order` *owns* its `OrderItem`s (composition) — they can't meaningfully exist without the order they belong to, which is why `Order.add_item()` is the only way to create one.
 
 **Expected Output:**
 

--- a/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_23_Pandas/README.md
+++ b/content/lessons/Phase_02_Functions_Modularity_Data_Wrangling/Day_23_Pandas/README.md
@@ -35,6 +35,15 @@ by_region.to_csv("summary.csv")        # Save results
 
 A DataFrame is like a SQL table or an Excel sheet in memory: rows have numeric indices, columns have named headers, and you can query, join, and transform data using Python instead of clicking around a spreadsheet. The key difference is that your entire analysis is a script you can re-run on next month's data in seconds.
 
+```mermaid
+flowchart LR
+    A["Load: pd.read_csv()"] --> B["Filter: df[condition]"]
+    B --> C["Aggregate: groupby().sum()"]
+    C --> D["Save: df.to_csv()"]
+```
+
+This load → filter → aggregate → save chain is the backbone of nearly every Pandas script you'll write — the sections below cover each stage in detail.
+
 ---
 
 ## The Technical Deep Dive

--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_25_Data_Cleaning/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_25_Data_Cleaning/README.md
@@ -55,6 +55,24 @@ This is the reality of business data. It's messy, inconsistent, and riddled with
 
 ## The Technical Deep Dive
 
+```mermaid
+flowchart TD
+    A[Detect missing values: isnull().sum()] --> B{Any missing?}
+    B -- No --> Z[Continue to type conversion / dedup]
+    B -- Yes --> C{Choose a strategy}
+    C --> D[Drop rows: dropna]
+    C --> E[Fill with mean/median/mode]
+    C --> F[Forward/backward fill]
+    C --> G[Flag as Unknown]
+    D --> H[Validate: assert no unexpected nulls remain]
+    E --> H
+    F --> H
+    G --> H
+    H --> Z
+```
+
+Every cleaning pipeline below follows this same shape: detect, decide on a strategy per column, apply it, then validate before moving on.
+
 ### Handling Missing Data
 
 Missing data is inevitable. The key is choosing the right strategy.

--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_31_Databases/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_31_Databases/README.md
@@ -168,6 +168,41 @@ FROM employees e
 JOIN departments d ON e.department_id = d.id;
 ```
 
+### Entity Relationships
+
+The tables across this lesson's examples relate to each other like this:
+
+```mermaid
+erDiagram
+    DEPARTMENTS ||--o{ EMPLOYEES : employs
+    PRODUCTS ||--o{ SALES : "sold in"
+
+    DEPARTMENTS {
+        int id
+        string department_name
+    }
+    EMPLOYEES {
+        int id
+        string name
+        string department
+        float salary
+        string hire_date
+    }
+    PRODUCTS {
+        int id
+        string name
+        float price
+    }
+    SALES {
+        int id
+        int product_id
+        int quantity
+        string sale_date
+    }
+```
+
+A `DEPARTMENTS` row has many `EMPLOYEES` (one-to-many); a `PRODUCTS` row has many `SALES` line items. This is the relationship the `JOIN` query above walks across.
+
 ---
 
 ## Senior-Level Insights

--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_33_API/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_33_API/README.md
@@ -172,6 +172,24 @@ def safe_api_call(url, params=None):
 data = safe_api_call("https://api.github.com/users/octocat")
 ```
 
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API as API Server
+    Client->>API: GET /users/octocat (Authorization header)
+    API->>API: Validate auth token
+    alt Token valid
+        API->>API: Process request
+        API-->>Client: 200 OK + JSON body
+    else Token invalid/expired
+        API-->>Client: 401 Unauthorized
+    else Too many requests
+        API-->>Client: 429 Too Many Requests (Retry-After)
+    end
+```
+
+`safe_api_call()` above is the client-side half of this exchange — it has to handle all three branches the server might take.
+
 ---
 
 ## Senior-Level Insights

--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_34_Building_an_API/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_34_Building_an_API/README.md
@@ -75,6 +75,28 @@ def create_product(product: Product):
 
 **Navigate to `http://127.0.0.1:8000/docs` after starting the server** — you'll see a fully interactive API explorer with no extra setup.
 
+```mermaid
+sequenceDiagram
+    participant Client
+    participant FastAPI
+    participant Pydantic
+    participant Endpoint as create_product()
+
+    Client->>FastAPI: POST /products {"price": "not a number"}
+    FastAPI->>Pydantic: Parse & validate body against Product model
+    alt Validation fails
+        Pydantic-->>FastAPI: ValidationError
+        FastAPI-->>Client: 422 Unprocessable Entity
+    else Validation passes
+        Pydantic-->>FastAPI: Validated Product instance
+        FastAPI->>Endpoint: create_product(product)
+        Endpoint-->>FastAPI: return response dict
+        FastAPI-->>Client: 200 OK + JSON
+    end
+```
+
+Validation happens *before* your endpoint function ever runs — by the time `create_product()` executes, `product.price` is guaranteed to be a `float`.
+
 **`dict` vs Pydantic model in responses:**
 
 - Returning a `dict` works but bypasses Pydantic validation on output

--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_35_Flask_Web_Framework/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_35_Flask_Web_Framework/README.md
@@ -206,6 +206,19 @@ def dashboard(user):
 </form>
 ```
 
+```mermaid
+flowchart TD
+    A[GET /login] --> B[Flask routes to login view]
+    B --> C["render_template('login.html')"]
+    C --> D[User submits form: POST /login]
+    D --> E["request.form: read username/password"]
+    E --> F{Credentials valid?}
+    F -- Yes --> G["redirect to /dashboard/&lt;user&gt;"]
+    F -- No --> C
+```
+
+The same view function handles both `GET` (show the form) and `POST` (process the submission) — that's why `request.method` is checked at the top of `login()`.
+
 ### Dynamic Routes
 
 ```python


### PR DESCRIPTION
## Summary
- Adds Mermaid diagrams to the 10 Phase 1-3 lessons identified in `docs/mermaid-diagram-candidates.md`
- Each diagram is placed next to its most relevant existing code example, with a short sentence tying it back to the lesson content
- Diagram types used: `flowchart` (Day_09, Day_10, Day_13, Day_23, Day_25, Day_35), `classDiagram` (Day_18, x2), `erDiagram` (Day_31), `sequenceDiagram` (Day_33, Day_34)

## Notes
- Mermaid *rendering* isn't implemented in `src/components/MarkdownRenderer.tsx` yet (tracked as 🔲 in `docs/markdown-renderer-roadmap.md`); the fenced blocks render as plain code today and will pick up syntax/diagram rendering once that lands. Adding the content now is prep work independent of that feature.
- Could not run `scripts/validate-content.js` in this environment (missing `zod`/`node_modules`); manually verified all 10 files have balanced/even code-fence counts confirming well-formed Markdown.

## Test plan
- [ ] Run `npm run validate-content` once dependencies are installed, to confirm lesson schema validation passes
- [ ] Once Mermaid rendering ships, spot-check each of the 10 lessons in the rendered site

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CgfphxqJ5R8Hkm4XTdpbzv)_