### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix carriage return comment stripping bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-23 - Carriage Return Comment Stripper Bypass in Python Security Validator
+**Vulnerability:** The `stripPythonCommentsAndStrings` utility functions failed to recognize carriage returns (`\r`) as valid line endings for Python comments. Attackers could hide malicious code like `# comment\rimport os\nos.system(...)` which the security validator would treat entirely as a comment and thus allow, but the Python runtime would execute the code on the second line.
+**Learning:** Python (and its AST) considers `\r`, `\n`, and `\r\n` all as valid line terminators. A security validation routine that manually processes strings must account for all possible newline characters when parsing single-line structures like comments.
+**Prevention:** Always use regex or explicitly test for `\r` as well as `\n` when finding the end of a comment in a custom parser, or ideally, rely on the runtime's own AST parser if available to avoid implementation mismatches.

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -310,11 +310,9 @@ print("bad")
     expect(validatePythonCode('f"{eval(1)} "').valid).toBe(false)
   })
 
-
   it('should prevent newline bypass within comments', () => {
     // The carriage return (\r) was previously bypassing the comment stripper,
     // allowing the rest of the line (e.g. import os) to be evaluated as valid code.
     expect(validatePythonCode('# comment\rimport os').valid).toBe(false)
   })
-
 })

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -309,4 +309,12 @@ print("bad")
     expect(validatePythonCode('f"{1+1}"').valid).toBe(true)
     expect(validatePythonCode('f"{eval(1)} "').valid).toBe(false)
   })
+
+
+  it('should prevent newline bypass within comments', () => {
+    // The carriage return (\r) was previously bypassing the comment stripper,
+    // allowing the rest of the line (e.g. import os) to be evaluated as valid code.
+    expect(validatePythonCode('# comment\rimport os').valid).toBe(false)
+  })
+
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,7 +120,16 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
+      const nextLF = stripped.indexOf('\n', i)
+      const nextCR = stripped.indexOf('\r', i)
+
+      let nextNewline = -1
+      if (nextLF !== -1 && nextCR !== -1) {
+        nextNewline = Math.min(nextLF, nextCR)
+      } else {
+        nextNewline = Math.max(nextLF, nextCR)
+      }
+
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string
       }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The python code security validator failed to correctly detect carriage returns (`\r`) as end-of-line comment characters.
🎯 Impact: An attacker could bypass the python validation checks entirely.
🔧 Fix: Modified the parsing logic to check for both \n and \r characters.
✅ Verification: Handled safely in tests.

---
*PR created automatically by Jules for task [2686446381830342955](https://jules.google.com/task/2686446381830342955) started by @saint2706*