### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix carriage return comment bypass in code security

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-07-08 - Fix Carriage Return Comment Bypass in Python Validation
+**Vulnerability:** A critical security vulnerability was discovered in `stripPythonCommentsAndStrings` where comments were only stripped up to the `\n` character. Attackers could use a carriage return `\r` to bypass the security scanner because the parser considered the rest of the file a comment and removed it from validation, but Pyodide executed the code following the `\r`.
+**Learning:** Python treats `\r` as a valid newline character. String parsing logic that strips comments must handle both `\n` and `\r`.
+**Prevention:** Always use regex or robust character checking for newlines `\r` and `\n` instead of `indexOf('\n')` when stripping code comments for validation.

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -250,6 +250,10 @@ print("bad")
     expect(validatePythonCode('getattr(f, "__globals__")').valid).toBe(false)
   })
 
+  it('should block carriage return comment bypasses', () => {
+    expect(validatePythonCode('# comment \r__import__(\'os\')')).toEqual(expect.objectContaining({ valid: false }))
+  })
+
   it('should block line continuations bypassing checks', () => {
     expect(validatePythonCode('import \\\njs').valid).toBe(false)
     expect(validatePythonCode('from \\\njs import window').valid).toBe(false)

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -251,7 +251,9 @@ print("bad")
   })
 
   it('should block carriage return comment bypasses', () => {
-    expect(validatePythonCode('# comment \r__import__(\'os\')')).toEqual(expect.objectContaining({ valid: false }))
+    expect(validatePythonCode("# comment \r__import__('os')")).toEqual(
+      expect.objectContaining({ valid: false }),
+    )
   })
 
   it('should block line continuations bypassing checks', () => {

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,8 +120,10 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
-      if (nextNewline === -1) {
+      const nextNewlineStr = stripped.indexOf('\n', i)
+      const nextReturnStr = stripped.indexOf('\r', i)
+      const nextNewline = [nextNewlineStr, nextReturnStr].filter(idx => idx !== -1).sort((a, b) => a - b)[0]
+      if (nextNewline === undefined) {
         break // Rest of the line is a comment, end of string
       }
       i = nextNewline // Skip to newline

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -122,7 +122,9 @@ export function stripPythonCommentsAndStrings(code: string): string {
     if (!inString && char === '#') {
       const nextNewlineStr = stripped.indexOf('\n', i)
       const nextReturnStr = stripped.indexOf('\r', i)
-      const nextNewline = [nextNewlineStr, nextReturnStr].filter(idx => idx !== -1).sort((a, b) => a - b)[0]
+      const nextNewline = [nextNewlineStr, nextReturnStr]
+        .filter((idx) => idx !== -1)
+        .sort((a, b) => a - b)[0]
       if (nextNewline === undefined) {
         break // Rest of the line is a comment, end of string
       }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The python security validator failed to check for `\r` newlines when stripping comments, allowing attackers to hide malicious code inside comments that would still be executed by Pyodide.
🎯 Impact: An attacker could bypass the python sandbox protections to execute arbitrary system code or access unauthorized APIs.
🔧 Fix: Updated the `stripPythonCommentsAndStrings` function to correctly split comments at either `\n` or `\r`.
✅ Verification: Added a test verifying that `# comment \r__import__('os')` is properly blocked.

---
*PR created automatically by Jules for task [8320398766777900606](https://jules.google.com/task/8320398766777900606) started by @saint2706*