### PR TITLE
⚡ Bolt: Cache ScrollProgress target selector

### DIFF
--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,11 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const targetRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    targetRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +41,10 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        if (!targetRef.current || !targetRef.current.isConnected) {
+          targetRef.current = document.querySelector<HTMLElement>(targetSelector)
+        }
+        const element = targetRef.current
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cached the `document.querySelector` result in a `useRef` for the `ScrollProgress` component.
🎯 Why: `document.querySelector` was being called on every scroll event (via requestAnimationFrame), which is an expensive DOM operation that can cause performance bottlenecks during scrolling.
📊 Impact: Reduces unnecessary DOM queries during scrolling to zero after the first successful query.
🔬 Measurement: Profile scrolling performance on lesson pages; observe reduced script execution time and eliminated DOM query costs during scroll.

---
*PR created automatically by Jules for task [1032285804189776928](https://jules.google.com/task/1032285804189776928) started by @saint2706*