### PR TITLE
fix: force LF line endings to fix Windows CI parse error

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` with `* text=auto eol=lf` to force LF line endings on checkout across all platforms.

## Root cause
The CI run at [run 28240749081 / job 83666717893](https://github.com/saint2706/Coding-For-MBA/actions/runs/28240749081/job/83666717893) (windows-latest unit-test job) logs:

```
Failed to parse file:///D:/a/Coding-For-MBA/Coding-For-MBA/scripts/analyze-bundle.js. Excluding it from coverage.
Error [RollupError]: Expected ident
  code: 'PARSE_ERROR',
  pos: 527
```

This job's overall conclusion was actually `success` (tests pass, coverage report still generates) — the error is non-fatal, but it's a real parsing bug worth fixing. The repo had no `.gitattributes`, so Windows runners checkout with Git's default `core.autocrlf=true`, converting `\n` → `\r\n` in tracked text files. Rollup's native parser (used by `@vitest/coverage-v8` to remap coverage for files not exercised by tests, like `scripts/analyze-bundle.js`) computes positions from the raw file bytes, so the extra `\r` bytes shift offsets and trip the parser. The same job on `ubuntu-latest` does not hit this — confirming it's a line-ending/platform issue, not a real syntax error in the source.

## Fix
Added `.gitattributes` forcing `eol=lf` for all text files, so checkouts are byte-identical across `windows-latest` and `ubuntu-latest` runners.

## Test plan
- [ ] Confirm the `unit-test (windows-latest, 22.x)` job no longer logs the `Failed to parse ... Excluding it from coverage` / `RollupError: Expected ident` warning after this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DQcmS8xhs5akSYaYn68Zvy)_