### PR TITLE
Add SessionStart hook to install graphify and node modules

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web / remote environments.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+if ! command -v graphify >/dev/null 2>&1; then
+  pip install graphifyy -q
+fi
+
+npm install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Summary
- Add `.claude/hooks/session-start.sh`, a `SessionStart` hook that runs automatically at the start of each Claude Code on the web session in this repo.
- The hook installs the `graphify` CLI (via `pip install graphifyy`, skipped if already on `PATH`) and runs `npm install` so both the knowledge-graph tooling and the app's dev/lint/test scripts work without manual setup.
- Register the hook in `.claude/settings.json` alongside the existing `PreToolUse` hook config.
- The hook only runs in remote/web sessions (`CLAUDE_CODE_REMOTE=true`) and runs synchronously, so dependencies are guaranteed to be ready before the agent starts working.

## Test plan
- [x] Ran the hook directly (`CLAUDE_CODE_REMOTE=true ./.claude/hooks/session-start.sh`) and confirmed `graphify --version` resolves and `node_modules` is populated (844 packages).
- [x] Ran `npm run typecheck` (the project's lint command) — passes with no errors.
- [x] Ran a sample test (`npx vitest run src/utils/__tests__/slug.test.ts`) — 6/6 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F9bz6JaAtdruMqmT32ESST)_