### PR TITLE
⚡ Bolt: Cache DOM queries in ScrollProgress

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-05 - Caching DOM queries in scroll handlers
+**Learning:** `document.querySelector` inside a scroll event's `requestAnimationFrame` handler can cause performance degradation by forcing the browser to query the DOM on every scroll frame.
+**Action:** Always cache the reference to the DOM element queried, and only re-query if the element no longer exists in the document.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -31,12 +31,18 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
 
   useEffect(() => {
     let ticking = false
+    // ⚡ Bolt: Cache DOM node to prevent expensive querySelector calls on every scroll frame
+    let cachedElement: HTMLElement | null = null
 
     const updateProgress = () => {
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        let element = cachedElement
+        if (!element || !document.body.contains(element)) {
+          element = document.querySelector<HTMLElement>(targetSelector)
+          cachedElement = element
+        }
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cached the DOM element result of `document.querySelector` within the `ScrollProgress` component's scroll event handler.
🎯 Why: Calling `document.querySelector` inside a high-frequency event like `scroll` (even when throttled by `requestAnimationFrame`) forces the browser to repeatedly search the DOM, which can cause frame drops on large pages.
📊 Impact: Reduces DOM queries on scroll from 60 per second to 1 (only querying once initially), freeing up main thread execution time for smoother scrolling.
🔬 Measurement: Profile the scroll event and note the disappearance of `querySelector` calls in the call tree.

---
*PR created automatically by Jules for task [11067221824787013110](https://jules.google.com/task/11067221824787013110) started by @saint2706*