### PR TITLE
Add manual workflow to close all open PRs and delete branches

### DIFF
--- a/.github/workflows/close-all-prs.yml
+++ b/.github/workflows/close-all-prs.yml
@@ -1,0 +1,68 @@
+name: Close All Open PRs
+
+# Manual-only cleanup tool: closes every open pull request against this repo
+# and deletes its head branch (skipped for branches that live on a fork).
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type CLOSE-ALL to confirm closing every open PR and deleting its branch'
+        required: true
+      dry_run:
+        description: 'Dry run: list what would happen without making changes'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  close-and-cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Guard confirmation
+        if: ${{ github.event.inputs.confirm != 'CLOSE-ALL' }}
+        run: |
+          echo "::error::Input 'confirm' must be exactly CLOSE-ALL. Aborting."
+          exit 1
+
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Close all open PRs and delete branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t prs < <(gh pr list --repo "$REPO" --state open --limit 1000 \
+            --json number,headRefName,isCrossRepository \
+            --jq '.[] | @base64')
+
+          echo "Found ${#prs[@]} open PR(s)."
+
+          for row in "${prs[@]}"; do
+            pr=$(echo "$row" | base64 --decode)
+            number=$(echo "$pr" | jq -r '.number')
+            branch=$(echo "$pr" | jq -r '.headRefName')
+            cross=$(echo "$pr" | jq -r '.isCrossRepository')
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[dry-run] Would close PR #$number and delete branch '$branch' (fork: $cross)"
+              continue
+            fi
+
+            echo "Closing PR #$number (branch: $branch)"
+            if [ "$cross" = "true" ]; then
+              gh pr close "$number" --repo "$REPO"
+              echo "  Branch '$branch' lives on a fork; not deleted."
+            else
+              gh pr close "$number" --repo "$REPO" --delete-branch \
+                || echo "  Warning: failed to delete branch '$branch' for PR #$number"
+            fi
+          done


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch`-only GitHub Action (`.github/workflows/close-all-prs.yml`) that lists every open PR, closes it, and deletes its head branch
- Fork-owned branches are closed but not deleted (the token can't delete branches on another repo)
- Requires typing `CLOSE-ALL` in the `confirm` input to run; `dry_run` defaults to `true` so the first run only logs intended actions

## Test plan
- [ ] Run the workflow manually with `dry_run: true` and confirm the log output lists the expected open PRs/branches
- [ ] Run again with `dry_run: false` and `confirm: CLOSE-ALL` on a repo with disposable test PRs to confirm closing + branch deletion behaves as expected
- [ ] Confirm fork-based PRs are closed but their branches are left alone


---
_Generated by [Claude Code](https://claude.ai/code/session_01MXQf53uwryitGz9Zq2jmir)_