### PR TITLE
Add content-authoring safety net for exercise/question structure

### DIFF
--- a/docs/markdown-renderer-roadmap.md
+++ b/docs/markdown-renderer-roadmap.md
@@ -127,10 +127,17 @@ review count, as a lightweight spaced-repetition nudge.
   itself. Images with no alt text (or mixed with other inline content) fall
   back to the previous plain rendering with no caption.
 
-## Content-authoring safety nets 🔲
+## Content-authoring safety nets ✅
 
-A lint rule (could live in `scripts/validate-content`) that checks every
-`### Exercise N` has a `**Goal**` and code block, and every `### Question N`
-has a `<details>` block — `findInteractiveBlocks` already encodes these
-structural assumptions; validating them at build time would prevent silently
-unparsed exercises.
+Implemented via `src/utils/content-structure-core.js`'s `findStructuralIssues`,
+a remark-AST scan that mirrors the heading/boundary and label-detection rules
+`findInteractiveBlocks` (`MarkdownRenderer.tsx`) relies on, so a section that
+would silently render with an empty Goal/code/answer panel gets flagged
+instead. `scripts/validate-content.js` runs it over every lesson body: a
+`### Question N` missing a `<details>` answer block always fails validation
+(no lesson currently omits one, so this is a safe hard gate); a
+`### Exercise N` missing its `**Goal**` paragraph or python code block is
+printed as a non-blocking warning by default, since a large share of existing
+exercises are intentionally code-free discussion prompts. Pass `--strict`
+(`npm run validate-content:strict`) to promote those exercise warnings to
+failures once content is cleaned up incrementally.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\"",
     "validate-content": "node scripts/validate-content.js",
+    "validate-content:strict": "node scripts/validate-content.js --strict",
     "predeploy": "npm run build",
     "optimize:images": "node scripts/optimize-images.js",
     "deploy": "gh-pages -d dist",

--- a/scripts/__tests__/validate-content.test.ts
+++ b/scripts/__tests__/validate-content.test.ts
@@ -178,5 +178,70 @@ This is a sample lesson body with enough content to pass validation checks becau
       const exitCode = runValidation('/test-dir')
       expect(exitCode).toBe(0)
     })
+
+    function mockSingleReadme(content: string) {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+      vi.spyOn(fs, 'readdirSync').mockImplementation(
+        (pathStr: fs.PathLike, options?: { withFileTypes?: boolean }) => {
+          const p = pathStr.toString().replace(/\\/g, '/')
+          if (p.endsWith('/test-dir') && options?.withFileTypes) {
+            return [{ name: 'phase1', isDirectory: () => true }] as unknown as fs.Dirent[]
+          }
+          if (p.endsWith('/test-dir/phase1') && options?.withFileTypes) {
+            return [{ name: 'README.md', isDirectory: () => false }] as unknown as fs.Dirent[]
+          }
+          return []
+        },
+      )
+      vi.spyOn(fs, 'readFileSync').mockReturnValue(content)
+    }
+
+    const lessonWithBrokenExercise = `---
+day: 1
+title: Sample Lesson
+phase: 1
+difficulty: beginner
+duration: 30
+---
+This is a sample lesson body with enough content to pass validation checks because it clearly exceeds one hundred characters in total length.
+
+### Exercise 1: Missing Goal
+
+\`\`\`python
+print("hi")
+\`\`\`
+`
+
+    const lessonWithBrokenQuestion = `---
+day: 1
+title: Sample Lesson
+phase: 1
+difficulty: beginner
+duration: 30
+---
+This is a sample lesson body with enough content to pass validation checks because it clearly exceeds one hundred characters in total length.
+
+## Mastery Check
+
+### Question 1: No Answer
+
+What happens here?
+`
+
+    it('does not fail by default when an exercise is missing a **Goal** paragraph', () => {
+      mockSingleReadme(lessonWithBrokenExercise)
+      expect(runValidation('/test-dir')).toBe(0)
+    })
+
+    it('fails in strict mode when an exercise is missing a **Goal** paragraph', () => {
+      mockSingleReadme(lessonWithBrokenExercise)
+      expect(runValidation('/test-dir', { strict: true })).toBe(1)
+    })
+
+    it('always fails when a mastery question is missing a <details> answer block', () => {
+      mockSingleReadme(lessonWithBrokenQuestion)
+      expect(runValidation('/test-dir')).toBe(1)
+      expect(runValidation('/test-dir', { strict: true })).toBe(1)
+    })
   })
 })

--- a/scripts/validate-content.js
+++ b/scripts/validate-content.js
@@ -38,6 +38,7 @@ import {
   normalizeDayToken,
 } from '../src/utils/dayToken-core.js'
 import { extractExercisesFromContent } from '../src/utils/exercise-extractor-core.js'
+import { findStructuralIssues } from '../src/utils/content-structure-core.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const LESSONS_DIR = path.join(__dirname, '..', 'content', 'lessons')
@@ -131,17 +132,52 @@ export function validateLessonContent(rawContent, fileName = 'README.md') {
 }
 
 /**
+ * Checks a lesson body's `### Exercise N` / `### Question N` sections against
+ * the structural assumptions `findInteractiveBlocks` relies on to parse them.
+ * A missing `<details>` answer block always fails validation (no lesson in
+ * the curriculum currently omits one, so this is a safe hard gate). Missing
+ * `**Goal**` paragraphs or code blocks on exercises are reported as
+ * non-blocking warnings by default — a large share of existing exercises are
+ * intentionally code-free discussion prompts — and only fail validation when
+ * `strict` is enabled, so the check can be tightened once content is cleaned
+ * up incrementally.
+ *
+ * @param {string} body - The lesson's Markdown body (frontmatter stripped).
+ * @param {boolean} strict - Whether to treat exercise structural issues as errors too.
+ * @returns {{ errors: string[], warnings: string[] }}
+ */
+function checkStructuralIssues(body, strict) {
+  const issues = findStructuralIssues(body)
+  const errors = []
+  const warnings = []
+
+  for (const issue of issues) {
+    const message = `${issue.type === 'exercise' ? 'Exercise' : 'Question'} ${issue.message}`
+    if (issue.type === 'mastery' || strict) {
+      errors.push(message)
+    } else {
+      warnings.push(message)
+    }
+  }
+
+  return { errors, warnings }
+}
+
+/**
  * Executes the main validation pipeline for all curriculum files.
  * Validates frontmatter, extracts exercises, and cross-checks phase metadata against the filesystem.
  *
  * @param {string} [lessonsDir=LESSONS_DIR] - The root directory of the curriculum to validate.
+ * @param {{ strict?: boolean }} [options] - `strict: true` also fails validation on exercises
+ *   missing a **Goal** paragraph or code block (see `checkStructuralIssues`).
  * @returns {number} An exit code: 0 if all validations pass, 1 if any file fails.
  */
-export function runValidation(lessonsDir = LESSONS_DIR) {
+export function runValidation(lessonsDir = LESSONS_DIR, { strict = false } = {}) {
   const files = findReadmes(lessonsDir, lessonsDir).sort()
   const totalFiles = files.length
   const fileResults = new Map()
   const crossCheckFailures = []
+  const structuralWarningsByFile = new Map()
 
   console.log(`\n📋 Validating ${totalFiles} lesson files...\n`)
 
@@ -169,6 +205,15 @@ export function runValidation(lessonsDir = LESSONS_DIR) {
         if (!result.success) {
           fileErrors.push(...formatZodIssues(result.error, 'Invalid exercise'))
         }
+      }
+
+      const { errors: structuralErrors, warnings: structuralWarnings } = checkStructuralIssues(
+        body,
+        strict,
+      )
+      fileErrors.push(...structuralErrors)
+      if (structuralWarnings.length > 0) {
+        structuralWarningsByFile.set(relativePath, structuralWarnings)
       }
     }
 
@@ -226,6 +271,15 @@ export function runValidation(lessonsDir = LESSONS_DIR) {
   console.log(`✅ Passed files: ${passCount}/${totalFiles}`)
   console.log(`❌ Failed files: ${failCount}/${totalFiles}`)
   console.log(`🔎 Cross-check failures: ${crossCheckFailures.length}`)
+  if (structuralWarningsByFile.size > 0) {
+    const warningCount = [...structuralWarningsByFile.values()].reduce(
+      (sum, warnings) => sum + warnings.length,
+      0,
+    )
+    console.log(
+      `⚠️  Structural warnings (non-blocking, use --strict to enforce): ${warningCount} in ${structuralWarningsByFile.size} file(s)`,
+    )
+  }
 
   if (failCount > 0) {
     console.log('\n📄 File-level failures:\n')
@@ -251,6 +305,17 @@ export function runValidation(lessonsDir = LESSONS_DIR) {
     return 1
   }
 
+  if (structuralWarningsByFile.size > 0) {
+    console.log('\n📄 Structural warnings:\n')
+    for (const [file, warnings] of structuralWarningsByFile.entries()) {
+      console.log(`  📄 ${file}`)
+      for (const warning of warnings) {
+        console.log(`     ⚠ ${warning}`)
+      }
+      console.log()
+    }
+  }
+
   console.log('\n🎉 All lessons have valid frontmatter and metadata!\n')
   return 0
 }
@@ -259,5 +324,6 @@ const isMainModule =
   process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href
 
 if (isMainModule) {
-  process.exit(runValidation())
+  const strict = process.argv.includes('--strict')
+  process.exit(runValidation(LESSONS_DIR, { strict }))
 }

--- a/src/utils/__tests__/content-structure-core.test.ts
+++ b/src/utils/__tests__/content-structure-core.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+import { findStructuralIssues } from '../content-structure-core.js'
+
+describe('findStructuralIssues', () => {
+  it('returns no issues for a well-formed exercise and question', () => {
+    const markdown = `
+### Exercise 1: Compute Sum
+
+**Goal**: Add two numbers.
+
+\`\`\`python
+print(2 + 3)
+\`\`\`
+
+## Mastery Check
+
+### Question 1: What does + do?
+
+Explain addition.
+
+<details>
+<summary>Click for Answer</summary>
+
+It adds two numbers.
+
+</details>
+`
+
+    expect(findStructuralIssues(markdown)).toEqual([])
+  })
+
+  it('flags an exercise missing a **Goal** paragraph', () => {
+    const markdown = `
+### Exercise 1: Compute Sum
+
+\`\`\`python
+print(2 + 3)
+\`\`\`
+`
+
+    const issues = findStructuralIssues(markdown)
+    expect(issues).toHaveLength(1)
+    expect(issues[0]).toMatchObject({
+      type: 'exercise',
+      heading: 'Exercise 1: Compute Sum',
+    })
+    expect(issues[0]?.message).toMatch(/Goal/)
+  })
+
+  it('flags an exercise missing a python code block', () => {
+    const markdown = `
+### Exercise 1: Compute Sum
+
+**Goal**: Add two numbers.
+`
+
+    const issues = findStructuralIssues(markdown)
+    expect(issues).toHaveLength(1)
+    expect(issues[0]).toMatchObject({ type: 'exercise' })
+    expect(issues[0]?.message).toMatch(/code block/)
+  })
+
+  it('flags both missing pieces when neither is present', () => {
+    const markdown = `
+### Exercise 1: Compute Sum
+
+Just some prose, no goal or code.
+`
+
+    const issues = findStructuralIssues(markdown)
+    expect(issues).toHaveLength(2)
+    expect(issues.map((issue) => issue.message).join(' ')).toMatch(/Goal/)
+    expect(issues.map((issue) => issue.message).join(' ')).toMatch(/code block/)
+  })
+
+  it('flags a question missing a <details> answer block', () => {
+    const markdown = `
+### Question 1: What does + do?
+
+Explain addition.
+`
+
+    const issues = findStructuralIssues(markdown)
+    expect(issues).toHaveLength(1)
+    expect(issues[0]).toMatchObject({
+      type: 'mastery',
+      heading: 'Question 1: What does + do?',
+    })
+    expect(issues[0]?.message).toMatch(/<details>/)
+  })
+
+  it('scopes each exercise/question independently across multiple blocks', () => {
+    const markdown = `
+### Exercise 1: Good One
+
+**Goal**: Do the thing.
+
+\`\`\`python
+do_thing()
+\`\`\`
+
+### Exercise 2: Bad One
+
+Missing everything.
+
+## Mastery Check
+
+### Question 1: Fine
+
+Text
+
+<details>
+<summary>Answer</summary>
+
+Yes.
+
+</details>
+
+### Question 2: Broken
+
+No answer here.
+`
+
+    const issues = findStructuralIssues(markdown)
+    expect(issues.map((issue) => issue.heading)).toEqual([
+      'Exercise 2: Bad One',
+      'Exercise 2: Bad One',
+      'Question 2: Broken',
+    ])
+  })
+
+  it('reports a source line for each issue', () => {
+    const markdown = `Intro paragraph.\n\n### Exercise 1: Compute Sum\n\nNo goal or code.\n`
+
+    const issues = findStructuralIssues(markdown)
+    expect(issues[0]?.line).toBe(3)
+  })
+
+  it('ignores headings that are not Exercise/Question sections', () => {
+    const markdown = `
+### Just a heading
+
+Some content with no code or goal.
+`
+
+    expect(findStructuralIssues(markdown)).toEqual([])
+  })
+})

--- a/src/utils/content-structure-core.d.ts
+++ b/src/utils/content-structure-core.d.ts
@@ -1,0 +1,14 @@
+export interface StructuralIssue {
+  type: 'exercise' | 'mastery'
+  heading: string
+  line: number | null
+  message: string
+}
+
+/**
+ * Scans a lesson's Markdown body for `### Exercise N` and `### Question N`
+ * sections that are missing the structural pieces `findInteractiveBlocks`
+ * expects (a `**Goal**` paragraph + code block for exercises, a `<details>`
+ * answer block for questions).
+ */
+export function findStructuralIssues(content: string): StructuralIssue[]

--- a/src/utils/content-structure-core.js
+++ b/src/utils/content-structure-core.js
@@ -1,0 +1,125 @@
+/**
+ * Structural linting for interactive Markdown blocks (`### Exercise N` /
+ * `### Question N`). Mirrors the heading/boundary and label-detection rules
+ * that `findInteractiveBlocks` (src/components/MarkdownRenderer.tsx) relies
+ * on to parse exercises and mastery-check questions, so authoring mistakes
+ * that would otherwise silently render as an empty Goal/code/answer panel
+ * get surfaced instead.
+ */
+
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkGfm from 'remark-gfm'
+
+function getInlineNodeText(node) {
+  if (!node) return ''
+  if (node.type === 'text' || node.type === 'inlineCode') return node.value
+  if (Array.isArray(node.children)) {
+    return node.children.map((child) => getInlineNodeText(child)).join('')
+  }
+  return ''
+}
+
+function getHeadingText(node) {
+  return node.children.map((child) => getInlineNodeText(child)).join('').trim()
+}
+
+function isLabeledParagraph(node, label) {
+  if (!node || node.type !== 'paragraph') return false
+  const first = node.children[0]
+  if (!first || first.type !== 'strong') return false
+
+  const strongText = first.children
+    .map((child) => getInlineNodeText(child))
+    .join('')
+    .trim()
+    .replace(/:$/, '')
+
+  return strongText.toLowerCase() === label.toLowerCase()
+}
+
+/**
+ * @typedef {Object} StructuralIssue
+ * @property {'exercise' | 'mastery'} type
+ * @property {string} heading - The full heading text (e.g. "Exercise 1: Report Scheduler").
+ * @property {number | null} line - 1-based source line of the heading, if available.
+ * @property {string} message - Human-readable description of the missing structure.
+ */
+
+/**
+ * Scans a lesson's Markdown body for `### Exercise N` and `### Question N`
+ * sections that are missing the structural pieces `findInteractiveBlocks`
+ * expects (a `**Goal**` paragraph + code block for exercises, a `<details>`
+ * answer block for questions).
+ *
+ * @param {string} content - The Markdown body to scan (frontmatter stripped).
+ * @returns {StructuralIssue[]} Issues found, in document order.
+ */
+export function findStructuralIssues(content) {
+  const tree = unified().use(remarkParse).use(remarkGfm).parse(content)
+  const topLevelNodes = tree.children
+  const issues = []
+
+  for (let i = 0; i < topLevelNodes.length; i++) {
+    const node = topLevelNodes[i]
+    if (!node || node.type !== 'heading' || node.depth !== 3) continue
+
+    const headingText = getHeadingText(node)
+    const exerciseMatch = headingText.match(/^Exercise\s+\d+\s*:\s*(.+)$/i)
+    const questionMatch = headingText.match(/^Question\s+\d+\s*:\s*(.+)$/i)
+    if (!exerciseMatch && !questionMatch) continue
+
+    const line = node.position?.start?.line ?? null
+
+    let boundaryIndex = topLevelNodes.length
+    for (let j = i + 1; j < topLevelNodes.length; j++) {
+      const candidate = topLevelNodes[j]
+      if (!candidate) continue
+      if (candidate.type === 'heading' && candidate.depth <= 3) {
+        boundaryIndex = j
+        break
+      }
+    }
+    const sectionNodes = topLevelNodes.slice(i + 1, boundaryIndex)
+
+    if (exerciseMatch) {
+      const hasGoal = sectionNodes.some((sectionNode) => isLabeledParagraph(sectionNode, 'Goal'))
+      const hasCode = sectionNodes.some(
+        (sectionNode) =>
+          sectionNode.type === 'code' && (sectionNode.lang === 'python' || sectionNode.lang === 'py'),
+      )
+
+      if (!hasGoal) {
+        issues.push({
+          type: 'exercise',
+          heading: headingText,
+          line,
+          message: `"${headingText}" is missing a **Goal** paragraph`,
+        })
+      }
+      if (!hasCode) {
+        issues.push({
+          type: 'exercise',
+          heading: headingText,
+          line,
+          message: `"${headingText}" is missing a python code block`,
+        })
+      }
+      continue
+    }
+
+    const hasDetails = sectionNodes.some(
+      (sectionNode) => sectionNode.type === 'html' && /<details[\s>]/i.test(sectionNode.value),
+    )
+    if (!hasDetails) {
+      issues.push({
+        type: 'mastery',
+        heading: headingText,
+        line,
+        message: `"${headingText}" is missing a <details> answer block`,
+      })
+    }
+  }
+
+  return issues
+}


### PR DESCRIPTION
## Summary
- Implements the [Content-authoring safety nets](https://github.com/saint2706/Coding-For-MBA/blob/main/docs/markdown-renderer-roadmap.md#content-authoring-safety-nets-) roadmap item.
- Adds `src/utils/content-structure-core.js`'s `findStructuralIssues`, a remark-AST scan that mirrors the heading/boundary and label-detection rules `findInteractiveBlocks` (`MarkdownRenderer.tsx`) relies on to parse `### Exercise N` / `### Question N` sections — so a section that would silently render with an empty Goal/code/answer panel gets flagged instead of failing silently.
- Wires it into `scripts/validate-content.js`: a `### Question N` missing a `<details>` answer block always fails validation (no lesson in the curriculum currently omits one, so this is a safe hard gate today). A `### Exercise N` missing its `**Goal**` paragraph or python code block is reported as a **non-blocking warning** by default, since a large share of existing exercises (475 across 127 files) are intentionally code-free discussion prompts. Pass `--strict` (new `npm run validate-content:strict` script) to promote those into build failures once content is cleaned up incrementally.
- Updates the roadmap doc to mark the item implemented.

## Test plan
- [x] `npx vitest run` — 717 tests pass (100 files), including new `src/utils/__tests__/content-structure-core.test.ts` and extended `scripts/__tests__/validate-content.test.ts` cases covering warning vs. `--strict` behavior.
- [x] `npx tsc -b` — typecheck passes clean.
- [x] `node scripts/validate-content.js` — exits 0 (174/174 files pass), prints 475 non-blocking structural warnings across 127 files.
- [x] `node scripts/validate-content.js --strict` — exits 1, confirming the flag correctly escalates exercise structural issues to failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011RTLdjRhqtNCBk7fnCGZt2

---
_Generated by [Claude Code](https://claude.ai/code/session_011RTLdjRhqtNCBk7fnCGZt2)_