### PR TITLE
⚡ Bolt: Add route prefetching to internal links

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2024-07-04 - [Manual Route Prefetching Omissions]
-**Learning:** The codebase relies on a custom manual prefetching mechanism (`createRoutePrefetchHandlers` in `prefetchRoutes.ts`) to preemptively load Vite code splits for routes. While properly implemented in `Navbar`, it was omitted in many core content navigation elements (`Sidebar`, `Curriculum`, `Home`, `Lesson` pagination, etc.), leading to delayed chunk loading on interaction.
-**Action:** Always ensure that new `react-router-dom` `<Link>` components in this codebase are wrapped with `{...createRoutePrefetchHandlers(to)}` to leverage the custom prefetching architecture and eliminate perceived loading delays.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-04 - [Manual Route Prefetching Omissions]
+**Learning:** The codebase relies on a custom manual prefetching mechanism (`createRoutePrefetchHandlers` in `prefetchRoutes.ts`) to preemptively load Vite code splits for routes. While properly implemented in `Navbar`, it was omitted in many core content navigation elements (`Sidebar`, `Curriculum`, `Home`, `Lesson` pagination, etc.), leading to delayed chunk loading on interaction.
+**Action:** Always ensure that new `react-router-dom` `<Link>` components in this codebase are wrapped with `{...createRoutePrefetchHandlers(to)}` to leverage the custom prefetching architecture and eliminate perceived loading delays.

--- a/fix_prefetch.cjs
+++ b/fix_prefetch.cjs
@@ -1,0 +1,54 @@
+const fs = require('fs')
+
+function updateSidebar() {
+  const file = 'src/components/Sidebar.tsx'
+  let content = fs.readFileSync(file, 'utf8')
+
+  // Add import if not exists
+  if (!content.includes('createRoutePrefetchHandlers')) {
+    content = content.replace(
+      "import SidebarPhaseGroup from './SidebarPhaseGroup'",
+      "import SidebarPhaseGroup from './SidebarPhaseGroup'\nimport { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'"
+    )
+  }
+
+  content = content.replace(
+    'aria-current={active ? \'page\' : undefined}',
+    'aria-current={active ? \'page\' : undefined}\n      {...createRoutePrefetchHandlers(to)}'
+  )
+
+  content = content.replace(
+    '<Link to="/" className="sidebar-brand" onClick={onClose}>',
+    '<Link to="/" className="sidebar-brand" onClick={onClose} {...createRoutePrefetchHandlers(\'/\')}>'
+  )
+
+  fs.writeFileSync(file, content)
+}
+
+function updateSidebarPhaseGroup() {
+  const file = 'src/components/SidebarPhaseGroup.tsx'
+  let content = fs.readFileSync(file, 'utf8')
+
+  if (!content.includes('createRoutePrefetchHandlers')) {
+    content = content.replace(
+      "import { dayTokenToProgressId } from '../utils/dayToken'",
+      "import { dayTokenToProgressId } from '../utils/dayToken'\nimport { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'"
+    )
+  }
+
+  content = content.replace(
+    'aria-current={currentPath === `/phase/${phase.phase}` ? \'page\' : undefined}',
+    'aria-current={currentPath === `/phase/${phase.phase}` ? \'page\' : undefined}\n                {...createRoutePrefetchHandlers(`/phase/${phase.phase}`)}'
+  )
+
+  content = content.replace(
+    'aria-current={currentPath === `/lesson/${lesson.day}` ? \'page\' : undefined}',
+    'aria-current={currentPath === `/lesson/${lesson.day}` ? \'page\' : undefined}\n                  {...createRoutePrefetchHandlers(`/lesson/${lesson.day}`)}'
+  )
+
+  fs.writeFileSync(file, content)
+}
+
+updateSidebar()
+updateSidebarPhaseGroup()
+console.log('updated')

--- a/fix_prefetch2.cjs
+++ b/fix_prefetch2.cjs
@@ -1,0 +1,59 @@
+const fs = require('fs')
+
+function updateExercises() {
+  const file = 'src/pages/Exercises.tsx'
+  let content = fs.readFileSync(file, 'utf8')
+
+  // Add import if not exists
+  if (!content.includes('createRoutePrefetchHandlers')) {
+    content = content.replace(
+      "import { Link } from 'react-router-dom'",
+      "import { Link } from 'react-router-dom'\nimport { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'"
+    )
+  }
+
+  content = content.replace(
+    '<Link key={p} to={`/solutions/${p}`} className="exercises-notebook-link">',
+    '<Link key={p} to={`/solutions/${p}`} className="exercises-notebook-link" {...createRoutePrefetchHandlers(`/solutions/${p}`)}>'
+  )
+
+  fs.writeFileSync(file, content)
+}
+
+function updateHome() {
+  const file = 'src/pages/Home.tsx'
+  let content = fs.readFileSync(file, 'utf8')
+
+  if (!content.includes('createRoutePrefetchHandlers')) {
+    content = content.replace(
+      "import { Link } from 'react-router-dom'",
+      "import { Link } from 'react-router-dom'\nimport { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'"
+    )
+  }
+
+  content = content.replace(
+    '<Link to={`/phase/${phase.phase}`} className="phase-card-editorial" key={phase.phase}>',
+    '<Link to={`/phase/${phase.phase}`} className="phase-card-editorial" key={phase.phase} {...createRoutePrefetchHandlers(`/phase/${phase.phase}`)}>'
+  )
+
+  content = content.replace(
+    '<Link\n            to={lastVisitedLesson ? `/lesson/${lastVisitedLesson.day}` : \'/lesson/1\'}\n            className="action-primary"\n          >',
+    '<Link\n            to={lastVisitedLesson ? `/lesson/${lastVisitedLesson.day}` : \'/lesson/1\'}\n            className="action-primary"\n            {...createRoutePrefetchHandlers(lastVisitedLesson ? `/lesson/${lastVisitedLesson.day}` : \'/lesson/1\')}\n          >'
+  )
+
+  content = content.replace(
+    '<Link to="/curriculum" className="action-secondary">',
+    '<Link to="/curriculum" className="action-secondary" {...createRoutePrefetchHandlers(\'/curriculum\')}>'
+  )
+
+  content = content.replace(
+    '<Link to={`/lesson/${lastVisitedLesson.day}`} className="dashboard-tile-link">',
+    '<Link to={`/lesson/${lastVisitedLesson.day}`} className="dashboard-tile-link" {...createRoutePrefetchHandlers(`/lesson/${lastVisitedLesson.day}`)}>'
+  )
+
+  fs.writeFileSync(file, content)
+}
+
+updateExercises()
+updateHome()
+console.log('updated')

--- a/fix_remaining.cjs
+++ b/fix_remaining.cjs
@@ -1,0 +1,26 @@
+const fs = require('fs')
+
+function updateCurriculum() {
+  const file = 'src/pages/Curriculum.tsx'
+  let content = fs.readFileSync(file, 'utf8')
+
+  if (!content.includes('createRoutePrefetchHandlers')) {
+    content = content.replace(
+      "import { Link } from 'react-router-dom'",
+      "import { Link } from 'react-router-dom'\nimport { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'"
+    )
+  }
+
+  content = content.replace(
+    '<Link to={`/phase/${phase.phase}`} className="curriculum-phase-header">',
+    '<Link to={`/phase/${phase.phase}`} className="curriculum-phase-header" {...createRoutePrefetchHandlers(`/phase/${phase.phase}`)}>'
+  )
+
+  content = content.replace(
+    '<Link\n                      to={`/lesson/${lesson.day}`}\n                      className={`curriculum-day-link ${isDone ? \'curriculum-day-link--done\' : \'\'}`}\n                    >',
+    '<Link\n                      to={`/lesson/${lesson.day}`}\n                      className={`curriculum-day-link ${isDone ? \'curriculum-day-link--done\' : \'\'}`}\n                      {...createRoutePrefetchHandlers(`/lesson/${lesson.day}`)}\n                    >'
+  )
+  fs.writeFileSync(file, content)
+}
+updateCurriculum()
+console.log('done')

--- a/fix_remaining2.cjs
+++ b/fix_remaining2.cjs
@@ -1,0 +1,27 @@
+const fs = require('fs')
+
+function updateProgressDashboard() {
+  const file = 'src/pages/ProgressDashboard.tsx'
+  let content = fs.readFileSync(file, 'utf8')
+
+  if (!content.includes('createRoutePrefetchHandlers')) {
+    content = content.replace(
+      "import { Link } from 'react-router-dom'",
+      "import { Link } from 'react-router-dom'\nimport { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'"
+    )
+  }
+
+  content = content.replace(
+    '<Link className="continue-banner-cta" to={`/lesson/${challengeLesson.day}`}>',
+    '<Link className="continue-banner-cta" to={`/lesson/${challengeLesson.day}`} {...createRoutePrefetchHandlers(`/lesson/${challengeLesson.day}`)}>'
+  )
+
+  content = content.replace(
+    '<Link to={`/lesson/${lesson.day}`} className="mastery-review-link">',
+    '<Link to={`/lesson/${lesson.day}`} className="mastery-review-link" {...createRoutePrefetchHandlers(`/lesson/${lesson.day}`)}>'
+  )
+
+  fs.writeFileSync(file, content)
+}
+updateProgressDashboard()
+console.log('done')

--- a/fix_remaining3.cjs
+++ b/fix_remaining3.cjs
@@ -1,0 +1,27 @@
+const fs = require('fs')
+
+function updatePhaseOverview() {
+  const file = 'src/pages/PhaseOverview.tsx'
+  let content = fs.readFileSync(file, 'utf8')
+
+  if (!content.includes('createRoutePrefetchHandlers')) {
+    content = content.replace(
+      "import { useParams, Link } from 'react-router-dom'",
+      "import { useParams, Link } from 'react-router-dom'\nimport { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'"
+    )
+  }
+
+  content = content.replace(
+    '<Link to={`/solutions/${phaseNum}`} className="phase-notebooks-link">',
+    '<Link to={`/solutions/${phaseNum}`} className="phase-notebooks-link" {...createRoutePrefetchHandlers(`/solutions/${phaseNum}`)}>'
+  )
+
+  content = content.replace(
+    '<Link\n                    to={`/lesson/${lesson.day}`}\n                    className={`phase-day-link ${isCompleted ? \'phase-day-link--done\' : \'\'}`}\n                  >',
+    '<Link\n                    to={`/lesson/${lesson.day}`}\n                    className={`phase-day-link ${isCompleted ? \'phase-day-link--done\' : \'\'}`}\n                    {...createRoutePrefetchHandlers(`/lesson/${lesson.day}`)}\n                  >'
+  )
+
+  fs.writeFileSync(file, content)
+}
+updatePhaseOverview()
+console.log('done')

--- a/fix_remaining4.cjs
+++ b/fix_remaining4.cjs
@@ -1,0 +1,27 @@
+const fs = require('fs')
+
+function updateLesson() {
+  const file = 'src/pages/Lesson.tsx'
+  let content = fs.readFileSync(file, 'utf8')
+
+  if (!content.includes('createRoutePrefetchHandlers')) {
+    content = content.replace(
+      "import { useParams, Link, useNavigate } from 'react-router-dom'",
+      "import { useParams, Link, useNavigate } from 'react-router-dom'\nimport { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'"
+    )
+  }
+
+  content = content.replace(
+    '<Link to={`/lesson/${prev.day}`} className="lesson-nav-btn prev">',
+    '<Link to={`/lesson/${prev.day}`} className="lesson-nav-btn prev" {...createRoutePrefetchHandlers(`/lesson/${prev.day}`)}>'
+  )
+
+  content = content.replace(
+    '<Link to={`/lesson/${next.day}`} className="lesson-nav-btn next">',
+    '<Link to={`/lesson/${next.day}`} className="lesson-nav-btn next" {...createRoutePrefetchHandlers(`/lesson/${next.day}`)}>'
+  )
+
+  fs.writeFileSync(file, content)
+}
+updateLesson()
+console.log('done')

--- a/fix_remaining5.cjs
+++ b/fix_remaining5.cjs
@@ -1,0 +1,16 @@
+const fs = require('fs')
+
+function updatePhaseOverview2() {
+  const file = 'src/pages/PhaseOverview.tsx'
+  let content = fs.readFileSync(file, 'utf8')
+
+  // Actually, PhaseOverview might already have those handlers or something failed in replacement.
+  content = content.replace(
+    'import { createRoutePrefetchHandlers } from \'../utils/prefetchRoutes\'\n',
+    ''
+  )
+
+  fs.writeFileSync(file, content)
+}
+updatePhaseOverview2()
+console.log('done')

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -131,7 +131,12 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
         aria-label="Lesson navigation"
       >
         <div className="sidebar-header">
-          <Link to="/" className="sidebar-brand" onClick={onClose} {...createRoutePrefetchHandlers('/')}>
+          <Link
+            to="/"
+            className="sidebar-brand"
+            onClick={onClose}
+            {...createRoutePrefetchHandlers('/')}
+          >
             <span className="sidebar-brand-mark" aria-hidden="true">
               C/M
             </span>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -13,6 +13,7 @@ import { getReviewDueCountByPhase, getReviewStreak } from '../utils/reviewTracke
 import { normalizeDayToken, dayTokenToProgressId } from '../utils/dayToken'
 import { useProgressStore } from '../stores/progressStore'
 import SidebarPhaseGroup from './SidebarPhaseGroup'
+import { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'
 
 interface SidebarProps {
   isOpen: boolean
@@ -34,6 +35,7 @@ function PrimaryItem({ to, active, glyph, label, onClick }: PrimaryItemProps) {
       className={`tree-item tree-item--primary ${active ? 'active' : ''}`}
       onClick={onClick}
       aria-current={active ? 'page' : undefined}
+      {...createRoutePrefetchHandlers(to)}
     >
       <span className="tree-glyph" aria-hidden="true">
         {glyph}
@@ -129,7 +131,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
         aria-label="Lesson navigation"
       >
         <div className="sidebar-header">
-          <Link to="/" className="sidebar-brand" onClick={onClose}>
+          <Link to="/" className="sidebar-brand" onClick={onClose} {...createRoutePrefetchHandlers('/')}>
             <span className="sidebar-brand-mark" aria-hidden="true">
               C/M
             </span>

--- a/src/components/SidebarPhaseGroup.tsx
+++ b/src/components/SidebarPhaseGroup.tsx
@@ -11,6 +11,7 @@ import { Link } from 'react-router-dom'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { getLessonsByPhase, getLesson, type Phase } from '../utils/contentLoader'
 import { dayTokenToProgressId } from '../utils/dayToken'
+import { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'
 
 interface SidebarPhaseGroupProps {
   phase: Phase
@@ -106,6 +107,7 @@ function SidebarPhaseGroup({
                 className={`day-link day-link--overview ${currentPath === `/phase/${phase.phase}` ? 'active' : ''}`}
                 onClick={onClose}
                 aria-current={currentPath === `/phase/${phase.phase}` ? 'page' : undefined}
+                {...createRoutePrefetchHandlers(`/phase/${phase.phase}`)}
               >
                 <span className="day-link-prefix" aria-hidden="true">
                   ▸
@@ -128,6 +130,7 @@ function SidebarPhaseGroup({
                   className={`day-link ${currentPath === `/lesson/${lesson.day}` ? 'active' : ''}`}
                   onClick={onClose}
                   aria-current={currentPath === `/lesson/${lesson.day}` ? 'page' : undefined}
+                  {...createRoutePrefetchHandlers(`/lesson/${lesson.day}`)}
                 >
                   <span
                     className={`day-link-prefix ${completedSet.has(dayTokenToProgressId(lesson.day)) ? 'completed' : ''}`}

--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -201,7 +201,11 @@ export default function Curriculum() {
             variants={phaseVariants}
             transition={{ duration: prefersReducedMotion ? 0 : 0.28 }}
           >
-            <Link to={`/phase/${phase.phase}`} className="curriculum-phase-header" {...createRoutePrefetchHandlers(`/phase/${phase.phase}`)}>
+            <Link
+              to={`/phase/${phase.phase}`}
+              className="curriculum-phase-header"
+              {...createRoutePrefetchHandlers(`/phase/${phase.phase}`)}
+            >
               <span className="curriculum-phase-num display-numeral" aria-hidden="true">
                 {phase.phaseLabel}
               </span>

--- a/src/pages/Curriculum.tsx
+++ b/src/pages/Curriculum.tsx
@@ -11,6 +11,7 @@
 
 import { useRef, useMemo } from 'react'
 import { Link } from 'react-router-dom'
+import { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'
 import { motion, useReducedMotion, useScroll, useTransform } from 'motion/react'
 import SEOHead from '../components/SEOHead'
 import { buildItemListSchema, buildProductSchema } from '../utils/seoSchemas'
@@ -200,7 +201,7 @@ export default function Curriculum() {
             variants={phaseVariants}
             transition={{ duration: prefersReducedMotion ? 0 : 0.28 }}
           >
-            <Link to={`/phase/${phase.phase}`} className="curriculum-phase-header">
+            <Link to={`/phase/${phase.phase}`} className="curriculum-phase-header" {...createRoutePrefetchHandlers(`/phase/${phase.phase}`)}>
               <span className="curriculum-phase-num display-numeral" aria-hidden="true">
                 {phase.phaseLabel}
               </span>
@@ -258,6 +259,7 @@ export default function Curriculum() {
                     <Link
                       to={`/lesson/${lesson.day}`}
                       className={`curriculum-day-link ${isDone ? 'curriculum-day-link--done' : ''}`}
+                      {...createRoutePrefetchHandlers(`/lesson/${lesson.day}`)}
                     >
                       <span className="curriculum-day-marker" aria-hidden="true">
                         {isDone ? '✓' : String(index + 1).padStart(2, '0')}

--- a/src/pages/Exercises.tsx
+++ b/src/pages/Exercises.tsx
@@ -135,7 +135,12 @@ export default function Exercises() {
             const icon = phaseIcons[p - 1] || '📖'
             const hasNotebook = notebookPhases.has(p)
             return hasNotebook ? (
-              <Link key={p} to={`/solutions/${p}`} className="exercises-notebook-link" {...createRoutePrefetchHandlers(`/solutions/${p}`)}>
+              <Link
+                key={p}
+                to={`/solutions/${p}`}
+                className="exercises-notebook-link"
+                {...createRoutePrefetchHandlers(`/solutions/${p}`)}
+              >
                 <span aria-hidden="true">{icon}</span> Phase {p} Solutions
               </Link>
             ) : null

--- a/src/pages/Exercises.tsx
+++ b/src/pages/Exercises.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useMemo } from 'react'
 import { Link } from 'react-router-dom'
+import { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'
 import { motion } from 'motion/react'
 import { ExercisesEmptyIllustration } from '../components/EmptyStateIllustrations'
 import SEOHead from '../components/SEOHead'
@@ -134,7 +135,7 @@ export default function Exercises() {
             const icon = phaseIcons[p - 1] || '📖'
             const hasNotebook = notebookPhases.has(p)
             return hasNotebook ? (
-              <Link key={p} to={`/solutions/${p}`} className="exercises-notebook-link">
+              <Link key={p} to={`/solutions/${p}`} className="exercises-notebook-link" {...createRoutePrefetchHandlers(`/solutions/${p}`)}>
                 <span aria-hidden="true">{icon}</span> Phase {p} Solutions
               </Link>
             ) : null

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,6 +12,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'
 import SEOHead from '../components/SEOHead'
 import { buildWebSiteSchema, buildCourseSchema, buildProductSchema } from '../utils/seoSchemas'
 import {
@@ -119,7 +120,7 @@ export default function Home() {
         const phasePct = Math.round((completedInPhase / Math.max(1, lessons.length)) * 100)
 
         return (
-          <Link to={`/phase/${phase.phase}`} className="phase-card-editorial" key={phase.phase}>
+          <Link to={`/phase/${phase.phase}`} className="phase-card-editorial" key={phase.phase} {...createRoutePrefetchHandlers(`/phase/${phase.phase}`)}>
             <div className="phase-card-numeral display-numeral" aria-hidden="true">
               {pad(phase.phase)}
             </div>
@@ -205,13 +206,14 @@ export default function Home() {
           <Link
             to={lastVisitedLesson ? `/lesson/${lastVisitedLesson.day}` : '/lesson/1'}
             className="action-primary"
+            {...createRoutePrefetchHandlers(lastVisitedLesson ? `/lesson/${lastVisitedLesson.day}` : '/lesson/1')}
           >
             <span className="action-glyph" aria-hidden="true">
               ›
             </span>
             {lastVisitedLesson ? `Resume Day ${lastVisitedLesson.day}` : 'Begin Day 01'}
           </Link>
-          <Link to="/curriculum" className="action-secondary">
+          <Link to="/curriculum" className="action-secondary" {...createRoutePrefetchHandlers('/curriculum')}>
             See the full curriculum
           </Link>
         </EditorialCover.Actions>
@@ -224,7 +226,7 @@ export default function Home() {
           <TerminalDashboard.TileHeader label="LAST OPEN" symbol="·" />
           <TerminalDashboard.TileValue>
             {lastVisitedLesson ? (
-              <Link to={`/lesson/${lastVisitedLesson.day}`} className="dashboard-tile-link">
+              <Link to={`/lesson/${lastVisitedLesson.day}`} className="dashboard-tile-link" {...createRoutePrefetchHandlers(`/lesson/${lastVisitedLesson.day}`)}>
                 Day {lastVisitedLesson.day}
               </Link>
             ) : (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -120,7 +120,12 @@ export default function Home() {
         const phasePct = Math.round((completedInPhase / Math.max(1, lessons.length)) * 100)
 
         return (
-          <Link to={`/phase/${phase.phase}`} className="phase-card-editorial" key={phase.phase} {...createRoutePrefetchHandlers(`/phase/${phase.phase}`)}>
+          <Link
+            to={`/phase/${phase.phase}`}
+            className="phase-card-editorial"
+            key={phase.phase}
+            {...createRoutePrefetchHandlers(`/phase/${phase.phase}`)}
+          >
             <div className="phase-card-numeral display-numeral" aria-hidden="true">
               {pad(phase.phase)}
             </div>
@@ -206,14 +211,20 @@ export default function Home() {
           <Link
             to={lastVisitedLesson ? `/lesson/${lastVisitedLesson.day}` : '/lesson/1'}
             className="action-primary"
-            {...createRoutePrefetchHandlers(lastVisitedLesson ? `/lesson/${lastVisitedLesson.day}` : '/lesson/1')}
+            {...createRoutePrefetchHandlers(
+              lastVisitedLesson ? `/lesson/${lastVisitedLesson.day}` : '/lesson/1',
+            )}
           >
             <span className="action-glyph" aria-hidden="true">
               ›
             </span>
             {lastVisitedLesson ? `Resume Day ${lastVisitedLesson.day}` : 'Begin Day 01'}
           </Link>
-          <Link to="/curriculum" className="action-secondary" {...createRoutePrefetchHandlers('/curriculum')}>
+          <Link
+            to="/curriculum"
+            className="action-secondary"
+            {...createRoutePrefetchHandlers('/curriculum')}
+          >
             See the full curriculum
           </Link>
         </EditorialCover.Actions>
@@ -226,7 +237,11 @@ export default function Home() {
           <TerminalDashboard.TileHeader label="LAST OPEN" symbol="·" />
           <TerminalDashboard.TileValue>
             {lastVisitedLesson ? (
-              <Link to={`/lesson/${lastVisitedLesson.day}`} className="dashboard-tile-link" {...createRoutePrefetchHandlers(`/lesson/${lastVisitedLesson.day}`)}>
+              <Link
+                to={`/lesson/${lastVisitedLesson.day}`}
+                className="dashboard-tile-link"
+                {...createRoutePrefetchHandlers(`/lesson/${lastVisitedLesson.day}`)}
+              >
                 Day {lastVisitedLesson.day}
               </Link>
             ) : (

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
+import { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'
 import SEOHead from '../components/SEOHead'
 import EditorialLessonHeader from '../components/EditorialLessonHeader'
 /**
@@ -380,7 +381,7 @@ export default function Lesson() {
         {/* Prev/Next navigation */}
         <nav className="lesson-nav" aria-label="Lesson navigation">
           {prev && (
-            <Link to={`/lesson/${prev.day}`} className="lesson-nav-btn prev">
+            <Link to={`/lesson/${prev.day}`} className="lesson-nav-btn prev" {...createRoutePrefetchHandlers(`/lesson/${prev.day}`)}>
               <span className="lesson-nav-label">← Previous</span>
               <span className="lesson-nav-title">
                 Day {prev.day}: {prev.title}
@@ -388,7 +389,7 @@ export default function Lesson() {
             </Link>
           )}
           {next && (
-            <Link to={`/lesson/${next.day}`} className="lesson-nav-btn next">
+            <Link to={`/lesson/${next.day}`} className="lesson-nav-btn next" {...createRoutePrefetchHandlers(`/lesson/${next.day}`)}>
               <span className="lesson-nav-label">Next →</span>
               <span className="lesson-nav-title">
                 Day {next.day}: {next.title}

--- a/src/pages/Lesson.tsx
+++ b/src/pages/Lesson.tsx
@@ -381,7 +381,11 @@ export default function Lesson() {
         {/* Prev/Next navigation */}
         <nav className="lesson-nav" aria-label="Lesson navigation">
           {prev && (
-            <Link to={`/lesson/${prev.day}`} className="lesson-nav-btn prev" {...createRoutePrefetchHandlers(`/lesson/${prev.day}`)}>
+            <Link
+              to={`/lesson/${prev.day}`}
+              className="lesson-nav-btn prev"
+              {...createRoutePrefetchHandlers(`/lesson/${prev.day}`)}
+            >
               <span className="lesson-nav-label">← Previous</span>
               <span className="lesson-nav-title">
                 Day {prev.day}: {prev.title}
@@ -389,7 +393,11 @@ export default function Lesson() {
             </Link>
           )}
           {next && (
-            <Link to={`/lesson/${next.day}`} className="lesson-nav-btn next" {...createRoutePrefetchHandlers(`/lesson/${next.day}`)}>
+            <Link
+              to={`/lesson/${next.day}`}
+              className="lesson-nav-btn next"
+              {...createRoutePrefetchHandlers(`/lesson/${next.day}`)}
+            >
               <span className="lesson-nav-label">Next →</span>
               <span className="lesson-nav-title">
                 Day {next.day}: {next.title}

--- a/src/pages/PhaseOverview.tsx
+++ b/src/pages/PhaseOverview.tsx
@@ -10,6 +10,7 @@
  */
 
 import { useParams, Link } from 'react-router-dom'
+import { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'
 import { motion, useReducedMotion } from 'motion/react'
 import { useMemo } from 'react'
 import SEOHead from '../components/SEOHead'
@@ -91,6 +92,7 @@ export default function PhaseOverview() {
             <Link
               to={`/lesson/${lesson.day}`}
               className={`lesson-row ${isDone ? 'lesson-row--done' : ''}`}
+              {...createRoutePrefetchHandlers(`/lesson/${lesson.day}`)}
             >
               <span className="lesson-row-marker" aria-hidden="true">
                 {isDone ? '✓' : String(index + 1).padStart(2, '0')}
@@ -208,7 +210,7 @@ export default function PhaseOverview() {
               Complete reference solutions with explanations — run them in your browser.
             </p>
           </header>
-          <Link to={`/solutions/${phase.phase}`} className="action-secondary">
+          <Link to={`/solutions/${phase.phase}`} className="action-secondary" {...createRoutePrefetchHandlers(`/solutions/${phase.phase}`)}>
             Open Phase {phase.phase} solutions
             <span aria-hidden="true">→</span>
           </Link>

--- a/src/pages/PhaseOverview.tsx
+++ b/src/pages/PhaseOverview.tsx
@@ -210,7 +210,11 @@ export default function PhaseOverview() {
               Complete reference solutions with explanations — run them in your browser.
             </p>
           </header>
-          <Link to={`/solutions/${phase.phase}`} className="action-secondary" {...createRoutePrefetchHandlers(`/solutions/${phase.phase}`)}>
+          <Link
+            to={`/solutions/${phase.phase}`}
+            className="action-secondary"
+            {...createRoutePrefetchHandlers(`/solutions/${phase.phase}`)}
+          >
             Open Phase {phase.phase} solutions
             <span aria-hidden="true">→</span>
           </Link>

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -309,7 +309,11 @@ export default function ProgressDashboard() {
                 Day {challengeLesson.day}: {challengeLesson.title}
               </p>
             </div>
-            <Link className="continue-banner-cta" to={`/lesson/${challengeLesson.day}`} {...createRoutePrefetchHandlers(`/lesson/${challengeLesson.day}`)}>
+            <Link
+              className="continue-banner-cta"
+              to={`/lesson/${challengeLesson.day}`}
+              {...createRoutePrefetchHandlers(`/lesson/${challengeLesson.day}`)}
+            >
               Start challenge
             </Link>
           </div>
@@ -408,7 +412,11 @@ export default function ProgressDashboard() {
           <ul className="mastery-review-list">
             {reviewLessons.map(({ lesson, reviewCount }) => (
               <li className="mastery-review-row" key={lesson.day}>
-                <Link to={`/lesson/${lesson.day}`} className="mastery-review-link" {...createRoutePrefetchHandlers(`/lesson/${lesson.day}`)}>
+                <Link
+                  to={`/lesson/${lesson.day}`}
+                  className="mastery-review-link"
+                  {...createRoutePrefetchHandlers(`/lesson/${lesson.day}`)}
+                >
                   Day {lesson.day}: {lesson.title}
                 </Link>
                 <span className="mastery-review-count">

--- a/src/pages/ProgressDashboard.tsx
+++ b/src/pages/ProgressDashboard.tsx
@@ -12,6 +12,7 @@
 
 import { useEffect, useMemo } from 'react'
 import { Link } from 'react-router-dom'
+import { createRoutePrefetchHandlers } from '../utils/prefetchRoutes'
 import SEOHead from '../components/SEOHead'
 import {
   getAllPhases,
@@ -308,7 +309,7 @@ export default function ProgressDashboard() {
                 Day {challengeLesson.day}: {challengeLesson.title}
               </p>
             </div>
-            <Link className="continue-banner-cta" to={`/lesson/${challengeLesson.day}`}>
+            <Link className="continue-banner-cta" to={`/lesson/${challengeLesson.day}`} {...createRoutePrefetchHandlers(`/lesson/${challengeLesson.day}`)}>
               Start challenge
             </Link>
           </div>
@@ -407,7 +408,7 @@ export default function ProgressDashboard() {
           <ul className="mastery-review-list">
             {reviewLessons.map(({ lesson, reviewCount }) => (
               <li className="mastery-review-row" key={lesson.day}>
-                <Link to={`/lesson/${lesson.day}`} className="mastery-review-link">
+                <Link to={`/lesson/${lesson.day}`} className="mastery-review-link" {...createRoutePrefetchHandlers(`/lesson/${lesson.day}`)}>
                   Day {lesson.day}: {lesson.title}
                 </Link>
                 <span className="mastery-review-count">

--- a/test_perf.cjs
+++ b/test_perf.cjs
@@ -1,0 +1,1 @@
+console.log('Validating structure')

--- a/test_typecheck.cjs
+++ b/test_typecheck.cjs
@@ -1,0 +1,8 @@
+const { execSync } = require('child_process');
+
+try {
+  execSync('npm run build', { stdio: 'inherit' });
+  console.log('Build passed');
+} catch (e) {
+  console.error('Build failed');
+}


### PR DESCRIPTION
💡 What: Added route prefetching handlers to internal application links in `Sidebar`, `Home`, `Curriculum`, `Lesson`, `Exercises`, and `ProgressDashboard` components.
🎯 Why: While `Navbar` correctly utilized the `createRoutePrefetchHandlers` utility to preemptively load Webpack/Vite code splits (like phase content) when users hovered or focused on links, the main navigation elements in the content body and sidebar lacked these handlers. This resulted in delayed chunk loading when navigating between lessons or phases.
📊 Impact: Eliminates perceived application lag when navigating the core curriculum (e.g. from the sidebar or curriculum overview) by initiating the chunk download before the click event fires.
🔬 Measurement: Verify by checking the network tab in DevTools; hovering over a sidebar phase or lesson link should now trigger an immediate `fetch` for the associated module chunk.

---
*PR created automatically by Jules for task [997360203029429792](https://jules.google.com/task/997360203029429792) started by @saint2706*