### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix carriage return bypass in Python comment stripping

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-13 - Carriage Return Comment Stripping Bypass
+**Vulnerability:** Python comment parser relied only on `\n` to end comments, allowing attackers to hide malicious payloads behind a `\r` (carriage return).
+**Learning:** Python runtime executes code separated by `\r`, making it a valid newline character for command injection bypass when simple line feeds are the only check.
+**Prevention:** Use comprehensive newline detection parsing (`\n` and `\r`) or AST-based parsers instead of simple checks when validating code.

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -311,7 +311,7 @@ print("bad")
   })
   it('should handle carriage returns hiding malicious code', () => {
     // A comment followed by a carriage return, then malicious code
-    const code = '# comment\ros.system("ls")';
-    expect(validatePythonCode(code).valid).toBe(false);
+    const code = '# comment\ros.system("ls")'
+    expect(validatePythonCode(code).valid).toBe(false)
   })
 })

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -309,4 +309,9 @@ print("bad")
     expect(validatePythonCode('f"{1+1}"').valid).toBe(true)
     expect(validatePythonCode('f"{eval(1)} "').valid).toBe(false)
   })
+  it('should handle carriage returns hiding malicious code', () => {
+    // A comment followed by a carriage return, then malicious code
+    const code = '# comment\ros.system("ls")';
+    expect(validatePythonCode(code).valid).toBe(false);
+  })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,7 +120,15 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
+      const nextLF = stripped.indexOf('\n', i)
+      const nextCR = stripped.indexOf('\r', i)
+      let nextNewline = -1
+      if (nextLF !== -1 && nextCR !== -1) {
+        nextNewline = Math.min(nextLF, nextCR)
+      } else {
+        nextNewline = Math.max(nextLF, nextCR)
+      }
+
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string
       }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The python comment stripping code only respected line feed (\n) as a newline character, allowing malicious Python code following a carriage return (\r) to bypass code validation but still be executed by the python runtime.
🎯 Impact: Attackers could execute arbitrary system commands or banned built-in functions via Pyodide by embedding them after a carriage return in a comment.
🔧 Fix: Updated the comment parsing logic in `src/utils/codeSecurity.ts` to properly terminate comments upon encountering either \n or \r.
✅ Verification: All new and existing security tests pass.

---
*PR created automatically by Jules for task [16667535898908299538](https://jules.google.com/task/16667535898908299538) started by @saint2706*