### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Python security validation bypass via carriage return

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-16 - Prevent Python Comment Bypass via Carriage Returns
+**Vulnerability:** The Python comment parsing logic only recognized line feeds (`\n`) as the end of a comment, allowing malicious payloads hidden behind carriage returns (`\r`) to execute.
+**Learning:** Python runtime interprets both `\r` and `\n` as valid line endings. Security parsers must handle both to avoid bypasses, as relying on only one allows attackers to hide executable code.
+**Prevention:** Always use robust newline parsing or an AST-based state machine for security validations, handling all platform-specific line endings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11603,9 +11603,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.12",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.12.tgz",
+      "integrity": "sha512-1xGnbYN3zbog9CwuNDQULNRrTCLIn46/WmpR1f0w6PsCYQHkylZr5vkd6kfMZYV6pRnQkcPNRyiA8LsrNKyhpg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -44,6 +44,13 @@ describe('stripPythonCommentsAndStrings', () => {
 })
 
 describe('validatePythonCode', () => {
+  it('should not allow malicious code hidden behind carriage returns (\r)', () => {
+    // Malicious payload hidden behind a carriage return instead of a newline
+    const code = "# comment\rimport js"
+    expect(validatePythonCode(code).valid).toBe(false)
+    expect(validatePythonCode(code).error).toContain('js')
+  })
+
   it('should allow safe code', () => {
     expect(validatePythonCode('print("Hello")').valid).toBe(true)
     expect(validatePythonCode('import json').valid).toBe(true)

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -46,7 +46,7 @@ describe('stripPythonCommentsAndStrings', () => {
 describe('validatePythonCode', () => {
   it('should not allow malicious code hidden behind carriage returns (\r)', () => {
     // Malicious payload hidden behind a carriage return instead of a newline
-    const code = "# comment\rimport js"
+    const code = '# comment\rimport js'
     expect(validatePythonCode(code).valid).toBe(false)
     expect(validatePythonCode(code).error).toContain('js')
   })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,7 +120,12 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
+      let nextNewline = stripped.indexOf('\n', i)
+      const nextCR = stripped.indexOf('\r', i)
+
+      if (nextNewline === -1) nextNewline = nextCR
+      else if (nextCR !== -1 && nextCR < nextNewline) nextNewline = nextCR
+
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string
       }


### PR DESCRIPTION
This PR fixes a security vulnerability in `src/utils/codeSecurity.ts` where the python comment stripper only respected line feeds (\`\\n\`) and not carriage returns (\`\\r\`). A malicious user could use carriage returns to bypass the comment stripping logic and hide dangerous modules or keywords. The parser has been updated to check for and respect the earliest of either \`\\n\` or \`\\r\`. A test has been added to ensure this vulnerability does not regress.

---
*PR created automatically by Jules for task [14021308091494658338](https://jules.google.com/task/14021308091494658338) started by @saint2706*