### PR TITLE
⚡ Bolt: Cache ScrollProgress querySelector

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-18 - Caching document.querySelector in Scroll Event Handlers
+**Learning:** Calling `document.querySelector` inside a scroll event handler (even if debounced or throttled with `requestAnimationFrame`) can cause unnecessary main-thread overhead as it traverses the DOM on every tick.
+**Action:** When a React component needs to track a specific external DOM element during scroll events, cache the result of `document.querySelector` using `useRef`. Always verify the element is still in the DOM using `element.isConnected` to prevent holding onto stale references if the element is unmounted. Reset the ref in a `useEffect` if the selector prop changes.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,11 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const targetRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    targetRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +41,13 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        let element = targetRef.current
+        // ⚡ Bolt Optimization: Cache document.querySelector result in useRef to prevent
+        // unnecessary DOM queries on every scroll event tick.
+        if (!element || !element.isConnected) {
+          element = document.querySelector<HTMLElement>(targetSelector)
+          targetRef.current = element
+        }
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cache document.querySelector result using useRef in ScrollProgress component.
🎯 Why: Prevent unnecessary DOM queries on every scroll event when targetSelector is provided, reducing main-thread CPU usage during scrolling.
📊 Impact: Reduces document.querySelector overhead on scroll.
🔬 Measurement: Profile the scroll event and confirm `document.querySelector` is not repeatedly called.

---
*PR created automatically by Jules for task [12046622018414827915](https://jules.google.com/task/12046622018414827915) started by @saint2706*