### PR TITLE
⚡ Bolt: Cache DOM queries in ScrollProgress

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-11 - Cache document.querySelector for ScrollProgress
+**Learning:** `ScrollProgress.tsx` queries the DOM using `document.querySelector` inside a `requestAnimationFrame` handler during scrolling, which causes DOM layouts to thrash continuously.
+**Action:** Always cache the reference using `useRef`, ensure to check if `element.isConnected` is still valid, and reset the cache when the target selector prop changes.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,15 +28,23 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const elementRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
     let ticking = false
+
+    // Reset the cached element when the target selector changes
+    elementRef.current = null
 
     const updateProgress = () => {
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        // ⚡ Bolt: Cache DOM query to prevent layout thrashing on scroll
+        if (!elementRef.current || !elementRef.current.isConnected) {
+          elementRef.current = document.querySelector<HTMLElement>(targetSelector)
+        }
+        const element = elementRef.current
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cache `document.querySelector` inside `ScrollProgress.tsx` using `useRef`.
🎯 Why: Repeatedly querying the DOM in a scroll event handler causes unnecessary layout thrashing.
📊 Impact: Reduces main thread blocking time during scrolling.
🔬 Measurement: Profile the scroll event and observe the reduced execution time in `updateProgress`.

---
*PR created automatically by Jules for task [5975884914015718755](https://jules.google.com/task/5975884914015718755) started by @saint2706*