### PR TITLE
Fix raw markdown rendering in Phase Milestone Exam questions

### DIFF
--- a/src/components/ExerciseWidget.tsx
+++ b/src/components/ExerciseWidget.tsx
@@ -25,6 +25,7 @@ import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import SyntaxHighlighter from '../utils/prism'
 import CodePlayground, { type CodePlaygroundHandle } from './CodePlayground'
 import CopyButton from './CopyButton'
+import { MarkdownFragment } from './MarkdownFragment'
 import { useLocation } from 'react-router-dom'
 import { getAllExercises } from '../utils/contentLoader'
 import { markExerciseComplete } from '../utils/exerciseProgress'
@@ -219,9 +220,7 @@ export default function ExerciseWidget({
 
       {instructions && (
         <div className="exercise-widget__instructions">
-          {instructions.split('\n').map((line, i) => (
-            <p key={i}>{line}</p>
-          ))}
+          <MarkdownFragment content={instructions} />
         </div>
       )}
 

--- a/src/components/MarkdownFragment.tsx
+++ b/src/components/MarkdownFragment.tsx
@@ -1,0 +1,608 @@
+/**
+ * Shared Markdown Fragment Renderer
+ *
+ * Houses the ReactMarkdown configuration (plugins, sanitizer schema, and
+ * custom renderers) shared by `MarkdownRenderer`, `MasteryCheck`, and
+ * `ExerciseWidget` so that any markdown-bearing text (question bodies,
+ * answers, exercise instructions) renders consistently instead of showing
+ * raw markdown syntax.
+ */
+
+import {
+  useState,
+  useEffect,
+  useCallback,
+  JSX,
+  useMemo,
+  type ComponentProps,
+  type MouseEvent,
+  lazy,
+  Suspense,
+} from 'react'
+import { createPortal } from 'react-dom'
+import ReactMarkdown, { Components, ExtraProps } from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import remarkMath from 'remark-math'
+import rehypeKatex from 'rehype-katex'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize, { type Options as RehypeSanitizeOptions } from 'rehype-sanitize'
+import 'katex/dist/katex.min.css'
+import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
+import SyntaxHighlighter from '../utils/prism'
+import CopyButton from './CopyButton'
+import GlossaryTerm from './GlossaryTerm'
+import { glossaryTerms, getGlossaryRegex } from '../utils/glossary'
+import { getSecureLinkAttributes } from '../utils/linkSafety'
+import { rehypeSlugCustom } from '../utils/rehype-slug-custom'
+import { remarkCallouts } from '../utils/remark-callouts'
+import { remarkCodeMeta } from '../utils/remark-code-meta'
+import { toastSuccess, toastError } from '../utils/toast'
+
+const COLLAPSE_THRESHOLD = 20
+const COLLAPSED_LINE_COUNT = 15
+
+const CodePlayground = lazy(() => import('./CodePlayground'))
+const SqlPlayground = lazy(() => import('./SqlPlayground'))
+const MermaidDiagram = lazy(() => import('./MermaidDiagram'))
+
+const customTheme = {
+  ...oneDark,
+  'pre[class*="language-"]': {
+    ...(oneDark['pre[class*="language-"]'] as object),
+    background: 'transparent',
+    margin: 0,
+    padding: 0,
+  },
+  'code[class*="language-"]': {
+    ...(oneDark['code[class*="language-"]'] as object),
+    background: 'transparent',
+  },
+}
+
+function CodeBlock({
+  className,
+  children,
+  isDiff,
+  highlightLines,
+}: {
+  className?: string
+  children: React.ReactNode
+  isDiff?: boolean
+  highlightLines?: number[]
+}) {
+  const match = /language-(\w+)/.exec(className || '')
+  const lang = match ? match[1]! : ''
+  const code = String(children).replace(/\n$/, '')
+  const [showPlayground, setShowPlayground] = useState(false)
+  const isPython = lang === 'python' || lang === 'py'
+  const isSql = lang === 'sql'
+  const isRunnable = isPython || isSql
+
+  const lines = code.split('\n')
+  const isLong = lines.length > COLLAPSE_THRESHOLD
+  const [collapsed, setCollapsed] = useState(isLong)
+  const [wrapLines, setWrapLines] = useState(true)
+
+  const highlightLineSet = useMemo(() => new Set(highlightLines ?? []), [highlightLines])
+
+  const getLineProps = useCallback(
+    (lineNumber: number): { className?: string } => {
+      const lineClasses: string[] = []
+      if (highlightLineSet.has(lineNumber)) {
+        lineClasses.push('code-block-line--highlighted')
+      }
+      if (isDiff) {
+        const sourceLine = lines[lineNumber - 1] ?? ''
+        if (sourceLine.startsWith('+') && !sourceLine.startsWith('+++')) {
+          lineClasses.push('code-block-line--diff-add')
+        } else if (sourceLine.startsWith('-') && !sourceLine.startsWith('---')) {
+          lineClasses.push('code-block-line--diff-remove')
+        }
+      }
+      return lineClasses.length > 0 ? { className: lineClasses.join(' ') } : {}
+    },
+    [highlightLineSet, isDiff, lines],
+  )
+
+  if (!match) {
+    return <code className={className}>{children}</code>
+  }
+
+  const displayCode = collapsed ? lines.slice(0, COLLAPSED_LINE_COUNT).join('\n') : code
+  const hiddenLineCount = lines.length - COLLAPSED_LINE_COUNT
+
+  return (
+    <div
+      className="code-block-wrapper code-block--wrapped"
+      data-wrap={wrapLines ? 'true' : 'false'}
+    >
+      <div className="code-block-header">
+        <span className="code-block-lang">
+          {lang}
+          {isDiff && lang !== 'diff' && <span className="code-block-diff-badge">diff</span>}
+        </span>
+        <div style={{ display: 'flex', gap: '0.4rem', alignItems: 'center' }}>
+          <button
+            type="button"
+            className="code-block-copy focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+            onClick={() => setWrapLines((w) => !w)}
+            aria-label={wrapLines ? 'Disable line wrapping' : 'Enable line wrapping'}
+            title={wrapLines ? 'Unwrap long lines' : 'Wrap long lines'}
+          >
+            {wrapLines ? '↔ Unwrap' : '↩ Wrap'}
+          </button>
+          {isRunnable && (
+            <button
+              type="button"
+              className="code-block-try-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+              onClick={() => setShowPlayground((p) => !p)}
+              aria-label={showPlayground ? 'Close playground' : 'Try this code'}
+            >
+              {showPlayground ? '✕ Close' : '▶ Try It'}
+            </button>
+          )}
+          <CopyButton text={code} ariaLabel="Copy code to clipboard" />
+        </div>
+      </div>
+      <div className={`code-block-content${collapsed ? ' code-block-content--collapsed' : ''}`}>
+        <SyntaxHighlighter
+          style={customTheme}
+          language={lang}
+          PreTag="div"
+          wrapLongLines={wrapLines}
+          wrapLines
+          lineProps={getLineProps}
+          showLineNumbers={lines.length > 3}
+          lineNumberStyle={{
+            minWidth: '2.5em',
+            paddingRight: '1em',
+            color: 'var(--text-muted)',
+            userSelect: 'none',
+            opacity: 0.45,
+            fontSize: '0.75rem',
+          }}
+          customStyle={{
+            margin: 0,
+            padding: '1rem',
+            background: 'transparent',
+            fontSize: '0.8125rem',
+            lineHeight: '1.65',
+            overflowX: 'hidden',
+            whiteSpace: wrapLines ? 'pre-wrap' : 'pre',
+            overflowWrap: wrapLines ? 'anywhere' : 'normal',
+            wordBreak: wrapLines ? 'break-word' : 'normal',
+          }}
+          tabIndex={0}
+          codeTagProps={{
+            style: {
+              fontFamily: 'var(--font-mono)',
+              whiteSpace: wrapLines ? 'pre-wrap' : 'pre',
+              overflowWrap: wrapLines ? 'anywhere' : 'normal',
+              wordBreak: wrapLines ? 'break-word' : 'normal',
+            },
+          }}
+        >
+          {displayCode}
+        </SyntaxHighlighter>
+      </div>
+      {isLong && (
+        <button
+          type="button"
+          className="code-block-expand-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? 'Expand code block' : 'Collapse code block'}
+        >
+          {collapsed
+            ? `▼ Show ${hiddenLineCount} more line${hiddenLineCount !== 1 ? 's' : ''}`
+            : '▲ Collapse'}
+        </button>
+      )}
+      {showPlayground && isPython && (
+        <div className="code-block-inline-playground">
+          <Suspense
+            fallback={
+              <div style={{ padding: '1rem', color: 'var(--text-muted)' }}>
+                Loading Pyodide environment...
+              </div>
+            }
+          >
+            <CodePlayground initialCode={code} />
+          </Suspense>
+        </div>
+      )}
+      {showPlayground && isSql && (
+        <div className="code-block-inline-playground">
+          <Suspense
+            fallback={
+              <div style={{ padding: '1rem', color: 'var(--text-muted)' }}>
+                Loading SQL engine...
+              </div>
+            }
+          >
+            <SqlPlayground initialCode={code} />
+          </Suspense>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function MermaidBlock({ code }: { code: string }) {
+  const [showSource, setShowSource] = useState(false)
+
+  return (
+    <div className="code-block-wrapper code-block--wrapped mermaid-block">
+      <div className="code-block-header">
+        <span className="code-block-lang">mermaid</span>
+        <div style={{ display: 'flex', gap: '0.4rem', alignItems: 'center' }}>
+          <button
+            type="button"
+            className="code-block-copy focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+            onClick={() => setShowSource((s) => !s)}
+            aria-label={showSource ? 'Show rendered diagram' : 'View diagram source'}
+          >
+            {showSource ? '◇ Diagram' : '⌗ Source'}
+          </button>
+          <CopyButton text={code} ariaLabel="Copy diagram source to clipboard" />
+        </div>
+      </div>
+      {showSource ? (
+        <pre className="mermaid-source">
+          <code>{code}</code>
+        </pre>
+      ) : (
+        <Suspense
+          fallback={<div className="mermaid-diagram-loading">Loading diagram renderer...</div>}
+        >
+          <MermaidDiagram code={code} />
+        </Suspense>
+      )}
+    </div>
+  )
+}
+
+const CodeComponent = (props: JSX.IntrinsicElements['code'] & ExtraProps) => {
+  const { children, className, node, ...rest } = props
+  const match = /language-(\w+)/.exec(className || '')
+  if (match) {
+    const lang = match[1]!
+    if (lang === 'mermaid') {
+      return <MermaidBlock code={String(children).replace(/\n$/, '')} />
+    }
+    const properties = node?.properties as Record<string, unknown> | undefined
+    const isDiff = properties?.dataDiff === 'true'
+    const highlightLinesAttr = properties?.dataHighlightLines
+    const highlightLines =
+      typeof highlightLinesAttr === 'string' && highlightLinesAttr.length > 0
+        ? highlightLinesAttr.split(',').map((n) => parseInt(n, 10))
+        : undefined
+    return (
+      <CodeBlock className={className} isDiff={isDiff} highlightLines={highlightLines}>
+        {children}
+      </CodeBlock>
+    )
+  }
+  return (
+    <code className={className} {...rest}>
+      {children}
+    </code>
+  )
+}
+
+const TableComponent = ({ children }: { children?: React.ReactNode }) => {
+  return (
+    <div className="table-wrapper">
+      <table>{children}</table>
+    </div>
+  )
+}
+
+const ImageWithZoom = (props: JSX.IntrinsicElements['img'] & ExtraProps) => {
+  const [zoomed, setZoomed] = useState(false)
+
+  const {
+    fetchPriority,
+    fetchpriority: lowercaseFetchPriority,
+    loading: _loading,
+    ...rest
+  } = props as JSX.IntrinsicElements['img'] & {
+    fetchPriority?: 'high' | 'low' | 'auto'
+    fetchpriority?: 'high' | 'low' | 'auto'
+  }
+
+  const isHighPriority = lowercaseFetchPriority === 'high' || fetchPriority === 'high'
+
+  useEffect(() => {
+    if (!zoomed) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setZoomed(false)
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [zoomed])
+
+  return (
+    <>
+      <img
+        loading={isHighPriority ? 'eager' : 'lazy'}
+        decoding="async"
+        fetchPriority={isHighPriority ? 'high' : undefined}
+        alt={rest.alt || 'Course image'}
+        className="zoomable-image"
+        onClick={() => rest.src && setZoomed(true)}
+        {...rest}
+      />
+      {zoomed &&
+        rest.src &&
+        createPortal(
+          <div
+            className="image-zoom-overlay"
+            onClick={() => setZoomed(false)}
+            role="presentation"
+            aria-label={`Zoomed: ${rest.alt || 'image'}`}
+          >
+            <button
+              type="button"
+              className="image-zoom-close focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+              onClick={(e) => {
+                e.stopPropagation()
+                setZoomed(false)
+              }}
+              aria-label="Close zoomed image"
+            >
+              ✕
+            </button>
+            <img
+              src={rest.src}
+              alt={rest.alt || 'Course image'}
+              className="image-zoom-content"
+              onClick={(e) => e.stopPropagation()}
+            />
+          </div>,
+          document.body,
+        )}
+    </>
+  )
+}
+
+const LinkComponent = ({ href, children, ...props }: JSX.IntrinsicElements['a'] & ExtraProps) => {
+  const attributes = getSecureLinkAttributes(href, props)
+
+  if (!attributes) {
+    return <span>{children}</span>
+  }
+
+  // Remove target and rel from props so they don't override secure attributes
+  const { target: _target, rel: _rel, ...rest } = props
+
+  return (
+    <a href={attributes.href} target={attributes.target} rel={attributes.rel} {...rest}>
+      {children}
+    </a>
+  )
+}
+
+function handleHeadingAnchorClick(event: MouseEvent<HTMLAnchorElement>, id: string) {
+  event.preventDefault()
+  const url = `${window.location.origin}${window.location.pathname}#${id}`
+  window.history.replaceState(null, '', `#${id}`)
+  navigator.clipboard
+    .writeText(url)
+    .then(() => toastSuccess('Link copied to clipboard 🔗'))
+    .catch(() => toastError('Could not copy link'))
+}
+
+function createHeadingComponent(Tag: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6') {
+  return ({
+    children,
+    id,
+    className: _className,
+    ...props
+  }: JSX.IntrinsicElements['h1'] & ExtraProps) => {
+    return (
+      <Tag
+        id={id}
+        tabIndex={-1}
+        style={{ outline: 'none' }}
+        className="heading-with-anchor"
+        {...props}
+      >
+        {children}
+        {id && (
+          <a
+            href={`#${id}`}
+            className="heading-anchor-link"
+            aria-label="Copy link to this section"
+            onClick={(event) => handleHeadingAnchorClick(event, id)}
+          />
+        )}
+      </Tag>
+    )
+  }
+}
+
+// ⚡ Bolt: Removed 'g' flag and global RegExp instance to prevent stateful RegExp.lastIndex race conditions
+// during React Concurrent Mode rendering. Replaced with stateless Array.from(matchAll()).
+const glossaryRegexSource = getGlossaryRegex().source
+const glossaryDefinitionsByLowerTerm = Object.fromEntries(
+  Object.entries(glossaryTerms).map(([term, definition]) => [term.toLowerCase(), definition]),
+)
+
+/** Wrap only the first occurrence of each glossary term in a text node. */
+function addGlossaryTooltips(text: string): (string | JSX.Element)[] {
+  const parts: (string | JSX.Element)[] = []
+  const matched = new Set<string>()
+  let lastIndex = 0
+  let keyIdx = 0
+
+  // Create a new RegExp instance per call to ensure pure, deterministic rendering.
+  const regex = new RegExp(glossaryRegexSource, 'gi')
+  const matches = Array.from(text.matchAll(regex))
+
+  for (const match of matches) {
+    const termLower = match[1]!.toLowerCase()
+    const matchStart = match.index
+    const matchEnd = match.index + match[0].length
+
+    // Append text before the match
+    if (matchStart > lastIndex) {
+      parts.push(text.slice(lastIndex, matchStart))
+    }
+
+    if (matched.has(termLower)) {
+      // Already matched in this paragraph, just append the text
+      parts.push(match[0])
+    } else {
+      matched.add(termLower)
+      const definition = glossaryDefinitionsByLowerTerm[termLower]
+
+      if (definition) {
+        parts.push(<GlossaryTerm key={`gl-${keyIdx++}`} text={match[0]} definition={definition} />)
+      } else {
+        parts.push(match[0])
+      }
+    }
+
+    lastIndex = matchEnd
+  }
+
+  // Append remaining text
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex))
+  }
+
+  return parts
+}
+
+function processGlossaryChildren(children: React.ReactNode): React.ReactNode {
+  if (typeof children === 'string') {
+    const parts = addGlossaryTooltips(children)
+    return parts.length === 1 && typeof parts[0] === 'string' ? parts[0] : <>{parts}</>
+  }
+  if (Array.isArray(children)) {
+    return children.map((child, i) => {
+      if (typeof child === 'string') {
+        const parts = addGlossaryTooltips(child)
+        return parts.length === 1 && typeof parts[0] === 'string' ? (
+          parts[0]
+        ) : (
+          <span key={i}>{parts}</span>
+        )
+      }
+      return child
+    })
+  }
+  return children
+}
+
+const ParagraphWithGlossary = ({ children, ...props }: JSX.IntrinsicElements['p'] & ExtraProps) => (
+  <p {...props}>{processGlossaryChildren(children)}</p>
+)
+
+export const markdownComponents: Components = {
+  code: CodeComponent,
+  table: TableComponent,
+  img: ImageWithZoom,
+  a: LinkComponent,
+  h1: createHeadingComponent('h1'),
+  h2: createHeadingComponent('h2'),
+  h3: createHeadingComponent('h3'),
+  h4: createHeadingComponent('h4'),
+  h5: createHeadingComponent('h5'),
+  h6: createHeadingComponent('h6'),
+  p: ParagraphWithGlossary,
+}
+
+const lessonSanitizerSchema: RehypeSanitizeOptions = {
+  tagNames: [
+    'a',
+    'blockquote',
+    'br',
+    'code',
+    'del',
+    'details',
+    'div',
+    'em',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'hr',
+    'img',
+    'input',
+    'li',
+    'ol',
+    'p',
+    'pre',
+    'span',
+    'strong',
+    'summary',
+    'table',
+    'tbody',
+    'td',
+    'th',
+    'thead',
+    'tr',
+    'ul',
+  ],
+  attributes: {
+    a: ['href', 'title', 'target', 'rel'],
+    code: ['className', 'dataDiff', 'dataHighlightLines'],
+    div: ['className', 'dataCallout'],
+    img: [
+      'src',
+      'alt',
+      'title',
+      'width',
+      'height',
+      'loading',
+      'decoding',
+      'fetchpriority',
+      'fetchPriority',
+    ],
+    input: [
+      ['type', 'checkbox'],
+      ['disabled', true],
+      ['checked', true],
+    ],
+    span: ['className', 'dataDefinition'],
+    td: ['align'],
+    th: ['align'],
+    '*': ['id'],
+  },
+  protocols: {
+    href: ['http', 'https', 'mailto'],
+    src: ['http', 'https'],
+  },
+}
+
+export const rehypePlugins: NonNullable<ComponentProps<typeof ReactMarkdown>['rehypePlugins']> = [
+  rehypeRaw,
+  [rehypeSanitize, lessonSanitizerSchema],
+  rehypeSlugCustom,
+  rehypeKatex,
+]
+
+export const remarkPlugins = [remarkGfm, remarkMath, remarkCallouts, remarkCodeMeta]
+
+/**
+ * Renders a standalone markdown string (a question body, answer explanation,
+ * or exercise instructions) using the same plugins and custom renderers as
+ * full lesson content, so bold text, inline code, and fenced code blocks
+ * render instead of showing raw markdown syntax.
+ */
+export function MarkdownFragment({ content }: { content: string }) {
+  if (!content) return null
+  return (
+    <ReactMarkdown
+      remarkPlugins={remarkPlugins}
+      rehypePlugins={rehypePlugins}
+      components={markdownComponents}
+    >
+      {content}
+    </ReactMarkdown>
+  )
+}

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -11,503 +11,16 @@
  * - Render code blocks with syntax highlighting and copy buttons.
  */
 
-import {
-  useState,
-  useEffect,
-  useCallback,
-  memo,
-  JSX,
-  useMemo,
-  type ComponentProps,
-  type MouseEvent,
-  lazy,
-  Suspense,
-} from 'react'
-import { createPortal } from 'react-dom'
-import ReactMarkdown, { Components, ExtraProps } from 'react-markdown'
+import { memo, JSX, useMemo, lazy, Suspense } from 'react'
+import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import remarkMath from 'remark-math'
 import remarkParse from 'remark-parse'
-import rehypeKatex from 'rehype-katex'
-import rehypeRaw from 'rehype-raw'
-import rehypeSanitize, { type Options as RehypeSanitizeOptions } from 'rehype-sanitize'
-import 'katex/dist/katex.min.css'
 import { unified } from 'unified'
 import type { Content, Heading, Html, Nodes, Paragraph, Root, Strong } from 'mdast'
-import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
-import SyntaxHighlighter from '../utils/prism'
-import CopyButton from './CopyButton'
-import GlossaryTerm from './GlossaryTerm'
-import { glossaryTerms, getGlossaryRegex } from '../utils/glossary'
-import { getSecureLinkAttributes } from '../utils/linkSafety'
-import { rehypeSlugCustom } from '../utils/rehype-slug-custom'
-import { remarkCallouts } from '../utils/remark-callouts'
-import { remarkCodeMeta } from '../utils/remark-code-meta'
-import { toastSuccess, toastError } from '../utils/toast'
+import { markdownComponents, remarkPlugins, rehypePlugins } from './MarkdownFragment'
 
-const COLLAPSE_THRESHOLD = 20
-const COLLAPSED_LINE_COUNT = 15
-
-const CodePlayground = lazy(() => import('./CodePlayground'))
-const SqlPlayground = lazy(() => import('./SqlPlayground'))
 const ExerciseWidget = lazy(() => import('./ExerciseWidget'))
 const MasteryCheck = lazy(() => import('./MasteryCheck'))
-const MermaidDiagram = lazy(() => import('./MermaidDiagram'))
-
-const customTheme = {
-  ...oneDark,
-  'pre[class*="language-"]': {
-    ...(oneDark['pre[class*="language-"]'] as object),
-    background: 'transparent',
-    margin: 0,
-    padding: 0,
-  },
-  'code[class*="language-"]': {
-    ...(oneDark['code[class*="language-"]'] as object),
-    background: 'transparent',
-  },
-}
-
-function CodeBlock({
-  className,
-  children,
-  isDiff,
-  highlightLines,
-}: {
-  className?: string
-  children: React.ReactNode
-  isDiff?: boolean
-  highlightLines?: number[]
-}) {
-  const match = /language-(\w+)/.exec(className || '')
-  const lang = match ? match[1]! : ''
-  const code = String(children).replace(/\n$/, '')
-  const [showPlayground, setShowPlayground] = useState(false)
-  const isPython = lang === 'python' || lang === 'py'
-  const isSql = lang === 'sql'
-  const isRunnable = isPython || isSql
-
-  const lines = code.split('\n')
-  const isLong = lines.length > COLLAPSE_THRESHOLD
-  const [collapsed, setCollapsed] = useState(isLong)
-  const [wrapLines, setWrapLines] = useState(true)
-
-  const highlightLineSet = useMemo(() => new Set(highlightLines ?? []), [highlightLines])
-
-  const getLineProps = useCallback(
-    (lineNumber: number): { className?: string } => {
-      const lineClasses: string[] = []
-      if (highlightLineSet.has(lineNumber)) {
-        lineClasses.push('code-block-line--highlighted')
-      }
-      if (isDiff) {
-        const sourceLine = lines[lineNumber - 1] ?? ''
-        if (sourceLine.startsWith('+') && !sourceLine.startsWith('+++')) {
-          lineClasses.push('code-block-line--diff-add')
-        } else if (sourceLine.startsWith('-') && !sourceLine.startsWith('---')) {
-          lineClasses.push('code-block-line--diff-remove')
-        }
-      }
-      return lineClasses.length > 0 ? { className: lineClasses.join(' ') } : {}
-    },
-    [highlightLineSet, isDiff, lines],
-  )
-
-  if (!match) {
-    return <code className={className}>{children}</code>
-  }
-
-  const displayCode = collapsed ? lines.slice(0, COLLAPSED_LINE_COUNT).join('\n') : code
-  const hiddenLineCount = lines.length - COLLAPSED_LINE_COUNT
-
-  return (
-    <div
-      className="code-block-wrapper code-block--wrapped"
-      data-wrap={wrapLines ? 'true' : 'false'}
-    >
-      <div className="code-block-header">
-        <span className="code-block-lang">
-          {lang}
-          {isDiff && lang !== 'diff' && <span className="code-block-diff-badge">diff</span>}
-        </span>
-        <div style={{ display: 'flex', gap: '0.4rem', alignItems: 'center' }}>
-          <button
-            type="button"
-            className="code-block-copy focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
-            onClick={() => setWrapLines((w) => !w)}
-            aria-label={wrapLines ? 'Disable line wrapping' : 'Enable line wrapping'}
-            title={wrapLines ? 'Unwrap long lines' : 'Wrap long lines'}
-          >
-            {wrapLines ? '↔ Unwrap' : '↩ Wrap'}
-          </button>
-          {isRunnable && (
-            <button
-              type="button"
-              className="code-block-try-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
-              onClick={() => setShowPlayground((p) => !p)}
-              aria-label={showPlayground ? 'Close playground' : 'Try this code'}
-            >
-              {showPlayground ? '✕ Close' : '▶ Try It'}
-            </button>
-          )}
-          <CopyButton text={code} ariaLabel="Copy code to clipboard" />
-        </div>
-      </div>
-      <div className={`code-block-content${collapsed ? ' code-block-content--collapsed' : ''}`}>
-        <SyntaxHighlighter
-          style={customTheme}
-          language={lang}
-          PreTag="div"
-          wrapLongLines={wrapLines}
-          wrapLines
-          lineProps={getLineProps}
-          showLineNumbers={lines.length > 3}
-          lineNumberStyle={{
-            minWidth: '2.5em',
-            paddingRight: '1em',
-            color: 'var(--text-muted)',
-            userSelect: 'none',
-            opacity: 0.45,
-            fontSize: '0.75rem',
-          }}
-          customStyle={{
-            margin: 0,
-            padding: '1rem',
-            background: 'transparent',
-            fontSize: '0.8125rem',
-            lineHeight: '1.65',
-            overflowX: 'hidden',
-            whiteSpace: wrapLines ? 'pre-wrap' : 'pre',
-            overflowWrap: wrapLines ? 'anywhere' : 'normal',
-            wordBreak: wrapLines ? 'break-word' : 'normal',
-          }}
-          tabIndex={0}
-          codeTagProps={{
-            style: {
-              fontFamily: 'var(--font-mono)',
-              whiteSpace: wrapLines ? 'pre-wrap' : 'pre',
-              overflowWrap: wrapLines ? 'anywhere' : 'normal',
-              wordBreak: wrapLines ? 'break-word' : 'normal',
-            },
-          }}
-        >
-          {displayCode}
-        </SyntaxHighlighter>
-      </div>
-      {isLong && (
-        <button
-          type="button"
-          className="code-block-expand-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
-          onClick={() => setCollapsed((c) => !c)}
-          aria-expanded={!collapsed}
-          aria-label={collapsed ? 'Expand code block' : 'Collapse code block'}
-        >
-          {collapsed
-            ? `▼ Show ${hiddenLineCount} more line${hiddenLineCount !== 1 ? 's' : ''}`
-            : '▲ Collapse'}
-        </button>
-      )}
-      {showPlayground && isPython && (
-        <div className="code-block-inline-playground">
-          <Suspense
-            fallback={
-              <div style={{ padding: '1rem', color: 'var(--text-muted)' }}>
-                Loading Pyodide environment...
-              </div>
-            }
-          >
-            <CodePlayground initialCode={code} />
-          </Suspense>
-        </div>
-      )}
-      {showPlayground && isSql && (
-        <div className="code-block-inline-playground">
-          <Suspense
-            fallback={
-              <div style={{ padding: '1rem', color: 'var(--text-muted)' }}>
-                Loading SQL engine...
-              </div>
-            }
-          >
-            <SqlPlayground initialCode={code} />
-          </Suspense>
-        </div>
-      )}
-    </div>
-  )
-}
-
-function MermaidBlock({ code }: { code: string }) {
-  const [showSource, setShowSource] = useState(false)
-
-  return (
-    <div className="code-block-wrapper code-block--wrapped mermaid-block">
-      <div className="code-block-header">
-        <span className="code-block-lang">mermaid</span>
-        <div style={{ display: 'flex', gap: '0.4rem', alignItems: 'center' }}>
-          <button
-            type="button"
-            className="code-block-copy focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
-            onClick={() => setShowSource((s) => !s)}
-            aria-label={showSource ? 'Show rendered diagram' : 'View diagram source'}
-          >
-            {showSource ? '◇ Diagram' : '⌗ Source'}
-          </button>
-          <CopyButton text={code} ariaLabel="Copy diagram source to clipboard" />
-        </div>
-      </div>
-      {showSource ? (
-        <pre className="mermaid-source">
-          <code>{code}</code>
-        </pre>
-      ) : (
-        <Suspense
-          fallback={<div className="mermaid-diagram-loading">Loading diagram renderer...</div>}
-        >
-          <MermaidDiagram code={code} />
-        </Suspense>
-      )}
-    </div>
-  )
-}
-
-const CodeComponent = (props: JSX.IntrinsicElements['code'] & ExtraProps) => {
-  const { children, className, node, ...rest } = props
-  const match = /language-(\w+)/.exec(className || '')
-  if (match) {
-    const lang = match[1]!
-    if (lang === 'mermaid') {
-      return <MermaidBlock code={String(children).replace(/\n$/, '')} />
-    }
-    const properties = node?.properties as Record<string, unknown> | undefined
-    const isDiff = properties?.dataDiff === 'true'
-    const highlightLinesAttr = properties?.dataHighlightLines
-    const highlightLines =
-      typeof highlightLinesAttr === 'string' && highlightLinesAttr.length > 0
-        ? highlightLinesAttr.split(',').map((n) => parseInt(n, 10))
-        : undefined
-    return (
-      <CodeBlock className={className} isDiff={isDiff} highlightLines={highlightLines}>
-        {children}
-      </CodeBlock>
-    )
-  }
-  return (
-    <code className={className} {...rest}>
-      {children}
-    </code>
-  )
-}
-
-const TableComponent = ({ children }: { children?: React.ReactNode }) => {
-  return (
-    <div className="table-wrapper">
-      <table>{children}</table>
-    </div>
-  )
-}
-
-const ImageWithZoom = (props: JSX.IntrinsicElements['img'] & ExtraProps) => {
-  const [zoomed, setZoomed] = useState(false)
-
-  const {
-    fetchPriority,
-    fetchpriority: lowercaseFetchPriority,
-    loading: _loading,
-    ...rest
-  } = props as JSX.IntrinsicElements['img'] & {
-    fetchPriority?: 'high' | 'low' | 'auto'
-    fetchpriority?: 'high' | 'low' | 'auto'
-  }
-
-  const isHighPriority = lowercaseFetchPriority === 'high' || fetchPriority === 'high'
-
-  useEffect(() => {
-    if (!zoomed) return
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setZoomed(false)
-    }
-    document.addEventListener('keydown', handleKey)
-    return () => document.removeEventListener('keydown', handleKey)
-  }, [zoomed])
-
-  return (
-    <>
-      <img
-        loading={isHighPriority ? 'eager' : 'lazy'}
-        decoding="async"
-        fetchPriority={isHighPriority ? 'high' : undefined}
-        alt={rest.alt || 'Course image'}
-        className="zoomable-image"
-        onClick={() => rest.src && setZoomed(true)}
-        {...rest}
-      />
-      {zoomed &&
-        rest.src &&
-        createPortal(
-          <div
-            className="image-zoom-overlay"
-            onClick={() => setZoomed(false)}
-            role="presentation"
-            aria-label={`Zoomed: ${rest.alt || 'image'}`}
-          >
-            <button
-              type="button"
-              className="image-zoom-close focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
-              onClick={(e) => {
-                e.stopPropagation()
-                setZoomed(false)
-              }}
-              aria-label="Close zoomed image"
-            >
-              ✕
-            </button>
-            <img
-              src={rest.src}
-              alt={rest.alt || 'Course image'}
-              className="image-zoom-content"
-              onClick={(e) => e.stopPropagation()}
-            />
-          </div>,
-          document.body,
-        )}
-    </>
-  )
-}
-
-const LinkComponent = ({ href, children, ...props }: JSX.IntrinsicElements['a'] & ExtraProps) => {
-  const attributes = getSecureLinkAttributes(href, props)
-
-  if (!attributes) {
-    return <span>{children}</span>
-  }
-
-  // Remove target and rel from props so they don't override secure attributes
-  const { target: _target, rel: _rel, ...rest } = props
-
-  return (
-    <a href={attributes.href} target={attributes.target} rel={attributes.rel} {...rest}>
-      {children}
-    </a>
-  )
-}
-
-function handleHeadingAnchorClick(event: MouseEvent<HTMLAnchorElement>, id: string) {
-  event.preventDefault()
-  const url = `${window.location.origin}${window.location.pathname}#${id}`
-  window.history.replaceState(null, '', `#${id}`)
-  navigator.clipboard
-    .writeText(url)
-    .then(() => toastSuccess('Link copied to clipboard 🔗'))
-    .catch(() => toastError('Could not copy link'))
-}
-
-function createHeadingComponent(Tag: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6') {
-  return ({
-    children,
-    id,
-    className: _className,
-    ...props
-  }: JSX.IntrinsicElements['h1'] & ExtraProps) => {
-    return (
-      <Tag
-        id={id}
-        tabIndex={-1}
-        style={{ outline: 'none' }}
-        className="heading-with-anchor"
-        {...props}
-      >
-        {children}
-        {id && (
-          <a
-            href={`#${id}`}
-            className="heading-anchor-link"
-            aria-label="Copy link to this section"
-            onClick={(event) => handleHeadingAnchorClick(event, id)}
-          />
-        )}
-      </Tag>
-    )
-  }
-}
-
-// ⚡ Bolt: Removed 'g' flag and global RegExp instance to prevent stateful RegExp.lastIndex race conditions
-// during React Concurrent Mode rendering. Replaced with stateless Array.from(matchAll()).
-const glossaryRegexSource = getGlossaryRegex().source
-const glossaryDefinitionsByLowerTerm = Object.fromEntries(
-  Object.entries(glossaryTerms).map(([term, definition]) => [term.toLowerCase(), definition]),
-)
-
-/** Wrap only the first occurrence of each glossary term in a text node. */
-function addGlossaryTooltips(text: string): (string | JSX.Element)[] {
-  const parts: (string | JSX.Element)[] = []
-  const matched = new Set<string>()
-  let lastIndex = 0
-  let keyIdx = 0
-
-  // Create a new RegExp instance per call to ensure pure, deterministic rendering.
-  const regex = new RegExp(glossaryRegexSource, 'gi')
-  const matches = Array.from(text.matchAll(regex))
-
-  for (const match of matches) {
-    const termLower = match[1]!.toLowerCase()
-    const matchStart = match.index
-    const matchEnd = match.index + match[0].length
-
-    // Append text before the match
-    if (matchStart > lastIndex) {
-      parts.push(text.slice(lastIndex, matchStart))
-    }
-
-    if (matched.has(termLower)) {
-      // Already matched in this paragraph, just append the text
-      parts.push(match[0])
-    } else {
-      matched.add(termLower)
-      const definition = glossaryDefinitionsByLowerTerm[termLower]
-
-      if (definition) {
-        parts.push(<GlossaryTerm key={`gl-${keyIdx++}`} text={match[0]} definition={definition} />)
-      } else {
-        parts.push(match[0])
-      }
-    }
-
-    lastIndex = matchEnd
-  }
-
-  // Append remaining text
-  if (lastIndex < text.length) {
-    parts.push(text.slice(lastIndex))
-  }
-
-  return parts
-}
-
-function processGlossaryChildren(children: React.ReactNode): React.ReactNode {
-  if (typeof children === 'string') {
-    const parts = addGlossaryTooltips(children)
-    return parts.length === 1 && typeof parts[0] === 'string' ? parts[0] : <>{parts}</>
-  }
-  if (Array.isArray(children)) {
-    return children.map((child, i) => {
-      if (typeof child === 'string') {
-        const parts = addGlossaryTooltips(child)
-        return parts.length === 1 && typeof parts[0] === 'string' ? (
-          parts[0]
-        ) : (
-          <span key={i}>{parts}</span>
-        )
-      }
-      return child
-    })
-  }
-  return children
-}
-
-const ParagraphWithGlossary = ({ children, ...props }: JSX.IntrinsicElements['p'] & ExtraProps) => (
-  <p {...props}>{processGlossaryChildren(children)}</p>
-)
 
 interface ParsedExercise {
   title: string
@@ -728,7 +241,6 @@ function findInteractiveBlocks(content: string): InteractiveBlock[] {
 
     const questionNodes =
       detailsNodeIndex >= 0 ? sectionNodes.slice(0, detailsNodeIndex) : sectionNodes
-    const detailsNode = detailsNodeIndex >= 0 ? (sectionNodes[detailsNodeIndex] as Html) : null
 
     let questionBody = ''
     if (questionNodes.length > 0) {
@@ -743,19 +255,37 @@ function findInteractiveBlocks(content: string): InteractiveBlock[] {
       }
     }
 
-    const detailsValue = detailsNode?.value || ''
-    const answerBody = detailsValue
+    // The <details> block is split into multiple sibling "html" nodes by the
+    // markdown parser whenever it contains a blank line (e.g. before a list),
+    // so its full raw text has to be reassembled from the opening tag through
+    // the matching closing tag rather than read off a single node's value.
+    let detailsRawValue = ''
+    if (detailsNodeIndex >= 0) {
+      const detailsStartNode = sectionNodes[detailsNodeIndex] as Html
+      let closingNodeIndex = -1
+      for (let k = detailsNodeIndex; k < sectionNodes.length; k++) {
+        const candidate = sectionNodes[k]
+        if (candidate?.type === 'html' && /<\/details>/i.test((candidate as Html).value)) {
+          closingNodeIndex = k
+          break
+        }
+      }
+      const closingNode =
+        closingNodeIndex >= 0 ? sectionNodes[closingNodeIndex]! : detailsStartNode
+      const start = getNodeStartOffset(detailsStartNode)
+      const end = getNodeEndOffset(closingNode)
+      if (start !== null && end !== null) {
+        detailsRawValue = content.slice(start, end)
+      }
+    }
+
+    const answerBody = detailsRawValue
       .replace(/^[\s\S]*?<summary>[\s\S]*?<\/summary>/i, '')
       .replace(/<\/details>\s*$/i, '')
       .trim()
 
     const { code: codeSnippet, remaining: questionText } = extractCodeBlock(questionBody)
     const answerText = answerBody
-      .replace(/```[\s\S]*?```/g, (codeBlock: string) => {
-        const codeContent = codeBlock.replace(/```(?:\w+)?\s*\n?/, '').replace(/\n?```$/, '')
-        return codeContent
-      })
-      .trim()
 
     blocks.push({
       type: 'mastery',
@@ -768,94 +298,6 @@ function findInteractiveBlocks(content: string): InteractiveBlock[] {
   blocks.sort((a, b) => a.startIndex - b.startIndex)
   return blocks
 }
-
-const markdownComponents: Components = {
-  code: CodeComponent,
-  table: TableComponent,
-  img: ImageWithZoom,
-  a: LinkComponent,
-  h1: createHeadingComponent('h1'),
-  h2: createHeadingComponent('h2'),
-  h3: createHeadingComponent('h3'),
-  h4: createHeadingComponent('h4'),
-  h5: createHeadingComponent('h5'),
-  h6: createHeadingComponent('h6'),
-  p: ParagraphWithGlossary,
-}
-
-const lessonSanitizerSchema: RehypeSanitizeOptions = {
-  tagNames: [
-    'a',
-    'blockquote',
-    'br',
-    'code',
-    'del',
-    'details',
-    'div',
-    'em',
-    'h1',
-    'h2',
-    'h3',
-    'h4',
-    'h5',
-    'h6',
-    'hr',
-    'img',
-    'input',
-    'li',
-    'ol',
-    'p',
-    'pre',
-    'span',
-    'strong',
-    'summary',
-    'table',
-    'tbody',
-    'td',
-    'th',
-    'thead',
-    'tr',
-    'ul',
-  ],
-  attributes: {
-    a: ['href', 'title', 'target', 'rel'],
-    code: ['className', 'dataDiff', 'dataHighlightLines'],
-    div: ['className', 'dataCallout'],
-    img: [
-      'src',
-      'alt',
-      'title',
-      'width',
-      'height',
-      'loading',
-      'decoding',
-      'fetchpriority',
-      'fetchPriority',
-    ],
-    input: [
-      ['type', 'checkbox'],
-      ['disabled', true],
-      ['checked', true],
-    ],
-    span: ['className', 'dataDefinition'],
-    td: ['align'],
-    th: ['align'],
-    '*': ['id'],
-  },
-  protocols: {
-    href: ['http', 'https', 'mailto'],
-    src: ['http', 'https'],
-  },
-}
-
-const rehypePlugins: NonNullable<ComponentProps<typeof ReactMarkdown>['rehypePlugins']> = [
-  rehypeRaw,
-  [rehypeSanitize, lessonSanitizerSchema],
-  rehypeSlugCustom,
-  rehypeKatex,
-]
-
-const remarkPlugins = [remarkGfm, remarkMath, remarkCallouts, remarkCodeMeta]
 
 function InteractiveContent({
   content,

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -270,8 +270,7 @@ function findInteractiveBlocks(content: string): InteractiveBlock[] {
           break
         }
       }
-      const closingNode =
-        closingNodeIndex >= 0 ? sectionNodes[closingNodeIndex]! : detailsStartNode
+      const closingNode = closingNodeIndex >= 0 ? sectionNodes[closingNodeIndex]! : detailsStartNode
       const start = getNodeStartOffset(detailsStartNode)
       const end = getNodeEndOffset(closingNode)
       if (start !== null && end !== null) {

--- a/src/components/MasteryCheck.tsx
+++ b/src/components/MasteryCheck.tsx
@@ -13,6 +13,7 @@
 
 import { useState, useId } from 'react'
 import CodePlayground from './CodePlayground'
+import { MarkdownFragment } from './MarkdownFragment'
 import { buildFAQSchema } from '../utils/seoSchemas'
 import { useMasteryStore, type MasteryStatus } from '../stores/masteryStore'
 
@@ -88,7 +89,7 @@ export default function MasteryCheck({
       </div>
 
       <div className="mastery-check__question">
-        {questionText.split('\n').map((line, i) => (line.trim() ? <p key={i}>{line}</p> : null))}
+        <MarkdownFragment content={questionText} />
       </div>
 
       {hasRunnableCode && (
@@ -125,9 +126,7 @@ export default function MasteryCheck({
         >
           <div className="mastery-check__answer-label">Answer</div>
           <div className="mastery-check__answer-body">
-            {answer.split('\n').map((line, i) => (
-              <p key={i}>{line}</p>
-            ))}
+            <MarkdownFragment content={answer} />
           </div>
 
           <div className="mastery-check__self-assess" role="group" aria-label="Self-assessment">


### PR DESCRIPTION
## Summary

- Phase Milestone Exam questions (and any `MasteryCheck`/`ExerciseWidget` content) were showing raw markdown syntax — `**bold**`, `` `inline code` ``, and fenced code blocks appeared literally instead of rendering, because `MasteryCheck.tsx` and `ExerciseWidget.tsx` rendered their text by naively splitting on `\n` into `<p>` tags rather than parsing markdown.
- Extracted the shared `ReactMarkdown` plugin/component configuration out of `MarkdownRenderer.tsx` into a new `src/components/MarkdownFragment.tsx`, and used the new `<MarkdownFragment>` component in `MasteryCheck` (question text, answer) and `ExerciseWidget` (instructions) so they render bold text, inline code, and code blocks correctly.
- While verifying the fix, found and fixed a related bug: the mastery-check `<details>` hint/answer block was read from only the *first* HTML fragment produced by the markdown parser (which splits raw `<details>` blocks at blank lines), so the "Answer" panel rendered completely empty for every milestone question with a multi-line hint list. Now the full `<details>...</details>` range is reassembled from the raw source before extracting the answer text.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run` — all 696 tests pass (97 files)
- [x] Verified visually with a local dev server + Playwright screenshots: Phase 1 Milestone Exam questions now render bold labels, inline code chips, nested lists, and fenced code blocks correctly, and the "Answer" panel now shows the hint list instead of being empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013zSYZjjnbWzzvMzvY4WH6Z)_