### PR TITLE
Add 5 real-data case studies (11-15) and mark roadmap item done

### DIFF
--- a/content/case-studies/11_ecommerce_customer_segmentation/README.md
+++ b/content/case-studies/11_ecommerce_customer_segmentation/README.md
@@ -1,0 +1,259 @@
+# 🎁 Case Study 11: E-Commerce Customer Segmentation & CLV (Real Data)
+
+> **Phases covered**: Phase 2 (Data Wrangling) · Phase 4 (ML Fundamentals)
+> **Difficulty**: Intermediate
+> **Estimated time**: 6–8 hours
+
+---
+
+## 🎯 Case Overview
+
+This case study uses **real transaction data** from a UK-based online gift
+retailer — no synthetic generator this time. Over two years (Dec 2009 – Dec
+2011), the company logged roughly **1 million line items** across ~40,000
+invoices from customers in the UK and abroad.
+
+Leadership wants to move from "blast the same email to everyone" marketing to
+**segment-based targeting**: who are the VIP customers worth protecting, who
+is drifting away, and who is a one-time bargain shopper not worth chasing?
+Your job: turn raw invoice rows into an RFM segmentation and a customer
+lifetime value (CLV) estimate that marketing can act on.
+
+---
+
+## 📊 Data Source & Attribution
+
+| | |
+| --- | --- |
+| **Dataset** | Online Retail II |
+| **Provider** | UCI Machine Learning Repository |
+| **Author** | Dr Daqing Chen, School of Engineering, London South Bank University |
+| **URL** | https://archive.ics.uci.edu/dataset/502/online+retail+ii |
+| **License** | CC BY 4.0 (free to use, share, and adapt with attribution) |
+| **Citation** | Chen, D. (2019). *Online Retail II* [Dataset]. UCI Machine Learning Repository. https://doi.org/10.24432/C5CG6D |
+| **Size** | ~1,067,371 rows, Dec 2009 – Dec 2011, two sheets ("Year 2009-2010", "Year 2010-2011") |
+
+This is real, messy, production data: it contains cancelled orders (invoice
+numbers prefixed `C`), missing `Customer ID` values, negative quantities, and
+non-product stock codes (postage, bank charges, adjustments). Cleaning it is
+part of the exercise, not something a generator has done for you.
+
+---
+
+## 📋 Business Context
+
+| Metric | Value |
+| --- | --- |
+| Invoices in dataset | ~40,000 |
+| Unique customers (with ID) | ~5,900 |
+| Countries represented | 40+ (mostly UK) |
+| Time span | 25 months |
+| Marketing budget per campaign | $50,000 |
+
+**Key question:** *Which customer segments should get a retention offer,
+which should get a win-back campaign, and which aren't worth the marketing
+spend?*
+
+---
+
+## 🗂️ Project Structure
+
+```
+11_ecommerce_customer_segmentation/
+├── README.md          ← this file (hand-holding guide)
+├── starter.py          ← scaffold with TODOs — follow step by step
+└── data_loader.py       ← downloads the real UCI dataset via `ucimlrepo`
+```
+
+---
+
+## 🛠️ Skills Applied
+
+| Phase | Topics |
+| ----- | ------ |
+| Phase 2 | Pandas data wrangling, real-world data cleaning, `datetime` handling |
+| Phase 4 | K-Means clustering, feature scaling, RFM analysis |
+| Phase 37B | Descriptive statistics, distribution skew in real financial data |
+
+---
+
+## 🤝 Hand-Holding Walkthrough
+
+> Follow these steps one at a time. Each step tells you *what* to do, *why*
+> it matters for the business, and *how* to code it.
+
+### Step 1 — Fetch the Real Dataset
+
+**What:** Download the actual Online Retail II dataset from UCI.
+
+**Why:** Unlike our other case studies, there is no generator here — you're
+working with the same raw export a real analyst would have pulled from the
+company's order system.
+
+**How:**
+
+```python
+# In data_loader.py
+pip install ucimlrepo
+python data_loader.py             # downloads and caches online_retail_ii.csv
+
+df = pd.read_csv("online_retail_ii.csv")
+print(df.shape)
+print(df.head())
+print(df["Invoice"].nunique(), "invoices |", df["Customer ID"].nunique(), "customers")
+```
+
+**✅ Checkpoint:** You should see columns `Invoice, StockCode, Description,
+Quantity, InvoiceDate, Price, Customer ID, Country` and roughly 1M rows
+across both years combined.
+
+---
+
+### Step 2 — Clean the Real-World Mess
+
+**What:** Remove cancellations, rows with no `Customer ID`, and non-positive
+quantities/prices.
+
+**Why:** Real data is dirty. Cancelled orders (invoices starting with `C`)
+would double-count revenue; rows without a `Customer ID` can't be attributed
+to a person for segmentation.
+
+**How:**
+
+```python
+df = df.dropna(subset=["Customer ID"])
+df = df[~df["Invoice"].astype(str).str.startswith("C")]
+df = df[(df["Quantity"] > 0) & (df["Price"] > 0)]
+df["InvoiceDate"] = pd.to_datetime(df["InvoiceDate"])
+df["revenue"] = df["Quantity"] * df["Price"]
+```
+
+**✅ Checkpoint:** Row count should drop by roughly 20–25% after cleaning.
+Total revenue should be a positive, plausible figure (tens of millions of
+pounds across the full period).
+
+---
+
+### Step 3 — RFM Feature Engineering
+
+**What:** For each customer, compute Recency (days since last purchase),
+Frequency (number of distinct invoices), and Monetary (total revenue).
+
+**Why:** RFM is the industry-standard segmentation lens for e-commerce and
+retail — it's simple, explainable to a non-technical marketing team, and
+correlates strongly with future value.
+
+**How:**
+
+```python
+snapshot_date = df["InvoiceDate"].max() + pd.Timedelta(days=1)
+
+rfm = df.groupby("Customer ID").agg(
+    recency=("InvoiceDate", lambda x: (snapshot_date - x.max()).days),
+    frequency=("Invoice", "nunique"),
+    monetary=("revenue", "sum"),
+)
+print(rfm.describe())
+```
+
+**✅ Checkpoint:** Recency should range 0–700+ days (spans the full dataset).
+Monetary should be right-skewed — a small number of customers driving a large
+share of revenue (check with `rfm["monetary"].quantile([0.5, 0.9, 0.99])`).
+
+---
+
+### Step 4 — K-Means Segmentation
+
+**What:** Scale the RFM features and cluster customers into 4–5 segments.
+
+**Why:** Raw RFM numbers aren't directly comparable (monetary is in pounds,
+recency is in days) — scaling puts them on equal footing before clustering.
+
+**How:**
+
+```python
+from sklearn.preprocessing import StandardScaler
+from sklearn.cluster import KMeans
+
+X = StandardScaler().fit_transform(rfm[["recency", "frequency", "monetary"]])
+
+inertias = []
+for k in range(2, 8):
+    km = KMeans(n_clusters=k, random_state=42, n_init=10).fit(X)
+    inertias.append(km.inertia_)
+# Plot inertias to find the elbow, then refit with the chosen k
+
+kmeans = KMeans(n_clusters=4, random_state=42, n_init=10)
+rfm["segment"] = kmeans.fit_predict(X)
+print(rfm.groupby("segment")[["recency", "frequency", "monetary"]].mean())
+```
+
+**✅ Checkpoint:** You should see one segment with low recency/high frequency/
+high monetary (your VIPs) and one with high recency/low frequency (at-risk
+or lapsed). Label each segment in plain English.
+
+---
+
+### Step 5 — Customer Lifetime Value & Targeting
+
+**What:** Estimate a simple historical CLV per segment and translate it into
+a targeting recommendation.
+
+**Why:** Segments alone don't tell marketing what to *do*. Attaching a dollar
+value to each segment justifies the spend on retention vs. win-back offers.
+
+**How:**
+
+```python
+rfm["avg_order_value"] = rfm["monetary"] / rfm["frequency"]
+segment_summary = rfm.groupby("segment").agg(
+    customers=("monetary", "count"),
+    avg_monetary=("monetary", "mean"),
+    avg_frequency=("frequency", "mean"),
+    avg_recency=("recency", "mean"),
+)
+segment_summary["pct_of_revenue"] = (
+    rfm.groupby("segment")["monetary"].sum() / rfm["monetary"].sum() * 100
+)
+print(segment_summary.sort_values("pct_of_revenue", ascending=False))
+```
+
+**✅ Checkpoint:** Your top-value segment should represent a disproportionate
+share of revenue relative to its customer count (classic 80/20 pattern) —
+this is your headline stat for the executive summary.
+
+---
+
+## 📊 Deliverables
+
+| # | Deliverable | Format |
+| - | --- | --- |
+| 1 | Cleaned, attributed dataset load pipeline | `data_loader.py` |
+| 2 | RFM table with segment labels | Jupyter / .py |
+| 3 | Segment profile chart (radar or bar) | PNG |
+| 4 | CLV-by-segment summary table | Markdown |
+| 5 | Executive summary with targeting recommendation | Markdown |
+
+---
+
+## 🏆 Stretch Goals
+
+- [ ] Add a probabilistic CLV model (BG/NBD + Gamma-Gamma via `lifetimes`)
+- [ ] Compare the two dataset years (2009-2010 vs. 2010-2011) for segment drift
+- [ ] Break segmentation out by `Country` to spot regional patterns
+- [ ] Build a Streamlit dashboard for marketing to explore segments interactively
+- [ ] Market-basket analysis (Apriori) on top segment's `Description` field
+
+---
+
+## 📚 Reference Lessons
+
+- Day 23–24D: Pandas, EDA, and the data cleaning playbook (Phase 2)
+- Day 44: Unsupervised learning — K-Means clustering (Phase 4)
+- Day 37B: Probability & statistics — distribution skew (Phase 4)
+
+---
+
+*This case study demonstrates working with real, unclean, attributed
+production data — the same skill gap between "tutorial data" and "my
+company's actual database export" that trips up most new analysts.*

--- a/content/case-studies/11_ecommerce_customer_segmentation/data_loader.py
+++ b/content/case-studies/11_ecommerce_customer_segmentation/data_loader.py
@@ -1,0 +1,39 @@
+"""
+Real-data loader for Case Study 11 — E-Commerce Customer Segmentation.
+
+Downloads the actual "Online Retail II" dataset from the UCI Machine
+Learning Repository and caches it locally as online_retail_ii.csv.
+
+Dataset:  Online Retail II
+Author:   Dr Daqing Chen, London South Bank University
+Source:   https://archive.ics.uci.edu/dataset/502/online+retail+ii
+License:  CC BY 4.0
+Citation: Chen, D. (2019). Online Retail II [Dataset].
+          UCI Machine Learning Repository. https://doi.org/10.24432/C5CG6D
+
+Usage:
+    pip install ucimlrepo
+    python data_loader.py
+"""
+
+import pandas as pd
+
+CACHE_FILE = "online_retail_ii.csv"
+
+
+def load_online_retail_ii() -> pd.DataFrame:
+    """Fetch the real UCI Online Retail II dataset (both sheets combined)."""
+    from ucimlrepo import fetch_ucirepo
+
+    dataset = fetch_ucirepo(id=502)
+    # ucimlrepo splits features/targets; this dataset has no target column,
+    # so everything of interest lives in .data.features
+    df = dataset.data.features
+    return df
+
+
+if __name__ == "__main__":
+    df = load_online_retail_ii()
+    df.to_csv(CACHE_FILE, index=False)
+    print(f"✅ Downloaded and cached {CACHE_FILE} — {len(df):,} rows")
+    print(df.head())

--- a/content/case-studies/11_ecommerce_customer_segmentation/starter.py
+++ b/content/case-studies/11_ecommerce_customer_segmentation/starter.py
@@ -1,0 +1,48 @@
+"""
+Case Study 11 — E-Commerce Customer Segmentation & CLV (Real Data)
+====================================================================
+Follow the step-by-step guide in README.md.
+
+Usage:
+    python data_loader.py      # first — downloads online_retail_ii.csv
+    python starter.py          # then — runs this analysis
+"""
+
+import pandas as pd
+import numpy as np
+from sklearn.preprocessing import StandardScaler
+from sklearn.cluster import KMeans
+
+# ---------------------------------------------------------------------------
+# Step 1 — Load the Real Dataset
+# ---------------------------------------------------------------------------
+# TODO: df = pd.read_csv("online_retail_ii.csv")
+# TODO: print(df.shape)
+
+# ---------------------------------------------------------------------------
+# Step 2 — Clean the Real-World Mess
+# ---------------------------------------------------------------------------
+# TODO: Drop rows with missing Customer ID
+# TODO: Remove cancelled invoices (Invoice starts with "C")
+# TODO: Keep only Quantity > 0 and Price > 0
+# TODO: Parse InvoiceDate, compute revenue = Quantity * Price
+
+# ---------------------------------------------------------------------------
+# Step 3 — RFM Feature Engineering
+# ---------------------------------------------------------------------------
+# TODO: Compute recency, frequency, monetary per Customer ID
+
+# ---------------------------------------------------------------------------
+# Step 4 — K-Means Segmentation
+# ---------------------------------------------------------------------------
+# TODO: Scale RFM features with StandardScaler
+# TODO: Fit KMeans for k=2..7, plot inertia to find the elbow
+# TODO: Refit with chosen k, assign segment labels
+
+# ---------------------------------------------------------------------------
+# Step 5 — CLV & Targeting Recommendation
+# ---------------------------------------------------------------------------
+# TODO: Compute avg_order_value and pct_of_revenue per segment
+# TODO: Rank segments, write the targeting recommendation
+
+print("✅ Starter script loaded — follow the TODOs in README.md step by step.")

--- a/content/case-studies/12_bank_telemarketing_conversion/README.md
+++ b/content/case-studies/12_bank_telemarketing_conversion/README.md
@@ -1,0 +1,258 @@
+# ☎️ Case Study 12: Bank Telemarketing Conversion (Real Data)
+
+> **Phases covered**: Phase 4 (ML Fundamentals) · Phase 5 (Advanced ML)
+> **Difficulty**: Intermediate
+> **Estimated time**: 6–8 hours
+
+---
+
+## 🎯 Case Overview
+
+A Portuguese retail bank ran direct-marketing phone campaigns between 2008
+and 2010, calling clients to sell **term deposit** products. Call centre
+capacity is limited — agents can make roughly 2,000 calls a week — so the
+bank needs to know *who to call first*.
+
+This case study uses the bank's **actual, published campaign records**
+(anonymised client attributes, no synthetic generator). Your job: build a
+model that ranks clients by conversion probability, then translate that
+ranking into a call-list policy the call centre can actually use.
+
+---
+
+## 📊 Data Source & Attribution
+
+| | |
+| --- | --- |
+| **Dataset** | Bank Marketing |
+| **Provider** | UCI Machine Learning Repository |
+| **Authors** | Sérgio Moro, Paulo Rita, Paulo Cortez |
+| **URL** | https://archive.ics.uci.edu/dataset/222/bank+marketing |
+| **License** | CC BY 4.0 |
+| **Citation** | Moro, S., Rita, P., & Cortez, P. (2014). *Bank Marketing* [Dataset]. UCI Machine Learning Repository. https://doi.org/10.24432/C5K306 |
+| **Academic reference** | Moro, S., Cortez, P., & Rita, P. (2014). "A Data-Driven Approach to Predict the Success of Bank Telemarketing." *Decision Support Systems*, 62, 22-31. |
+| **Size** | 41,188 rows (`bank-additional-full` variant), 20 client/campaign/economic features |
+
+Real campaign data means real quirks: many categorical fields contain an
+explicit `"unknown"` category (the bank genuinely didn't have that data), and
+the target is heavily imbalanced — only ~11% of calls resulted in a "yes".
+
+---
+
+## 📋 Business Context
+
+| Metric | Value |
+| --- | --- |
+| Total calls in dataset | 41,188 |
+| Historical conversion rate | ~11.3% |
+| Cost per call (agent time) | $6 |
+| Average term deposit value to bank | $180 (first-year margin) |
+| Weekly call centre capacity | ~2,000 calls |
+
+**Key question:** *Given limited call capacity, which clients should the
+call centre prioritise to maximise conversions per dollar spent on calling?*
+
+---
+
+## 🗂️ Project Structure
+
+```
+12_bank_telemarketing_conversion/
+├── README.md          ← this file (hand-holding guide)
+├── starter.py          ← scaffold with TODOs — follow step by step
+└── data_loader.py       ← downloads the real UCI dataset via `ucimlrepo`
+```
+
+---
+
+## 🛠️ Skills Applied
+
+| Phase | Topics |
+| ----- | ------ |
+| Phase 4 | Logistic regression, classification metrics, train/test splitting |
+| Phase 5 | Gradient boosting / ensemble methods, class imbalance handling |
+| Phase 37B | Probability, expected value, threshold tuning |
+
+---
+
+## 🤝 Hand-Holding Walkthrough
+
+### Step 1 — Fetch the Real Dataset
+
+**What:** Download the real UCI Bank Marketing dataset.
+
+**Why:** This is the exact dataset behind a widely-cited banking analytics
+paper — working with it means your results are directly comparable to
+published research, not a one-off synthetic sample.
+
+**How:**
+
+```python
+# pip install ucimlrepo
+python data_loader.py            # downloads and caches bank_marketing.csv
+
+df = pd.read_csv("bank_marketing.csv")
+print(df.shape)
+print(df["y"].value_counts(normalize=True))
+```
+
+**✅ Checkpoint:** ~41,188 rows, 20 feature columns, target `y` roughly
+88.7% "no" / 11.3% "yes".
+
+---
+
+### Step 2 — Explore the Real Messiness
+
+**What:** Check for `"unknown"` categories, the `pdays` sentinel value
+(`999` means "never contacted before"), and the economic context columns
+(`emp.var.rate`, `euribor3m`, etc.).
+
+**Why:** Unlike synthetic data, real survey/CRM fields have missing-as-a-
+category values and encoded sentinels you have to know to interpret
+correctly — treating `pdays=999` as a literal number of days would badly
+distort any model.
+
+**How:**
+
+```python
+for col in df.select_dtypes(include="object").columns:
+    print(col, df[col].unique()[:6])
+
+df["was_previously_contacted"] = (df["pdays"] != 999).astype(int)
+```
+
+**✅ Checkpoint:** Several columns (`job`, `education`, `default`, `housing`,
+`loan`) should contain `"unknown"` — decide whether to impute, drop, or keep
+as its own category (keeping it is usually best here — non-response can
+itself be predictive).
+
+---
+
+### Step 3 — Encode & Split
+
+**What:** One-hot encode categoricals, then split into train/test sets
+*stratified* on the target.
+
+**Why:** With only ~11% positive class, a random (non-stratified) split can
+easily leave your test set with a skewed conversion rate, making metrics
+unreliable.
+
+**How:**
+
+```python
+from sklearn.model_selection import train_test_split
+
+X = pd.get_dummies(df.drop(columns=["y"]), drop_first=True)
+y = (df["y"] == "yes").astype(int)
+
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.2, stratify=y, random_state=42
+)
+```
+
+**✅ Checkpoint:** Conversion rate in `y_train` and `y_test` should both be
+within ~0.5 percentage points of the full dataset's 11.3%.
+
+---
+
+### Step 4 — Model with Class Imbalance in Mind
+
+**What:** Train a baseline logistic regression and a gradient boosting
+model, both with class-imbalance handling.
+
+**Why:** A model that just predicts "no" for everyone gets ~89% accuracy and
+is completely useless to the business — accuracy is the wrong metric here.
+
+**How:**
+
+```python
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import GradientBoostingClassifier
+from sklearn.metrics import classification_report, roc_auc_score
+
+logreg = LogisticRegression(max_iter=1000, class_weight="balanced")
+logreg.fit(X_train, y_train)
+
+gbc = GradientBoostingClassifier(random_state=42)
+gbc.fit(X_train, y_train)
+
+for name, model in [("LogReg", logreg), ("GBC", gbc)]:
+    proba = model.predict_proba(X_test)[:, 1]
+    print(name, "ROC-AUC:", roc_auc_score(y_test, proba))
+```
+
+**✅ Checkpoint:** Both models should score well above 0.5 ROC-AUC (a good
+model on this dataset typically lands around 0.75–0.80). Print a full
+`classification_report` and note precision/recall for the "yes" class
+specifically — that's what matters to the call centre.
+
+---
+
+### Step 5 — Turn Probabilities into a Call Policy
+
+**What:** Rank test-set clients by predicted conversion probability and
+compute the expected profit of calling the top N%.
+
+**Why:** The call centre doesn't need a probability — it needs a ranked
+list and a cut-off. This step converts model output into an operational
+decision.
+
+**How:**
+
+```python
+CALL_COST = 6
+DEPOSIT_VALUE = 180
+
+results = X_test.copy()
+results["actual"] = y_test.values
+results["predicted_proba"] = gbc.predict_proba(X_test)[:, 1]
+results = results.sort_values("predicted_proba", ascending=False)
+
+for pct in [0.1, 0.2, 0.3, 0.5, 1.0]:
+    n_calls = int(len(results) * pct)
+    subset = results.head(n_calls)
+    conversions = subset["actual"].sum()
+    profit = conversions * DEPOSIT_VALUE - n_calls * CALL_COST
+    print(f"Top {pct:.0%} ({n_calls} calls): {conversions} conversions, "
+          f"profit ${profit:,.0f}")
+```
+
+**✅ Checkpoint:** Calling only the top 20–30% by predicted probability
+should capture a disproportionate share of conversions relative to random
+calling — this is your headline "lift" chart for the executive summary.
+
+---
+
+## 📊 Deliverables
+
+| # | Deliverable | Format |
+| - | --- | --- |
+| 1 | Cleaned dataset with imbalance-aware split | `data_loader.py` |
+| 2 | Model comparison (LogReg vs. GBC) with ROC-AUC & PR curves | Jupyter / .py |
+| 3 | Lift chart / gains table by decile | PNG + table |
+| 4 | Recommended call-list threshold with expected profit | Markdown |
+| 5 | Executive summary for the call centre operations lead | Markdown |
+
+---
+
+## 🏆 Stretch Goals
+
+- [ ] Add SHAP values to explain which features drive conversion
+- [ ] Try SMOTE oversampling and compare to `class_weight="balanced"`
+- [ ] Segment by `poutcome` (outcome of previous campaign) — repeat contacts behave very differently
+- [ ] Build a simple Streamlit tool where an agent enters client attributes and gets a call/no-call recommendation
+- [ ] Re-run the analysis using only pre-call features (drop `duration`, which leaks the call outcome) and compare degradation
+
+---
+
+## 📚 Reference Lessons
+
+- Day 42–43: Classification (Phase 4)
+- Day 52: Ensemble methods — gradient boosting (Phase 5)
+- Day 37B: Probability, expected value, and decision thresholds (Phase 4)
+
+---
+
+*This case study is grounded in the same real dataset behind a published,
+peer-reviewed banking analytics paper — a good exercise in reproducing and
+extending real research rather than fitting a toy problem.*

--- a/content/case-studies/12_bank_telemarketing_conversion/data_loader.py
+++ b/content/case-studies/12_bank_telemarketing_conversion/data_loader.py
@@ -1,0 +1,38 @@
+"""
+Real-data loader for Case Study 12 — Bank Telemarketing Conversion.
+
+Downloads the actual "Bank Marketing" dataset from the UCI Machine
+Learning Repository and caches it locally as bank_marketing.csv.
+
+Dataset:  Bank Marketing
+Authors:  Sergio Moro, Paulo Rita, Paulo Cortez
+Source:   https://archive.ics.uci.edu/dataset/222/bank+marketing
+License:  CC BY 4.0
+Citation: Moro, S., Rita, P., & Cortez, P. (2014). Bank Marketing [Dataset].
+          UCI Machine Learning Repository. https://doi.org/10.24432/C5K306
+
+Usage:
+    pip install ucimlrepo
+    python data_loader.py
+"""
+
+import pandas as pd
+
+CACHE_FILE = "bank_marketing.csv"
+
+
+def load_bank_marketing() -> pd.DataFrame:
+    """Fetch the real UCI Bank Marketing dataset (features + target)."""
+    from ucimlrepo import fetch_ucirepo
+
+    dataset = fetch_ucirepo(id=222)
+    df = dataset.data.features.copy()
+    df["y"] = dataset.data.targets["y"]
+    return df
+
+
+if __name__ == "__main__":
+    df = load_bank_marketing()
+    df.to_csv(CACHE_FILE, index=False)
+    print(f"✅ Downloaded and cached {CACHE_FILE} — {len(df):,} rows")
+    print(df["y"].value_counts(normalize=True))

--- a/content/case-studies/12_bank_telemarketing_conversion/starter.py
+++ b/content/case-studies/12_bank_telemarketing_conversion/starter.py
@@ -1,0 +1,48 @@
+"""
+Case Study 12 — Bank Telemarketing Conversion (Real Data)
+===========================================================
+Follow the step-by-step guide in README.md.
+
+Usage:
+    python data_loader.py      # first — downloads bank_marketing.csv
+    python starter.py          # then — runs this analysis
+"""
+
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import GradientBoostingClassifier
+from sklearn.metrics import classification_report, roc_auc_score
+
+# ---------------------------------------------------------------------------
+# Step 1 — Load the Real Dataset
+# ---------------------------------------------------------------------------
+# TODO: df = pd.read_csv("bank_marketing.csv")
+# TODO: print(df["y"].value_counts(normalize=True))
+
+# ---------------------------------------------------------------------------
+# Step 2 — Explore the Real Messiness
+# ---------------------------------------------------------------------------
+# TODO: Inspect "unknown" categories in job, education, default, housing, loan
+# TODO: Create was_previously_contacted from pdays == 999
+
+# ---------------------------------------------------------------------------
+# Step 3 — Encode & Split
+# ---------------------------------------------------------------------------
+# TODO: One-hot encode categoricals with pd.get_dummies
+# TODO: Stratified train_test_split on y
+
+# ---------------------------------------------------------------------------
+# Step 4 — Model with Class Imbalance in Mind
+# ---------------------------------------------------------------------------
+# TODO: Fit LogisticRegression(class_weight="balanced") baseline
+# TODO: Fit GradientBoostingClassifier
+# TODO: Compare ROC-AUC and classification_report for both
+
+# ---------------------------------------------------------------------------
+# Step 5 — Turn Probabilities into a Call Policy
+# ---------------------------------------------------------------------------
+# TODO: Rank test set by predicted_proba
+# TODO: Compute expected profit for calling top 10/20/30/50/100%
+
+print("✅ Starter script loaded — follow the TODOs in README.md step by step.")

--- a/content/case-studies/13_taxi_demand_forecasting/README.md
+++ b/content/case-studies/13_taxi_demand_forecasting/README.md
@@ -1,0 +1,264 @@
+# 🚕 Case Study 13: Taxi Fleet Demand Forecasting (Real Data)
+
+> **Phases covered**: Phase 2 (Data Wrangling) · Phase 5 (Advanced ML)
+> **Difficulty**: Intermediate → Advanced
+> **Estimated time**: 8–10 hours
+
+---
+
+## 🎯 Case Overview
+
+You're the analytics lead for a taxi dispatch operation using **New York
+City's own official trip record data** — millions of real, GPS-timestamped
+rides published monthly by the city. No synthetic generator: this is the
+actual government open dataset that ride-hail researchers and NYC's own TLC
+regulators use.
+
+The dispatch team currently pre-positions drivers based on gut feel. They
+want an hourly demand forecast by pickup zone so they can reposition the
+fleet ahead of demand spikes and set a data-driven surge multiplier instead
+of an arbitrary one.
+
+---
+
+## 📊 Data Source & Attribution
+
+| | |
+| --- | --- |
+| **Dataset** | TLC Trip Record Data (Yellow Taxi) |
+| **Provider** | NYC Taxi & Limousine Commission (a NYC government agency) |
+| **URL** | https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page |
+| **Direct file pattern** | `https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_YYYY-MM.parquet` |
+| **Zone lookup table** | `https://d37ci6vzurychx.cloudfront.net/misc/taxi_zone_lookup.csv` |
+| **License** | Public domain — published by NYC Open Data as open government data |
+| **Size** | ~3 million trips per month (yellow cabs alone) |
+
+We'll work with **one month** of data to keep the exercise tractable; the
+pipeline generalises to any month TLC has published.
+
+---
+
+## 📋 Business Context
+
+| Metric | Value |
+| --- | --- |
+| Fleet size | 400 vehicles |
+| Avg. fare per trip | $18 |
+| Cost of an idle driver-hour | $25 |
+| Cost of an unmet-demand event (rider abandons) | $12 in lost goodwill/fare |
+| Pickup zones tracked | 263 (TLC taxi zones) |
+
+**Key question:** *How many rides should we expect in each zone, each hour,
+for tomorrow — and where should surge pricing kick in?*
+
+---
+
+## 🗂️ Project Structure
+
+```
+13_taxi_demand_forecasting/
+├── README.md          ← this file (hand-holding guide)
+├── starter.py          ← scaffold with TODOs — follow step by step
+└── data_loader.py       ← downloads one month of real TLC trip data
+```
+
+---
+
+## 🛠️ Skills Applied
+
+| Phase | Topics |
+| ----- | ------ |
+| Phase 2 | Pandas datetime handling, groupby aggregation at scale |
+| Phase 5 | Time-series forecasting, lag/rolling features, gradient boosting regression |
+| Phase 4 | Regression evaluation (MAE, MAPE) |
+
+---
+
+## 🤝 Hand-Holding Walkthrough
+
+### Step 1 — Download Real Trip Data
+
+**What:** Pull one month of real yellow taxi trips directly from the TLC's
+public CDN, plus the zone lookup table.
+
+**Why:** This is the actual dataset regulators and academic researchers use
+to study NYC mobility — working with it end-to-end (including the file size
+and column quirks) is a realistic "big-ish data" exercise.
+
+**How:**
+
+```python
+python data_loader.py             # downloads yellow_tripdata_2024-01.parquet
+                                   # + taxi_zone_lookup.csv
+
+import pandas as pd
+trips = pd.read_parquet("yellow_tripdata_2024-01.parquet")
+zones = pd.read_csv("taxi_zone_lookup.csv")
+print(trips.shape)
+print(trips.columns.tolist())
+```
+
+**✅ Checkpoint:** ~2.5–3 million rows, columns including
+`tpep_pickup_datetime`, `PULocationID`, `trip_distance`, `fare_amount`.
+
+---
+
+### Step 2 — Clean & Aggregate to Hourly Demand
+
+**What:** Filter obviously bad rows (negative fares, zero-distance trips,
+trips outside the target month), then aggregate to **pickups per zone per
+hour**.
+
+**Why:** Real GPS/meter data has recording errors — a handful of trips will
+have negative fares or 0-mile "trips" that are actually meter glitches. The
+forecasting model needs a clean, regular hourly time series, not raw
+trip-level rows.
+
+**How:**
+
+```python
+trips = trips[(trips["fare_amount"] > 0) & (trips["trip_distance"] > 0)]
+trips["pickup_hour"] = trips["tpep_pickup_datetime"].dt.floor("h")
+
+hourly_demand = (
+    trips.groupby(["PULocationID", "pickup_hour"])
+    .size()
+    .reset_index(name="pickups")
+)
+print(hourly_demand.shape)
+```
+
+**✅ Checkpoint:** Roughly 263 zones × ~720 hours in a month = up to ~190,000
+zone-hour rows (fewer in practice — quiet zones have gaps with zero trips).
+
+---
+
+### Step 3 — Time-Series Feature Engineering
+
+**What:** For a handful of the busiest zones, build lag and rolling-average
+features plus hour-of-day/day-of-week indicators.
+
+**Why:** Taxi demand is heavily driven by real, recurring patterns —
+weekday rush hours, weekend nightlife, airport zones spiking around flight
+banks. Lag features let a regression model capture that recurring
+structure without hand-coding every rule.
+
+**How:**
+
+```python
+top_zone = hourly_demand.groupby("PULocationID")["pickups"].sum().idxmax()
+zone_ts = (
+    hourly_demand[hourly_demand["PULocationID"] == top_zone]
+    .set_index("pickup_hour")
+    .asfreq("h", fill_value=0)
+)
+
+zone_ts["hour_of_day"] = zone_ts.index.hour
+zone_ts["day_of_week"] = zone_ts.index.dayofweek
+zone_ts["lag_1h"] = zone_ts["pickups"].shift(1)
+zone_ts["lag_24h"] = zone_ts["pickups"].shift(24)
+zone_ts["rolling_24h_avg"] = zone_ts["pickups"].rolling(24).mean()
+zone_ts = zone_ts.dropna()
+```
+
+**✅ Checkpoint:** Plot `pickups` over a week — you should clearly see daily
+peaks (e.g. evening rush) and a weekday/weekend shape difference.
+
+---
+
+### Step 4 — Forecast & Evaluate
+
+**What:** Train a gradient boosting regressor on the engineered features,
+using a time-based (not random) train/test split, and evaluate with MAPE.
+
+**Why:** Shuffling time-series data before splitting leaks future
+information into training — a time-based split (train on earlier weeks,
+test on the last week) mirrors how the model would actually be used in
+production.
+
+**How:**
+
+```python
+from sklearn.ensemble import GradientBoostingRegressor
+from sklearn.metrics import mean_absolute_percentage_error
+
+features = ["hour_of_day", "day_of_week", "lag_1h", "lag_24h", "rolling_24h_avg"]
+split_point = zone_ts.index.max() - pd.Timedelta(days=7)
+
+train = zone_ts[zone_ts.index <= split_point]
+test = zone_ts[zone_ts.index > split_point]
+
+model = GradientBoostingRegressor(random_state=42)
+model.fit(train[features], train["pickups"])
+preds = model.predict(test[features])
+
+mape = mean_absolute_percentage_error(test["pickups"], preds)
+print(f"MAPE: {mape:.1%}")
+```
+
+**✅ Checkpoint:** A reasonable model on the busiest zone should land under
+~20–25% MAPE. Plot actual vs. predicted for the test week.
+
+---
+
+### Step 5 — Translate Forecasts into Surge Pricing
+
+**What:** Compare forecasted demand to fleet supply capacity per zone-hour
+and recommend a surge multiplier where demand exceeds supply.
+
+**Why:** A forecast is only useful if it drives a decision. This step
+closes the loop from "predicted 340 pickups" to "set a 1.4x multiplier in
+zone 132 from 5–7pm."
+
+**How:**
+
+```python
+FLEET_CAPACITY_PER_HOUR = 60  # illustrative dispatch capacity per zone-hour
+
+test = test.copy()
+test["predicted_pickups"] = preds
+test["demand_supply_ratio"] = test["predicted_pickups"] / FLEET_CAPACITY_PER_HOUR
+test["surge_multiplier"] = test["demand_supply_ratio"].clip(lower=1.0, upper=2.5).round(2)
+
+print(test[["predicted_pickups", "surge_multiplier"]].describe())
+```
+
+**✅ Checkpoint:** Surge multipliers should stay at 1.0 during quiet hours
+and rise above 1.3–1.5 during identified peak windows — sanity check this
+against the hour-of-day pattern from Step 3.
+
+---
+
+## 📊 Deliverables
+
+| # | Deliverable | Format |
+| - | --- | --- |
+| 1 | Cleaned hourly zone-level demand table | .py / parquet |
+| 2 | Forecast model with time-based validation & MAPE | Jupyter / .py |
+| 3 | Actual vs. predicted demand chart | PNG |
+| 4 | Surge-multiplier recommendation table | Markdown |
+| 5 | Executive summary for fleet operations | Markdown |
+
+---
+
+## 🏆 Stretch Goals
+
+- [ ] Extend the model to all top-20 zones instead of just one
+- [ ] Add weather data (a real external feature) and measure lift
+- [ ] Compare gradient boosting against a classical SARIMA baseline
+- [ ] Join `taxi_zone_lookup.csv` borough info to compare borough-level patterns
+- [ ] Build a simple map visualization (folium/plotly) of predicted demand by zone
+
+---
+
+## 📚 Reference Lessons
+
+- Day 23–24D: Pandas & EDA at scale (Phase 2)
+- Day 56: Time series and forecasting (Phase 5)
+- Day 45: Feature engineering and evaluation (Phase 4)
+
+---
+
+*This case study works with the same public dataset NYC's own regulators
+and academic transportation researchers use — a good introduction to
+"big enough to be annoying" real government open data.*

--- a/content/case-studies/13_taxi_demand_forecasting/data_loader.py
+++ b/content/case-studies/13_taxi_demand_forecasting/data_loader.py
@@ -1,0 +1,47 @@
+"""
+Real-data loader for Case Study 13 — Taxi Fleet Demand Forecasting.
+
+Downloads one month of real NYC Yellow Taxi trip records plus the taxi
+zone lookup table, directly from the TLC's public data CDN.
+
+Dataset:  TLC Trip Record Data (Yellow Taxi)
+Provider: NYC Taxi & Limousine Commission (NYC government agency)
+Source:   https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page
+License:  Public domain (NYC Open Data / open government data)
+
+Usage:
+    python data_loader.py [YYYY-MM]
+
+    If no month is given, defaults to 2024-01. Any month TLC has
+    published (see the "About" page above) can be substituted.
+"""
+
+import sys
+
+import pandas as pd
+
+BASE_URL = "https://d37ci6vzurychx.cloudfront.net/trip-data"
+ZONE_LOOKUP_URL = "https://d37ci6vzurychx.cloudfront.net/misc/taxi_zone_lookup.csv"
+
+
+def load_month(year_month: str = "2024-01") -> pd.DataFrame:
+    """Download one month of real yellow taxi trip records as a DataFrame."""
+    url = f"{BASE_URL}/yellow_tripdata_{year_month}.parquet"
+    return pd.read_parquet(url)
+
+
+def load_zone_lookup() -> pd.DataFrame:
+    """Download the real TLC taxi zone lookup table (zone ID -> borough/zone name)."""
+    return pd.read_csv(ZONE_LOOKUP_URL)
+
+
+if __name__ == "__main__":
+    year_month = sys.argv[1] if len(sys.argv) > 1 else "2024-01"
+
+    trips = load_month(year_month)
+    trips.to_parquet(f"yellow_tripdata_{year_month}.parquet", index=False)
+    print(f"✅ Downloaded yellow_tripdata_{year_month}.parquet — {len(trips):,} trips")
+
+    zones = load_zone_lookup()
+    zones.to_csv("taxi_zone_lookup.csv", index=False)
+    print(f"✅ Downloaded taxi_zone_lookup.csv — {len(zones)} zones")

--- a/content/case-studies/13_taxi_demand_forecasting/starter.py
+++ b/content/case-studies/13_taxi_demand_forecasting/starter.py
@@ -1,0 +1,46 @@
+"""
+Case Study 13 — Taxi Fleet Demand Forecasting (Real Data)
+============================================================
+Follow the step-by-step guide in README.md.
+
+Usage:
+    python data_loader.py              # first — downloads real TLC trip data
+    python starter.py                  # then — runs this analysis
+"""
+
+import pandas as pd
+from sklearn.ensemble import GradientBoostingRegressor
+from sklearn.metrics import mean_absolute_percentage_error
+
+# ---------------------------------------------------------------------------
+# Step 1 — Load the Real Dataset
+# ---------------------------------------------------------------------------
+# TODO: trips = pd.read_parquet("yellow_tripdata_2024-01.parquet")
+# TODO: zones = pd.read_csv("taxi_zone_lookup.csv")
+
+# ---------------------------------------------------------------------------
+# Step 2 — Clean & Aggregate to Hourly Demand
+# ---------------------------------------------------------------------------
+# TODO: Filter fare_amount > 0 and trip_distance > 0
+# TODO: Floor tpep_pickup_datetime to the hour
+# TODO: Groupby PULocationID + pickup_hour, count -> pickups
+
+# ---------------------------------------------------------------------------
+# Step 3 — Time-Series Feature Engineering
+# ---------------------------------------------------------------------------
+# TODO: Pick the busiest zone, reindex to a continuous hourly frequency
+# TODO: Add hour_of_day, day_of_week, lag_1h, lag_24h, rolling_24h_avg
+
+# ---------------------------------------------------------------------------
+# Step 4 — Forecast & Evaluate
+# ---------------------------------------------------------------------------
+# TODO: Time-based train/test split (last 7 days = test)
+# TODO: Fit GradientBoostingRegressor, compute MAPE
+
+# ---------------------------------------------------------------------------
+# Step 5 — Translate Forecasts into Surge Pricing
+# ---------------------------------------------------------------------------
+# TODO: Compare predicted_pickups to FLEET_CAPACITY_PER_HOUR
+# TODO: Derive a clipped surge_multiplier per zone-hour
+
+print("✅ Starter script loaded — follow the TODOs in README.md step by step.")

--- a/content/case-studies/14_creditcard_fraud_real_data/README.md
+++ b/content/case-studies/14_creditcard_fraud_real_data/README.md
@@ -1,0 +1,279 @@
+# 💳 Case Study 14: Credit Card Fraud Detection (Real Transactions)
+
+> **Phases covered**: Phase 4 (ML Fundamentals) · Phase 5 (Advanced ML)
+> **Difficulty**: Advanced
+> **Estimated time**: 8–10 hours
+
+---
+
+## 🎯 Case Overview
+
+This case study uses **real, anonymised credit card transactions** collected
+by Worldline and the Machine Learning Group at the Université Libre de
+Bruxelles (ULB) — actual European cardholder purchases from September 2013,
+not a synthetic simulation.
+
+Because the underlying transaction fields are commercially confidential, the
+original 28 numeric features have been PCA-transformed by the data
+providers (you'll work with anonymised components `V1`–`V28` plus `Time` and
+`Amount`) — this is itself a realistic constraint: in production fraud
+teams, you rarely get raw, human-readable features either, because the
+signal often comes from a black-box risk engine.
+
+Your job: build a fraud classifier that catches as much real fraud as
+possible without generating so many false alarms that legitimate customers
+get blocked.
+
+---
+
+## 📊 Data Source & Attribution
+
+| | |
+| --- | --- |
+| **Dataset** | Credit Card Fraud Detection |
+| **Providers** | Worldline and the Machine Learning Group, Université Libre de Bruxelles (ULB) |
+| **Host** | Kaggle — https://www.kaggle.com/datasets/mlg-ulb/creditcardfraud |
+| **License** | Open Database License (ODbL) v1.0 |
+| **Citation** | Dal Pozzolo, A., Caelen, O., Johnson, R.A., & Bontempi, G. (2015). "Calibrating Probability with Undersampling for Unbalanced Classification." *IEEE Symposium Series on Computational Intelligence (SSCI)*. |
+| **Size** | 284,807 transactions over 2 days, 492 confirmed frauds (0.172%) |
+
+**Getting the data:** Kaggle requires a free account to download datasets.
+1. Create a Kaggle account and API token (`kaggle.json`) — see
+   https://www.kaggle.com/docs/api
+2. Run `python data_loader.py`, which uses `kagglehub` to fetch and cache
+   the dataset locally as `creditcard.csv`.
+
+---
+
+## 📋 Business Context
+
+| Metric | Value |
+| --- | --- |
+| Total transactions | 284,807 |
+| Confirmed fraud cases | 492 (0.172%) |
+| Avg. fraud loss per missed case | $122 (dataset average fraud amount) |
+| Cost of a false decline (customer friction) | $4 estimated support/goodwill cost |
+| Time window | 2 days of real transactions |
+
+**Key question:** *What decision threshold catches the most fraud dollars
+while keeping false declines of legitimate customers to an acceptable
+level?*
+
+---
+
+## 🗂️ Project Structure
+
+```
+14_creditcard_fraud_real_data/
+├── README.md          ← this file (hand-holding guide)
+├── starter.py          ← scaffold with TODOs — follow step by step
+└── data_loader.py       ← downloads the real ULB/Kaggle dataset
+```
+
+---
+
+## 🛠️ Skills Applied
+
+| Phase | Topics |
+| ----- | ------ |
+| Phase 4 | Classification, precision/recall, confusion matrices |
+| Phase 5 | Anomaly detection, extreme class imbalance, ensemble methods |
+| Phase 37B | Probability, cost-based decision thresholds |
+
+---
+
+## 🤝 Hand-Holding Walkthrough
+
+### Step 1 — Fetch the Real Dataset
+
+**What:** Download the actual anonymised transaction dataset from Kaggle.
+
+**Why:** This is one of the most-cited real fraud datasets in applied ML —
+its extreme, genuine class imbalance (0.172% fraud) is exactly the kind of
+challenge synthetic data tends to understate.
+
+**How:**
+
+```python
+# pip install kagglehub
+python data_loader.py             # downloads and caches creditcard.csv
+
+df = pd.read_csv("creditcard.csv")
+print(df.shape)
+print(df["Class"].value_counts())
+print(df["Class"].value_counts(normalize=True) * 100)
+```
+
+**✅ Checkpoint:** 284,807 rows, 31 columns (`Time`, `V1`–`V28`, `Amount`,
+`Class`). Only 492 rows should have `Class == 1`.
+
+---
+
+### Step 2 — Respect the Real Time Ordering
+
+**What:** Split the data by `Time` (transaction seconds elapsed) instead of
+randomly, training on the earlier portion and testing on the later portion.
+
+**Why:** In production, a fraud model is always trained on the past and
+deployed on the future. A random split leaks information across time and
+overstates how well the model would really perform.
+
+**How:**
+
+```python
+df_sorted = df.sort_values("Time")
+split_idx = int(len(df_sorted) * 0.8)
+train = df_sorted.iloc[:split_idx]
+test = df_sorted.iloc[split_idx:]
+
+print(f"Train fraud rate: {train['Class'].mean():.4%}")
+print(f"Test fraud rate: {test['Class'].mean():.4%}")
+```
+
+**✅ Checkpoint:** Both splits should retain roughly (though not exactly) the
+same ~0.17% fraud rate — real fraud rates do drift slightly over time,
+which is itself worth noting in your write-up.
+
+---
+
+### Step 3 — Model with the Right Metric
+
+**What:** Train a baseline logistic regression and a random forest, both
+weighted for class imbalance, and evaluate with **precision-recall AUC**,
+not ROC-AUC.
+
+**Why:** With 0.17% positives, ROC-AUC can look deceptively high even for a
+mediocre model, because the huge majority class dominates the false-positive
+rate calculation. Precision-recall AUC is the honest metric for this level
+of imbalance.
+
+**How:**
+
+```python
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import average_precision_score, classification_report
+
+features = [c for c in df.columns if c not in ("Class",)]
+X_train, y_train = train[features], train["Class"]
+X_test, y_test = test[features], test["Class"]
+
+logreg = LogisticRegression(max_iter=1000, class_weight="balanced")
+logreg.fit(X_train, y_train)
+
+rf = RandomForestClassifier(n_estimators=200, class_weight="balanced", random_state=42)
+rf.fit(X_train, y_train)
+
+for name, model in [("LogReg", logreg), ("RandomForest", rf)]:
+    proba = model.predict_proba(X_test)[:, 1]
+    print(name, "PR-AUC:", average_precision_score(y_test, proba))
+```
+
+**✅ Checkpoint:** Random Forest should meaningfully outperform logistic
+regression on PR-AUC (typically 0.75+ vs. 0.6-ish) — note this in your
+model comparison.
+
+---
+
+### Step 4 — Anomaly Detection as a Second Opinion
+
+**What:** Fit an unsupervised Isolation Forest (trained without labels) and
+compare its flagged transactions to the supervised model's.
+
+**Why:** In real fraud operations, new fraud patterns emerge that a
+supervised model — trained only on *known* past fraud — has never seen.
+Anomaly detection catches novel patterns a labelled classifier would miss.
+
+**How:**
+
+```python
+from sklearn.ensemble import IsolationForest
+
+iso = IsolationForest(contamination=0.0017, random_state=42)
+iso.fit(X_train)
+anomaly_scores = -iso.decision_function(X_test)  # higher = more anomalous
+
+# Compare: how many true frauds fall in the top 1% most anomalous?
+top_1pct_cutoff = pd.Series(anomaly_scores).quantile(0.99)
+flagged = anomaly_scores >= top_1pct_cutoff
+print(f"Frauds caught in top 1% anomalous: {y_test[flagged].sum()} / {y_test.sum()}")
+```
+
+**✅ Checkpoint:** The Isolation Forest should catch a meaningful (if
+imperfect) share of real frauds purely from anomaly structure, with no
+label information — a useful sanity check and a talking point for "what if
+a new fraud pattern that isn't in our training labels shows up tomorrow."
+
+---
+
+### Step 5 — Cost-Based Threshold Tuning
+
+**What:** Instead of the default 0.5 probability threshold, find the
+threshold that minimises total business cost (missed fraud + false
+declines).
+
+**Why:** The business doesn't care about F1 score — it cares about dollars.
+This step is where the model becomes an actual policy recommendation.
+
+**How:**
+
+```python
+import numpy as np
+
+FRAUD_LOSS = 122     # avg. loss per missed fraud
+FALSE_DECLINE_COST = 4  # avg. cost per legitimate customer wrongly declined
+
+proba = rf.predict_proba(X_test)[:, 1]
+best_cost, best_threshold = np.inf, 0.5
+
+for threshold in np.arange(0.1, 0.9, 0.05):
+    preds = (proba >= threshold).astype(int)
+    missed_fraud = ((preds == 0) & (y_test == 1)).sum()
+    false_declines = ((preds == 1) & (y_test == 0)).sum()
+    total_cost = missed_fraud * FRAUD_LOSS + false_declines * FALSE_DECLINE_COST
+    if total_cost < best_cost:
+        best_cost, best_threshold = total_cost, threshold
+
+print(f"Optimal threshold: {best_threshold:.2f}, total cost: ${best_cost:,.0f}")
+```
+
+**✅ Checkpoint:** The cost-optimal threshold is usually well below the
+default 0.5 — because missed fraud is far more expensive than a false
+decline, the model should be biased toward flagging more transactions for
+review.
+
+---
+
+## 📊 Deliverables
+
+| # | Deliverable | Format |
+| - | --- | --- |
+| 1 | Time-ordered train/test pipeline | `data_loader.py` + .py |
+| 2 | Model comparison with PR-AUC (LogReg vs. RF) | Jupyter / .py |
+| 3 | Isolation Forest anomaly-detection comparison | .py |
+| 4 | Cost-optimal threshold analysis | Markdown + chart |
+| 5 | Executive summary for the fraud operations team | Markdown |
+
+---
+
+## 🏆 Stretch Goals
+
+- [ ] Try SMOTE / undersampling and compare against `class_weight="balanced"`
+- [ ] Add a precision-recall curve plot for each model
+- [ ] Ensemble the supervised model and Isolation Forest score
+- [ ] Explore `Amount` and `Time` distributions between fraud/non-fraud (real, tangible patterns even in anonymised data)
+- [ ] Research and discuss why the original features were PCA-anonymised, and what that means for real-world model explainability requirements (e.g. regulatory adverse-action notices)
+
+---
+
+## 📚 Reference Lessons
+
+- Day 42–43: Classification & evaluation metrics (Phase 4)
+- Day 55: Advanced unsupervised learning — anomaly detection (Phase 5)
+- Day 37B: Probability & cost-based decisions (Phase 4)
+
+---
+
+*This case study uses the same real, published dataset behind a peer-
+reviewed IEEE paper on unbalanced fraud classification — genuine extreme
+class imbalance that synthetic data generators routinely understate.*

--- a/content/case-studies/14_creditcard_fraud_real_data/data_loader.py
+++ b/content/case-studies/14_creditcard_fraud_real_data/data_loader.py
@@ -1,0 +1,44 @@
+"""
+Real-data loader for Case Study 14 — Credit Card Fraud Detection.
+
+Downloads the actual "Credit Card Fraud Detection" dataset — real,
+anonymised European cardholder transactions from September 2013 — via
+Kaggle.
+
+Dataset:  Credit Card Fraud Detection
+Providers: Worldline and the Machine Learning Group, Universite Libre
+           de Bruxelles (ULB)
+Source:   https://www.kaggle.com/datasets/mlg-ulb/creditcardfraud
+License:  Open Database License (ODbL) v1.0
+Citation: Dal Pozzolo, A., Caelen, O., Johnson, R.A., & Bontempi, G. (2015).
+          "Calibrating Probability with Undersampling for Unbalanced
+          Classification." IEEE SSCI.
+
+Usage:
+    pip install kagglehub
+    Set up a free Kaggle account + API token (~/.kaggle/kaggle.json),
+    see https://www.kaggle.com/docs/api
+    python data_loader.py
+"""
+
+from pathlib import Path
+
+import pandas as pd
+
+CACHE_FILE = "creditcard.csv"
+
+
+def load_creditcard_fraud() -> pd.DataFrame:
+    """Fetch the real ULB/Kaggle credit card fraud dataset."""
+    import kagglehub
+
+    dataset_path = Path(kagglehub.dataset_download("mlg-ulb/creditcardfraud"))
+    csv_path = next(dataset_path.glob("*.csv"))
+    return pd.read_csv(csv_path)
+
+
+if __name__ == "__main__":
+    df = load_creditcard_fraud()
+    df.to_csv(CACHE_FILE, index=False)
+    print(f"✅ Downloaded and cached {CACHE_FILE} — {len(df):,} rows")
+    print(df["Class"].value_counts(normalize=True) * 100)

--- a/content/case-studies/14_creditcard_fraud_real_data/starter.py
+++ b/content/case-studies/14_creditcard_fraud_real_data/starter.py
@@ -1,0 +1,47 @@
+"""
+Case Study 14 — Credit Card Fraud Detection (Real Transactions)
+==================================================================
+Follow the step-by-step guide in README.md.
+
+Usage:
+    python data_loader.py      # first — downloads creditcard.csv via Kaggle
+    python starter.py          # then — runs this analysis
+"""
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier, IsolationForest
+from sklearn.metrics import average_precision_score, classification_report
+
+# ---------------------------------------------------------------------------
+# Step 1 — Load the Real Dataset
+# ---------------------------------------------------------------------------
+# TODO: df = pd.read_csv("creditcard.csv")
+# TODO: print(df["Class"].value_counts(normalize=True) * 100)
+
+# ---------------------------------------------------------------------------
+# Step 2 — Respect the Real Time Ordering
+# ---------------------------------------------------------------------------
+# TODO: Sort by Time, split 80/20 into train/test (no shuffling)
+
+# ---------------------------------------------------------------------------
+# Step 3 — Model with the Right Metric
+# ---------------------------------------------------------------------------
+# TODO: Fit LogisticRegression(class_weight="balanced")
+# TODO: Fit RandomForestClassifier(class_weight="balanced")
+# TODO: Compare average_precision_score (PR-AUC) for both
+
+# ---------------------------------------------------------------------------
+# Step 4 — Anomaly Detection as a Second Opinion
+# ---------------------------------------------------------------------------
+# TODO: Fit IsolationForest(contamination=0.0017) on X_train (no labels)
+# TODO: Check how many true frauds fall in the top 1% anomaly scores
+
+# ---------------------------------------------------------------------------
+# Step 5 — Cost-Based Threshold Tuning
+# ---------------------------------------------------------------------------
+# TODO: Sweep thresholds 0.1-0.9, compute missed_fraud*FRAUD_LOSS +
+#       false_declines*FALSE_DECLINE_COST, pick the minimum-cost threshold
+
+print("✅ Starter script loaded — follow the TODOs in README.md step by step.")

--- a/content/case-studies/15_market_entry_macro_analysis/README.md
+++ b/content/case-studies/15_market_entry_macro_analysis/README.md
@@ -1,0 +1,268 @@
+# 🌍 Case Study 15: Market-Entry Strategy with Real Macro Data
+
+> **Phases covered**: Phase 2 (Data Wrangling) · Phase 4 (ML Fundamentals)
+> **Difficulty**: Intermediate
+> **Estimated time**: 6–8 hours
+
+---
+
+## 🎯 Case Overview
+
+**ACME Consumer Electronics** wants to expand into one new international
+market next year. Rather than rely on a consultant's slide deck, the CFO
+wants a data-driven scorecard built on **real World Bank macroeconomic
+indicators** — actual GDP, inflation, unemployment, and connectivity data
+for the candidate countries, not illustrative numbers.
+
+Your job: pull real indicators for a shortlist of candidate countries,
+build a weighted market-attractiveness index, cluster the countries into
+peer groups, and recommend an entry sequence.
+
+---
+
+## 📊 Data Source & Attribution
+
+| | |
+| --- | --- |
+| **Dataset** | World Development Indicators (WDI) |
+| **Provider** | The World Bank |
+| **URL** | https://data.worldbank.org/ (API docs: https://datahelpdesk.worldbank.org/knowledgebase/articles/889392) |
+| **License** | CC BY 4.0 |
+| **Citation** | World Bank. *World Development Indicators*. The World Bank Group. Retrieved via the World Bank Open Data API. |
+| **Access method** | `pandas_datareader.wb` (no API key required — the World Bank API is fully public) |
+
+Indicators used (World Bank codes):
+
+| Code | Meaning |
+| --- | --- |
+| `NY.GDP.MKTP.KD.ZG` | GDP growth (annual %) |
+| `FP.CPI.TOTL.ZG` | Inflation, consumer prices (annual %) |
+| `SL.UEM.TOTL.ZS` | Unemployment (% of labor force) |
+| `IT.NET.USER.ZS` | Individuals using the Internet (% of population) |
+| `SP.POP.TOTL` | Total population |
+
+---
+
+## 📋 Business Context
+
+| Metric | Value |
+| --- | --- |
+| Candidate countries under review | 8 |
+| Years of history to pull | 10 |
+| Target segment | Middle-income consumer electronics buyers |
+| Board decision deadline | Next quarterly review |
+
+**Key question:** *Of the candidate countries, which offer the best
+risk-adjusted growth opportunity, and in what order should ACME enter them?*
+
+---
+
+## 🗂️ Project Structure
+
+```
+15_market_entry_macro_analysis/
+├── README.md          ← this file (hand-holding guide)
+├── starter.py          ← scaffold with TODOs — follow step by step
+└── data_loader.py       ← pulls real indicators from the World Bank API
+```
+
+---
+
+## 🛠️ Skills Applied
+
+| Phase | Topics |
+| ----- | ------ |
+| Phase 2 | Pandas reshaping (long ↔ wide), handling missing years in real API data |
+| Phase 4 | Feature scaling, K-Means clustering, weighted index construction |
+| Phase 37B | Volatility as a risk proxy (standard deviation of growth) |
+
+---
+
+## 🤝 Hand-Holding Walkthrough
+
+### Step 1 — Pull Real Indicators from the World Bank
+
+**What:** Fetch 10 years of real macro indicators for 8 candidate countries
+directly from the World Bank's public API.
+
+**Why:** This is the same data source finance and strategy teams actually
+cite in board decks — no placeholder numbers, and it's freely reproducible
+by anyone.
+
+**How:**
+
+```python
+# pip install pandas-datareader
+python data_loader.py             # fetches and caches macro_indicators.csv
+
+df = pd.read_csv("macro_indicators.csv")
+print(df.shape)
+print(df["country"].unique())
+```
+
+**✅ Checkpoint:** You should have rows for each country × year × indicator
+combination, spanning roughly the last 10 years (the World Bank API has
+reporting lag, so the most recent 1–2 years may be missing for some
+countries — a realistic constraint, not a bug).
+
+---
+
+### Step 2 — Reshape & Handle Real Gaps
+
+**What:** Pivot from long format (one row per country-year-indicator) to
+wide format (one row per country-year, one column per indicator), and
+decide how to handle missing values.
+
+**Why:** Real government statistics agencies don't all report on the same
+schedule — some countries have gaps for certain years/indicators. Forward-
+filling or averaging over available years is a defensible, explainable
+choice; silently dropping countries with any gap would bias your sample
+toward highly-developed economies.
+
+**How:**
+
+```python
+wide = df.pivot_table(
+    index=["country", "year"], columns="indicator", values="value"
+).reset_index()
+
+country_avg = wide.groupby("country").mean(numeric_only=True)
+print(country_avg)
+print(wide.isna().sum())
+```
+
+**✅ Checkpoint:** Every candidate country should have at least 6–7 years of
+non-missing data for GDP growth and inflation (the most reliably reported
+indicators); internet penetration may have more gaps for smaller countries.
+
+---
+
+### Step 3 — Build a Weighted Attractiveness Index
+
+**What:** Normalise each indicator (0–1 scale) and combine into a single
+weighted market-attractiveness score.
+
+**Why:** The CFO needs one ranked number per country, not five separate
+tables — but the *weights* should be explicit and adjustable, since
+"attractiveness" is a judgment call the business should own, not something
+buried in code.
+
+**How:**
+
+```python
+from sklearn.preprocessing import MinMaxScaler
+
+indicators = ["NY.GDP.MKTP.KD.ZG", "IT.NET.USER.ZS", "SP.POP.TOTL"]
+inverse_indicators = ["FP.CPI.TOTL.ZG", "SL.UEM.TOTL.ZS"]  # lower is better
+
+scaled = country_avg.copy()
+scaler = MinMaxScaler()
+scaled[indicators] = scaler.fit_transform(country_avg[indicators])
+scaled[inverse_indicators] = 1 - scaler.fit_transform(country_avg[inverse_indicators])
+
+weights = {
+    "NY.GDP.MKTP.KD.ZG": 0.35,
+    "FP.CPI.TOTL.ZG": 0.20,
+    "SL.UEM.TOTL.ZS": 0.15,
+    "IT.NET.USER.ZS": 0.20,
+    "SP.POP.TOTL": 0.10,
+}
+scaled["attractiveness_score"] = sum(scaled[k] * w for k, w in weights.items())
+print(scaled["attractiveness_score"].sort_values(ascending=False))
+```
+
+**✅ Checkpoint:** Re-run with two different weight sets (e.g. growth-
+weighted vs. stability-weighted) and check whether the top-3 ranking
+changes — report this sensitivity in your write-up.
+
+---
+
+### Step 4 — Cluster Countries into Peer Groups
+
+**What:** Run K-Means on the standardized indicators to group the 8
+candidates into 2–3 clusters (e.g. "high-growth/high-volatility" vs.
+"stable/moderate-growth").
+
+**Why:** A single ranked list hides structure — clustering surfaces whether
+your top picks are actually similar to each other (concentration risk) or
+diversified across different economic profiles.
+
+**How:**
+
+```python
+from sklearn.cluster import KMeans
+from sklearn.preprocessing import StandardScaler
+
+X = StandardScaler().fit_transform(country_avg[indicators + inverse_indicators])
+kmeans = KMeans(n_clusters=3, random_state=42, n_init=10)
+country_avg["cluster"] = kmeans.fit_predict(X)
+print(country_avg[["cluster"]].join(scaled["attractiveness_score"]))
+```
+
+**✅ Checkpoint:** Identify which cluster the top-ranked countries fall
+into and label each cluster in plain business language (e.g. "emerging
+high-growth", "stable mature market").
+
+---
+
+### Step 5 — Risk & Recommendation
+
+**What:** Compute year-over-year GDP growth volatility (standard deviation)
+per country as a risk proxy, and combine it with the attractiveness score
+into a final risk-adjusted recommendation.
+
+**Why:** A high-growth country with wildly swinging GDP is a different bet
+than a steady grower — the board needs both dimensions, not just the
+average.
+
+**How:**
+
+```python
+volatility = (
+    wide.groupby("country")["NY.GDP.MKTP.KD.ZG"].std().rename("gdp_volatility")
+)
+final = scaled[["attractiveness_score"]].join(volatility)
+final["risk_adjusted_score"] = final["attractiveness_score"] / (1 + final["gdp_volatility"] / 10)
+print(final.sort_values("risk_adjusted_score", ascending=False))
+```
+
+**✅ Checkpoint:** Rank the final entry sequence and note any countries
+where the risk adjustment meaningfully changes their position vs. the raw
+attractiveness score — that reordering is the key insight for the board.
+
+---
+
+## 📊 Deliverables
+
+| # | Deliverable | Format |
+| - | --- | --- |
+| 1 | Real macro indicator pull pipeline | `data_loader.py` |
+| 2 | Attractiveness index with sensitivity analysis | Jupyter / .py |
+| 3 | Country cluster visualization | PNG |
+| 4 | Risk-adjusted ranking table | Markdown |
+| 5 | Executive summary with recommended entry sequence | Markdown |
+
+---
+
+## 🏆 Stretch Goals
+
+- [ ] Add a real ease-of-doing-business or logistics-performance indicator
+- [ ] Plot GDP growth trajectories over time for the top-3 countries
+- [ ] Extend to 15–20 candidate countries and re-cluster
+- [ ] Build a Streamlit tool where the CFO can adjust indicator weights live
+- [ ] Compare your ranking against a real published index (e.g. IMD World Competitiveness) as a sanity check
+
+---
+
+## 📚 Reference Lessons
+
+- Day 23–24D: Pandas reshaping and real-world data gaps (Phase 2)
+- Day 44: Unsupervised learning — K-Means clustering (Phase 4)
+- Day 37B: Probability & statistics — volatility as risk (Phase 4)
+
+---
+
+*This case study is built entirely on real, publicly reproducible World
+Bank data — the same source real corporate strategy and finance teams cite,
+so the pipeline you build here generalises directly to any set of
+candidate markets.*

--- a/content/case-studies/15_market_entry_macro_analysis/data_loader.py
+++ b/content/case-studies/15_market_entry_macro_analysis/data_loader.py
@@ -1,0 +1,56 @@
+"""
+Real-data loader for Case Study 15 — Market-Entry Strategy with Real Macro
+Data.
+
+Pulls real macroeconomic indicators for a shortlist of candidate countries
+directly from the World Bank's public Open Data API. No API key required.
+
+Dataset:  World Development Indicators (WDI)
+Provider: The World Bank
+Source:   https://data.worldbank.org/
+License:  CC BY 4.0
+
+Usage:
+    pip install pandas-datareader
+    python data_loader.py
+"""
+
+import pandas as pd
+
+CACHE_FILE = "macro_indicators.csv"
+
+CANDIDATE_COUNTRIES = ["BR", "IN", "ID", "MX", "VN", "NG", "PL", "ZA"]
+
+INDICATORS = [
+    "NY.GDP.MKTP.KD.ZG",  # GDP growth (annual %)
+    "FP.CPI.TOTL.ZG",  # Inflation, consumer prices (annual %)
+    "SL.UEM.TOTL.ZS",  # Unemployment (% of labor force)
+    "IT.NET.USER.ZS",  # Individuals using the Internet (% of population)
+    "SP.POP.TOTL",  # Total population
+]
+
+
+def load_macro_indicators(start_year: int = 2014, end_year: int = 2023) -> pd.DataFrame:
+    """Fetch real World Bank indicators for the candidate countries."""
+    from pandas_datareader import wb
+
+    raw = wb.download(
+        indicator=INDICATORS,
+        country=CANDIDATE_COUNTRIES,
+        start=start_year,
+        end=end_year,
+    ).reset_index()
+    long_df = raw.melt(
+        id_vars=["country", "year"],
+        value_vars=INDICATORS,
+        var_name="indicator",
+        value_name="value",
+    )
+    return long_df
+
+
+if __name__ == "__main__":
+    df = load_macro_indicators()
+    df.to_csv(CACHE_FILE, index=False)
+    print(f"✅ Downloaded and cached {CACHE_FILE} — {len(df):,} rows")
+    print(df["country"].unique())

--- a/content/case-studies/15_market_entry_macro_analysis/starter.py
+++ b/content/case-studies/15_market_entry_macro_analysis/starter.py
@@ -1,0 +1,45 @@
+"""
+Case Study 15 — Market-Entry Strategy with Real Macro Data
+=============================================================
+Follow the step-by-step guide in README.md.
+
+Usage:
+    python data_loader.py      # first — pulls macro_indicators.csv from World Bank API
+    python starter.py          # then — runs this analysis
+"""
+
+import pandas as pd
+from sklearn.preprocessing import MinMaxScaler, StandardScaler
+from sklearn.cluster import KMeans
+
+# ---------------------------------------------------------------------------
+# Step 1 — Load Real World Bank Indicators
+# ---------------------------------------------------------------------------
+# TODO: df = pd.read_csv("macro_indicators.csv")
+# TODO: print(df["country"].unique())
+
+# ---------------------------------------------------------------------------
+# Step 2 — Reshape & Handle Real Gaps
+# ---------------------------------------------------------------------------
+# TODO: Pivot long -> wide (index=[country, year], columns=indicator)
+# TODO: country_avg = wide.groupby("country").mean(numeric_only=True)
+
+# ---------------------------------------------------------------------------
+# Step 3 — Build a Weighted Attractiveness Index
+# ---------------------------------------------------------------------------
+# TODO: MinMaxScaler on growth/positive indicators
+# TODO: Invert scale for inflation/unemployment (lower is better)
+# TODO: Combine into weighted attractiveness_score
+
+# ---------------------------------------------------------------------------
+# Step 4 — Cluster Countries into Peer Groups
+# ---------------------------------------------------------------------------
+# TODO: StandardScaler + KMeans(n_clusters=3) on the indicator set
+
+# ---------------------------------------------------------------------------
+# Step 5 — Risk & Recommendation
+# ---------------------------------------------------------------------------
+# TODO: Compute GDP growth volatility (std dev) per country
+# TODO: risk_adjusted_score = attractiveness_score / (1 + gdp_volatility / 10)
+
+print("✅ Starter script loaded — follow the TODOs in README.md step by step.")

--- a/docs/development-roadmap.md
+++ b/docs/development-roadmap.md
@@ -30,7 +30,7 @@ Work is organized into four pillars. Each slips independently — a quarter runn
 **Year 1 goal:** Keep the core 145 days fresh and add the first elective track for learners who finish the main path.
 - Audit all 12 phases for library/API drift (e.g., pandas/sklearn/LLM API syntax) and fix stale examples — content correctness regresses silently as dependencies move.
 - Design and ship one **elective/advanced track** (e.g., "Agentic AI & MLOps" or "Cloud Data Platforms" — pick based on which Phase 9-12 topics get the most learner engagement) as a clearly-marked optional branch off the main sequence, not a renumbering of existing days.
-- Add 3-5 new case studies (`content/case-studies/`) drawing on real, attributed business datasets, rotating out any that have gone stale.
+- ~~Add 3-5 new case studies (`content/case-studies/`) drawing on real, attributed business datasets, rotating out any that have gone stale.~~ **Done (2026-07):** added 5 case studies (11-15) built on real, cited public datasets — UCI Online Retail II, UCI Bank Marketing, NYC TLC taxi trip records, the ULB/Kaggle credit card fraud dataset, and World Bank macro indicators. Audited the original 10 (all synthetic-data-generator based) for staleness — no dead links or deprecated APIs found, so none were rotated out.
 
 **Year 2 goal:** A second elective track plus a capstone structure.
 - Ship a second elective track.


### PR DESCRIPTION
## Summary
- Adds case studies 11-15 to `content/case-studies/`, each built on a real, publicly attributed dataset (instead of the synthetic-generator pattern used by the existing 10):
  - **11 — E-commerce customer segmentation & CLV**: UCI *Online Retail II* (Chen, 2019, CC BY 4.0)
  - **12 — Bank telemarketing conversion**: UCI *Bank Marketing* (Moro, Rita & Cortez, 2014, CC BY 4.0)
  - **13 — Taxi fleet demand forecasting**: NYC TLC Trip Record Data (public domain, NYC Open Data)
  - **14 — Credit card fraud detection**: real anonymised transactions from Worldline/ULB (Dal Pozzolo et al., 2015, ODbL v1.0)
  - **15 — Market-entry strategy**: World Bank World Development Indicators (CC BY 4.0)
- Each case study ships a `README.md` (hand-holding walkthrough matching the existing template, plus a new "Data Source & Attribution" section with license/citation), a `data_loader.py` that fetches the real dataset from its authoritative source, and a `starter.py` TODO scaffold.
- Audited the original 10 case studies for staleness (dead links, deprecated library APIs) — found none, so none were rotated out.
- Marked the corresponding item in `docs/development-roadmap.md` (Pillar 1, Year 1 goal) as done.

## Test plan
- [x] `npx vitest run` — all 97 test files / 696 tests pass
- [x] Verified each new `README.md` parses correctly against `contentLoader.ts`'s title/difficulty/estimated-time/phases-covered regexes
- [x] `python3 -m py_compile` on all 10 new `.py` files — no syntax errors
- [ ] Manual UI check of the `/case-studies` page (not run in this environment; new entries are auto-discovered via `import.meta.glob`, same mechanism as the existing 10)

https://claude.ai/code/session_0147ko2MjQv3vN66FJTC3qRj


---
_Generated by [Claude Code](https://claude.ai/code/session_0147ko2MjQv3vN66FJTC3qRj)_