### PR TITLE
⚡ Bolt: Optimize ScrollProgress component to prevent repeated DOM queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-08 - Scroll Event DOM Query Bottleneck
+**Learning:** Calling `document.querySelector` inside a scroll event handler (even if throttled by `requestAnimationFrame`) is a significant performance anti-pattern. It forces the browser to evaluate the DOM structure repeatedly during scroll, increasing the risk of scroll jank.
+**Action:** Always cache DOM lookups (`document.querySelector`) in a `useRef` when used inside frequent event handlers like scroll or mousemove. Use `element.isConnected` to invalidate the cache if the element might unmount, and clear the ref if the target selector changes.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,12 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const targetRef = useRef<HTMLElement | null>(null)
+
+  // ⚡ Bolt: Reset cached ref when the selector changes to prevent stale cache bugs
+  useEffect(() => {
+    targetRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +42,12 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        // ⚡ Bolt: Cache querySelector results to prevent expensive DOM queries on every scroll event
+        if (!targetRef.current || !targetRef.current.isConnected) {
+          targetRef.current = document.querySelector<HTMLElement>(targetSelector)
+        }
+
+        const element = targetRef.current
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cached `document.querySelector` result in a `useRef` for the `ScrollProgress` component.
🎯 Why: Calling `document.querySelector` on every scroll event is expensive and can cause scroll jank, especially on complex pages.
📊 Impact: Reduces DOM query operations from O(scroll_events) to O(1) (per component mount/selector change), improving main thread availability during scrolling.
🔬 Measurement: The scroll event handler now runs faster, avoiding layout thrashing.

---
*PR created automatically by Jules for task [9916376676131489452](https://jules.google.com/task/9916376676131489452) started by @saint2706*