### PR TITLE
⚡ Bolt: Cache DOM queries in scroll handler

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-20 - Caching querySelector in ScrollProgress
+**Learning:** `document.querySelector` inside a high-frequency event handler like scroll events can cause performance bottlenecks as it searches the DOM on every frame request.
+**Action:** Always cache the results of `document.querySelector` in a `useRef` when used within high-frequency event handlers like scrolling, and ensure the ref is validated and updated appropriately if the target changes.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,12 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const targetElementRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    // Reset ref when targetSelector changes
+    targetElementRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +42,11 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        // Cache DOM query to prevent searching the document on every scroll frame
+        if (!targetElementRef.current || !targetElementRef.current.isConnected) {
+          targetElementRef.current = document.querySelector<HTMLElement>(targetSelector)
+        }
+        const element = targetElementRef.current
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cached the document.querySelector target using useRef in the ScrollProgress component.
🎯 Why: document.querySelector was being called on every animation frame during scrolling, which causes a DOM search on every frame.
📊 Impact: Eliminates redundant DOM queries, reducing CPU usage during scroll events.
🔬 Measurement: Verify scroll performance using Chrome DevTools Performance tab, specifically looking at scripting time during scroll.

---
*PR created automatically by Jules for task [15830212309490809537](https://jules.google.com/task/15830212309490809537) started by @saint2706*