### PR TITLE
Fix mermaid diagrams losing all text labels and dropped exercise content

### DIFF
--- a/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_25_Data_Cleaning/README.md
+++ b/content/lessons/Phase_03_Data_Engineering_Web_Development/Day_25_Data_Cleaning/README.md
@@ -57,7 +57,7 @@ This is the reality of business data. It's messy, inconsistent, and riddled with
 
 ```mermaid
 flowchart TD
-    A[Detect missing values: isnull().sum()] --> B{Any missing?}
+    A["Detect missing values: isnull().sum()"] --> B{Any missing?}
     B -- No --> Z[Continue to type conversion / dedup]
     B -- Yes --> C{Choose a strategy}
     C --> D[Drop rows: dropna]

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -208,8 +208,13 @@ function findInteractiveBlocks(content: string): InteractiveBlock[] {
         }
       }
 
-      if (firstCodeNodeIndex > goalNodeIndex) {
-        const instructionNodes = sectionNodes.slice(goalNodeIndex + 1, firstCodeNodeIndex)
+      // Exercises with no Python/py starter code (e.g. conceptual design or SQL-only
+      // exercises) leave `firstCodeNodeIndex` at -1; fall back to the section end so
+      // their instructions (explanations, diagrams, tables) still render instead of
+      // being silently dropped.
+      const instructionEndIndex = firstCodeNodeIndex >= 0 ? firstCodeNodeIndex : sectionNodes.length
+      if (instructionEndIndex > goalNodeIndex) {
+        const instructionNodes = sectionNodes.slice(goalNodeIndex + 1, instructionEndIndex)
         const instructionParts: string[] = []
         for (const instructionNode of instructionNodes) {
           const nodeStart = getNodeStartOffset(instructionNode)

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -75,7 +75,14 @@ function MermaidDiagram({ code }: MermaidDiagramProps) {
       .then(({ svg }) => {
         if (cancelled) return
         if (containerRef.current) {
-          containerRef.current.innerHTML = DOMPurify.sanitize(svg)
+          // Mermaid renders node/edge labels as HTML inside <foreignObject> (an SVG/HTML
+          // namespace boundary). DOMPurify's default namespace check only treats
+          // <annotation-xml> as a valid HTML integration point, so without this config
+          // it silently empties every <foreignObject>, stripping all diagram text.
+          containerRef.current.innerHTML = DOMPurify.sanitize(svg, {
+            ADD_TAGS: ['foreignObject'],
+            HTML_INTEGRATION_POINTS: { foreignobject: true },
+          })
         }
         setLoading(false)
       })

--- a/src/components/__tests__/MarkdownRenderer.test.tsx
+++ b/src/components/__tests__/MarkdownRenderer.test.tsx
@@ -449,6 +449,41 @@ starter
     expect(widget?.textContent).toContain('Practice parsing headings')
   })
 
+  it('captures instructions through to the section end for exercises with no starter code block', async () => {
+    const content = `
+### Exercise 2: Designing a DAG
+**Goal**: Draw the dependencies.
+
+* **Parallel**: A and B can run at the same time.
+* **Converge**: C waits for both.
+
+\`\`\`mermaid
+flowchart TD
+    A --> C
+    B --> C
+\`\`\`
+
+The two tasks run in parallel, but C cannot start until both finish.
+
+### Exercise 3: Next
+**Goal**: Unrelated goal.
+\`\`\`python
+print('ok')
+\`\`\`
+    `
+
+    const { findInteractiveBlocks } = await import('../MarkdownRenderer')
+    const blocks = findInteractiveBlocks(content)
+    const exercise2 = blocks.find(
+      (b) => b.type === 'exercise' && (b.data as { title: string }).title === 'Designing a DAG',
+    )
+    expect(exercise2).toBeTruthy()
+    const instructions = (exercise2!.data as { instructions: string }).instructions
+    expect(instructions).toContain('Converge')
+    expect(instructions).toContain('```mermaid')
+    expect(instructions).toContain('The two tasks run in parallel')
+  })
+
   it('parses mastery questions with nested heading formatting and details answers', () => {
     const content = `
 ### Question 2 : **Cash** *Flow* Check

--- a/src/components/__tests__/MermaidDiagram.test.tsx
+++ b/src/components/__tests__/MermaidDiagram.test.tsx
@@ -62,6 +62,27 @@ describe('MermaidDiagram', () => {
     expect(container.textContent).toContain('not a valid diagram')
   })
 
+  it('preserves foreignObject-based node labels through sanitization', async () => {
+    renderMock.mockResolvedValue({
+      svg:
+        '<svg xmlns="http://www.w3.org/2000/svg"><g class="node">' +
+        '<rect></rect>' +
+        '<foreignObject><div xmlns="http://www.w3.org/1999/xhtml">' +
+        '<span class="nodeLabel">Detect missing values</span>' +
+        '</div></foreignObject>' +
+        '</g></svg>',
+    })
+
+    act(() => {
+      root.render(<MermaidDiagram code="flowchart TD;\nA-->B;" />)
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('.mermaid-diagram svg')).toBeTruthy()
+    })
+    expect(container.textContent).toContain('Detect missing values')
+  })
+
   it('initializes mermaid with the dark theme when the dark palette is active', async () => {
     document.documentElement.setAttribute('data-palette-type', 'dark')
     renderMock.mockResolvedValue({ svg: '<svg></svg>' })


### PR DESCRIPTION
## Summary

Verified every mermaid diagram across all 37 lesson READMEs by rendering the live app in a headless browser and inspecting each diagram's DOM/SVG output. Found and fixed three distinct rendering bugs:

- **Universal missing-label bug (highest impact):** `MermaidDiagram.tsx` sanitized Mermaid's output SVG with `DOMPurify.sanitize(svg)` using default options. Mermaid renders flowchart/ER/class/state diagram labels as HTML inside `<foreignObject>` (an SVG→HTML namespace boundary). DOMPurify's default namespace check only treats `annotation-xml` as a valid HTML integration point, so it silently emptied every `<foreignObject>` — every node kept its shape but lost all of its text. This affected 33 of the 39 diagrams in the curriculum (everything except `sequenceDiagram`, which renders labels as plain SVG `<text>`). Fixed by passing `ADD_TAGS: ['foreignObject']` and `HTML_INTEGRATION_POINTS: { foreignobject: true }` to `DOMPurify.sanitize`, which restores labels while still stripping `<script>` tags and event-handler attributes.
- **Day 25 (Data Cleaning) parse error:** a flowchart node label contained an unquoted `(` (`A[Detect missing values: isnull().sum()]`), which Mermaid's parser rejected outright, rendering an error box instead of the diagram. Fixed by quoting the label.
- **Silently dropped exercise content (Days 87, 88, 109):** `findInteractiveBlocks` in `MarkdownRenderer.tsx` only captured an exercise's "instructions" text up to its first Python code block. Conceptual/SQL-only exercises with no Python starter code left `firstCodeNodeIndex` at `-1`, so the whole instructions region (scenario text, tables, and any embedded mermaid diagram) was dropped — only the "Goal" line rendered. `node scripts/validate-content.js` shows this pattern recurs across many other lessons in the curriculum, so this fix has broader benefit beyond the mermaid diagrams that surfaced it.

## Verification

- Built a Playwright script to visit all 37 lesson pages (`/#/lesson/:dayNum`, since the app uses `HashRouter`), inspect each `.mermaid-diagram-container`/`.mermaid-diagram-error`, and screenshot the rendered diagrams.
- Before the fix: 33/39 diagrams had empty text, 1 had a parse error, and 3 lessons had zero detected diagrams (dropped exercise content).
- After the fix: all 39 diagrams across all 37 lessons render with visible labels and zero errors.
- Added regression tests: `MermaidDiagram.test.tsx` now asserts `foreignObject` label content survives sanitization; `MarkdownRenderer.test.tsx` asserts exercise instructions are captured through to the section end when there's no starter code block.
- `npx tsc -b` and `npx vitest run` (719 tests) both pass.

## Test plan

- [x] `npx tsc -b` passes
- [x] `npx vitest run` — 719/719 tests pass
- [x] `node scripts/validate-content.js` — no new issues
- [x] Manually verified in a running dev server (screenshots) that previously-broken diagrams (Day 9, 18, 61, 96 for missing labels; Day 25 for the parse error; Day 87/88/109 for dropped content) now render correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01AG94Ky2U7naiHZYELqJr2q)_