### PR TITLE
ci: suppress punycode deprecation warning in deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,10 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      # actions/deploy-pages bundles a require() of Node's deprecated builtin
+      # `punycode` module, which logs a DEP0040 warning on every run.
+      NODE_OPTIONS: --disable-warning=DEP0040
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary
- The linked run ([job 83669888964](https://github.com/saint2706/Coding-For-MBA/actions/runs/28241637630/job/83669888964)) shows `(node:1937) [DEP0040] DeprecationWarning: The punycode module is deprecated` coming from the `deploy` step.
- This is emitted by `actions/deploy-pages@v5` itself — it's bundled (via ncc) with code that `require()`s Node's deprecated builtin `punycode` module. It's a widely-reported upstream issue affecting several GitHub Actions (`setup-node`, `setup-python`, `deploy-pages`), and there's no newer release of the action that removes it.
- Since we can't fix the action's bundled dependency from this repo, suppress just that warning code via `NODE_OPTIONS: --disable-warning=DEP0040` on the `deploy` job in `.github/workflows/deploy.yml`.

## Test plan
- [ ] Merge and confirm the next "Deploy to GitHub Pages" run no longer logs the `DEP0040` warning in the `deploy` job, and deployment still succeeds.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DGtexhiEmH2QtgrmYv7yb1)_