### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix python comment stripping bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - [Fix Python Comment Stripping Bypass]
+**Vulnerability:** The Python comment stripper (`stripPythonCommentsAndStrings` in `src/utils/codeSecurity.ts`) only checked for the `\n` character to terminate a comment. Since the Python runtime treats `\r` as a valid newline, an attacker could hide executable code like `eval('import js')` immediately after a `\r` character inside a comment. The scanner would consider it a comment and allow it, but Python would execute it.
+**Learning:** When sanitizing or validating code across environments, we must align our parser's understanding of structural boundaries (like newlines) with the target runtime's interpreter (in this case, Pyodide's Python runtime).
+**Prevention:** Always check for all valid line terminator characters (both `\n` and `\r`) when implementing custom parsing or comment-stripping logic for security checks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11603,9 +11603,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -309,4 +309,8 @@ print("bad")
     expect(validatePythonCode('f"{1+1}"').valid).toBe(true)
     expect(validatePythonCode('f"{eval(1)} "').valid).toBe(false)
   })
+
+  it('should block malicious code hidden behind a carriage return in a comment', () => {
+    expect(validatePythonCode('# comment\reval("import js")').valid).toBe(false)
+  })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,7 +120,18 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
+      const nextN = stripped.indexOf('\n', i)
+      const nextR = stripped.indexOf('\r', i)
+
+      let nextNewline = -1
+      if (nextN !== -1 && nextR !== -1) {
+        nextNewline = Math.min(nextN, nextR)
+      } else if (nextN !== -1) {
+        nextNewline = nextN
+      } else if (nextR !== -1) {
+        nextNewline = nextR
+      }
+
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string
       }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Python comment stripping allowed command execution bypass via carriage returns.
🎯 Impact: An attacker could execute arbitrary python code by obfuscating it after a \r character.
🔧 Fix: Updated the parser to properly recognize both \n and \r as comment terminators.
✅ Verification: Added tests and ran full test suite.

---
*PR created automatically by Jules for task [16914660715211715277](https://jules.google.com/task/16914660715211715277) started by @saint2706*