### PR TITLE
⚡ Bolt: Cache querySelector in ScrollProgress

### DIFF
--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,11 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const targetRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    targetRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +41,10 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        if (!targetRef.current || !targetRef.current.isConnected) {
+          targetRef.current = document.querySelector<HTMLElement>(targetSelector)
+        }
+        const element = targetRef.current
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cached the `document.querySelector` result in `ScrollProgress` using a `useRef`.
🎯 Why: The original implementation performed a potentially expensive DOM query on every scroll frame when a `targetSelector` was provided.
📊 Impact: Eliminates redundant DOM queries, reducing main thread workload during scroll events and improving scroll performance and UI responsiveness.
🔬 Measurement: Verified that tests and builds pass. The optimization works seamlessly during scrolling and updates properly if the target is detached.

---
*PR created automatically by Jules for task [11103096694471838569](https://jules.google.com/task/11103096694471838569) started by @saint2706*