### PR TITLE
🛡️ Sentinel: [HIGH] Fix regex bypass in comment stripping

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-10 - Regex bypass in Python comment stripping
+**Vulnerability:** Python code validation could be bypassed using a carriage return (`\r`) inside comments.
+**Learning:** The previous comment stripper only stopped at `\n`, allowing code on the same line after a `\r` to be ignored by the validator but executed by the Python runtime.
+**Prevention:** Always check for both `\r` and `\n` when manually parsing line-ending boundaries.

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -121,10 +121,20 @@ export function stripPythonCommentsAndStrings(code: string): string {
 
     if (!inString && char === '#') {
       const nextNewline = stripped.indexOf('\n', i)
-      if (nextNewline === -1) {
+      const nextCR = stripped.indexOf('\r', i)
+
+      let endOfLine = stripped.length
+      if (nextNewline !== -1 && nextCR !== -1) {
+        endOfLine = Math.min(nextNewline, nextCR)
+      } else if (nextNewline !== -1) {
+        endOfLine = nextNewline
+      } else if (nextCR !== -1) {
+        endOfLine = nextCR
+      } else {
         break // Rest of the line is a comment, end of string
       }
-      i = nextNewline // Skip to newline
+
+      i = endOfLine
       continue
     }
 


### PR DESCRIPTION
🚨 Severity: HIGH\n💡 Vulnerability: Code validator could be bypassed using \r in comments\n🎯 Impact: Arbitrary dangerous code execution\n🔧 Fix: Handle \r as newline in comment stripper\n✅ Verification: npm run test passes

---
*PR created automatically by Jules for task [5229172350608508680](https://jules.google.com/task/5229172350608508680) started by @saint2706*