### PR TITLE
⚡ Bolt: Cache ScrollProgress DOM queries to prevent layout thrashing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-16 - ScrollProgress Optimization
+**Learning:** `document.querySelector` is executed on every animation frame during scrolling when a `targetSelector` is provided. This forces the browser to evaluate the selector repeatedly, causing main thread blocking and unnecessary work, especially since the element structure is static for a given page.
+**Action:** Caching the DOM query inside a `useRef` drastically reduces DOM lookups. Combined with an `element.isConnected` check, it avoids stale reference issues while delivering significant scrolling performance improvements without breaking the functionality.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,11 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const elementRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    elementRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +41,11 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        let element = elementRef.current
+        if (!element || !element.isConnected) {
+          element = document.querySelector<HTMLElement>(targetSelector)
+          elementRef.current = element
+        }
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
**💡 What:** Added a `useRef` to cache the result of `document.querySelector` in the `ScrollProgress` component and verify its presence using `element.isConnected`.
**🎯 Why:** Calling `document.querySelector` on every scroll animation frame forces the browser to evaluate the selector repeatedly, causing main thread blocking and unnecessary layout thrashing.
**📊 Impact:** Reduces unnecessary DOM lookups during scrolling to near zero (only occurring once per target change), drastically improving main thread performance and scroll smoothness.
**🔬 Measurement:** Verify scrolling performance by running a performance profile while scrolling through a lesson and checking that no excessive Recalculate Style or DOM queries block the main thread.

---
*PR created automatically by Jules for task [17066515268026506436](https://jules.google.com/task/17066515268026506436) started by @saint2706*