### PR TITLE
⚡ Bolt: Cache DOM queries in ScrollProgress

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2025-02-18 - Caching DOM lookups in scroll events
+**Learning:** High frequency events like `scroll` (even if throttled via `requestAnimationFrame`) can become performance bottlenecks if they contain expensive DOM queries like `document.querySelector`.
+**Action:** Always cache the result of DOM queries inside high-frequency event listeners (e.g. using a `useRef` in React). Ensure you have a strategy to repopulate the cache if the element might remount, such as using `document.body.contains(ref.current)` or resetting the ref when props change.
+
+## 2025-02-18 - Typescript and Vite strict dependency requirements
+**Learning:** Randomly downgrading or modifying `package.json` dependencies (like typescript) during verification can cause build failures with vite plugins (e.g. `@vitejs/plugin-react`). This project has strict version alignment requirements.
+**Action:** Never modify `package.json` or `tsconfig.json` without explicit instruction. If a tool like `tsc` goes missing due to a mocked environment state, install it locally just to verify, but always revert the lockfile and package.json via `git restore package.json package-lock.json` before submitting.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,12 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const targetRef = useRef<HTMLElement | null>(null)
+
+  // ⚡ Bolt: Reset ref when targetSelector changes to ensure we query the new target
+  useEffect(() => {
+    targetRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +42,12 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        // ⚡ Bolt: Cache DOM query to prevent document.querySelector on every scroll event
+        if (!targetRef.current || !document.body.contains(targetRef.current)) {
+          targetRef.current = document.querySelector<HTMLElement>(targetSelector)
+        }
+        const element = targetRef.current
+
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cache document.querySelector in a useRef for ScrollProgress. 🎯 Why: Querying the DOM on every scroll event inside requestAnimationFrame is expensive. 📊 Impact: Eliminates redundant DOM queries, reducing scroll handler execution time. 🔬 Measurement: Run npm run test and verify smooth scrolling in UI.

---
*PR created automatically by Jules for task [4360855025439400284](https://jules.google.com/task/4360855025439400284) started by @saint2706*