### PR TITLE
Add in-lesson note panel to complete the Notes feature

### DIFF
--- a/src/components/NotePanel.tsx
+++ b/src/components/NotePanel.tsx
@@ -1,0 +1,126 @@
+/**
+ * Note Panel
+ *
+ * In-lesson widget for jotting down a private note tied to the current day.
+ *
+ * Key Responsibilities:
+ * - Show the existing note for this lesson, if any.
+ * - Let the reader create, edit, or delete that note.
+ * - Persist changes via the shared notes store (localStorage-backed),
+ *   so the note also appears on the "My Notes" page.
+ */
+
+import { useCallback, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useNotesStore } from '../stores/notesStore'
+
+interface NotePanelProps {
+  /** The lesson's day token, used as the note's storage key. */
+  day: string
+}
+
+/**
+ * Renders a collapsible note editor for a single lesson.
+ *
+ * @param {NotePanelProps} props - The component properties.
+ * @returns {React.ReactElement} The rendered note panel.
+ */
+export default function NotePanel({ day }: NotePanelProps) {
+  const note = useNotesStore((s) => s.notes[day])
+  const setNote = useNotesStore((s) => s.setNote)
+  const deleteNote = useNotesStore((s) => s.deleteNote)
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(note?.content ?? '')
+
+  const startEditing = useCallback(() => {
+    setDraft(note?.content ?? '')
+    setEditing(true)
+  }, [note])
+
+  const save = useCallback(() => {
+    const trimmed = draft.trim()
+    if (trimmed) setNote(day, trimmed)
+    else deleteNote(day)
+    setEditing(false)
+  }, [day, draft, setNote, deleteNote])
+
+  const cancel = useCallback(() => {
+    setDraft(note?.content ?? '')
+    setEditing(false)
+  }, [note])
+
+  return (
+    <section className="lesson-note-panel glass-card" aria-label="Your note for this lesson">
+      <div className="lesson-note-panel-header">
+        <h2 className="lesson-note-panel-title">
+          <span aria-hidden="true">✎</span> My note
+        </h2>
+        {!editing && !note && (
+          <button
+            type="button"
+            className="note-action-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+            onClick={startEditing}
+          >
+            + Add a note
+          </button>
+        )}
+        {!editing && note && (
+          <div className="note-card-actions">
+            <button
+              type="button"
+              className="note-action-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+              onClick={startEditing}
+              aria-label="Edit note"
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              className="note-action-btn note-action-btn--delete focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+              onClick={() => deleteNote(day)}
+              aria-label="Delete note"
+            >
+              Delete
+            </button>
+          </div>
+        )}
+      </div>
+
+      {editing ? (
+        <div className="note-editor">
+          <textarea
+            className="note-textarea"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            rows={4}
+            autoFocus
+            placeholder="Jot down a thought, question, or reminder about this lesson…"
+            aria-label="Note content"
+          />
+          <div className="note-editor-actions">
+            <button
+              type="button"
+              className="note-save-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+              onClick={save}
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              className="note-cancel-btn focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+              onClick={cancel}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : note ? (
+        <p className="note-content">{note.content}</p>
+      ) : (
+        <p className="lesson-note-panel-hint">
+          Notes are saved on this device and collected on your <Link to="/notes">Notes page</Link>.
+        </p>
+      )}
+    </section>
+  )
+}

--- a/src/components/__tests__/NotePanel.test.tsx
+++ b/src/components/__tests__/NotePanel.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import NotePanel from '../NotePanel'
+import { useNotesStore } from '../../stores/notesStore'
+
+function renderPanel(day = '1') {
+  return render(
+    <MemoryRouter>
+      <NotePanel day={day} />
+    </MemoryRouter>,
+  )
+}
+
+describe('NotePanel', () => {
+  beforeEach(() => {
+    useNotesStore.setState({ notes: {} })
+  })
+
+  it('shows an "Add a note" affordance when no note exists', () => {
+    renderPanel()
+    expect(screen.getByRole('button', { name: '+ Add a note' })).toBeInTheDocument()
+    expect(screen.queryByLabelText('Edit note')).not.toBeInTheDocument()
+  })
+
+  it('creates a note and persists it in the store', () => {
+    renderPanel('1')
+    fireEvent.click(screen.getByRole('button', { name: '+ Add a note' }))
+
+    const textarea = screen.getByLabelText('Note content')
+    fireEvent.change(textarea, { target: { value: 'Remember to review loops.' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(screen.getByText('Remember to review loops.')).toBeInTheDocument()
+    expect(useNotesStore.getState().notes['1']?.content).toBe('Remember to review loops.')
+  })
+
+  it('edits an existing note', () => {
+    useNotesStore.getState().setNote('1', 'Original note')
+    renderPanel('1')
+
+    fireEvent.click(screen.getByLabelText('Edit note'))
+    const textarea = screen.getByLabelText('Note content')
+    fireEvent.change(textarea, { target: { value: 'Updated note' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(screen.getByText('Updated note')).toBeInTheDocument()
+    expect(useNotesStore.getState().notes['1']?.content).toBe('Updated note')
+  })
+
+  it('deletes a note', () => {
+    useNotesStore.getState().setNote('1', 'To be deleted')
+    renderPanel('1')
+
+    fireEvent.click(screen.getByLabelText('Delete note'))
+
+    expect(screen.queryByText('To be deleted')).not.toBeInTheDocument()
+    expect(useNotesStore.getState().notes['1']).toBeUndefined()
+    expect(screen.getByRole('button', { name: '+ Add a note' })).toBeInTheDocument()
+  })
+
+  it('discards changes on cancel', () => {
+    useNotesStore.getState().setNote('1', 'Keep me')
+    renderPanel('1')
+
+    fireEvent.click(screen.getByLabelText('Edit note'))
+    fireEvent.change(screen.getByLabelText('Note content'), { target: { value: 'Discarded' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.getByText('Keep me')).toBeInTheDocument()
+    expect(useNotesStore.getState().notes['1']?.content).toBe('Keep me')
+  })
+
+  it('saving an empty note deletes it', () => {
+    useNotesStore.getState().setNote('1', 'Keep me')
+    renderPanel('1')
+
+    fireEvent.click(screen.getByLabelText('Edit note'))
+    fireEvent.change(screen.getByLabelText('Note content'), { target: { value: '   ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(useNotesStore.getState().notes['1']).toBeUndefined()
+  })
+})

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -47,6 +47,7 @@ import LessonSearch from '../components/LessonSearch'
 import PrerequisitePills from '../components/PrerequisitePills'
 import LessonCodeActions from '../components/LessonCodeActions'
 import RelatedLessons from '../components/RelatedLessons'
+import NotePanel from '../components/NotePanel'
 import { toastInfo, toastSuccess } from '../utils/toast'
 import { isTypingInEditableElement } from '../utils/shortcuts'
 import { useGamificationStore } from '../stores/gamificationStore'
@@ -397,6 +398,7 @@ export default function Lesson() {
         </nav>
 
         <div className={showSecondaryUi ? '' : 'reading-muted'}>
+          <NotePanel day={String(lesson.day)} />
           <RelatedLessons lesson={lesson} />
         </div>
 

--- a/src/pages/__tests__/Lesson.test.tsx
+++ b/src/pages/__tests__/Lesson.test.tsx
@@ -118,6 +118,27 @@ describe('Lesson completion toasts', () => {
     mockGetLessonStats.mockReturnValue({ gotIt: 0, reviewAgain: 0, total: 0 })
   })
 
+  it('renders the note panel for the current lesson', async () => {
+    const { useNotesStore } = await import('../../stores/notesStore')
+    useNotesStore.setState({ notes: {} })
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(<Lesson />)
+    })
+
+    expect(container.querySelector('.lesson-note-panel')).toBeTruthy()
+    expect(container.textContent).toContain('Add a note')
+
+    await act(async () => {
+      root.unmount()
+    })
+    document.body.removeChild(container)
+  })
+
   it('toggles reading mode via the preferences store and click', async () => {
     // Arrange
     const { useUserPreferencesStore } = await import('../../stores/userPreferencesStore')

--- a/src/styles/lesson.css
+++ b/src/styles/lesson.css
@@ -239,6 +239,46 @@
   color: var(--border-card);
 }
 
+/* --- In-lesson note panel --- */
+
+.lesson-note-panel {
+  margin-top: 3rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: var(--radius-lg);
+}
+
+.lesson-note-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.lesson-note-panel-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.lesson-note-panel-hint {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin: 0.75rem 0 0;
+}
+
+.lesson-note-panel .note-content,
+.lesson-note-panel .note-editor {
+  margin-top: 0.75rem;
+}
+
 /* --- Lesson nav (prev/next) --- */
 
 .lesson-nav {


### PR DESCRIPTION
## Summary

- The Notes feature was already reachable from both the desktop navbar/sidebar and the mobile bottom nav, and the `/notes` page could view, edit, and delete existing notes — but there was no way to actually *create* a note. The `/notes` empty state referenced an in-lesson "note panel" that didn't exist anywhere in the codebase.
- Adds a new `NotePanel` component, rendered on the `Lesson` page, that lets readers add, edit, and delete a note for the current day inline. It's backed by the existing `notesStore` (localStorage-persisted zustand store), so notes created there immediately show up on the `/notes` page.
- Styled with the existing `.note-*` classes from `progress.css` for visual consistency with the Notes page, plus a small set of new panel-specific rules in `lesson.css`.

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run` (703 tests, all passing, including new `NotePanel.test.tsx` and an added Lesson integration test)
- [x] Manually verified in a browser (desktop 1280px and mobile 390px viewports): add/edit/delete a note from a lesson page, confirmed it appears on `/notes`, and confirmed Notes is reachable from the desktop navbar/sidebar and the mobile bottom nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MQVp44BTx9TSTrCRRaWRqV)_