### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection bypass in Python comment stripping

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - Fix command injection bypass in Python comment stripping
+**Vulnerability:** Python code execution could bypass the security checks by hiding dangerous imports/functions behind carriage return `\r` characters disguised as comments.
+**Learning:** The Python parser treats `\r` as well as `\n` as valid newlines, so our regex/parsing for removing comments that only looked for `\n` was flawed.
+**Prevention:** Always consider both `\r` and `\n` as newlines when implementing comment stripping or parsing logic for multi-line languages like Python.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11603,9 +11603,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -309,4 +309,9 @@ print("bad")
     expect(validatePythonCode('f"{1+1}"').valid).toBe(true)
     expect(validatePythonCode('f"{eval(1)} "').valid).toBe(false)
   })
+
+  it('handles carriage returns in comments', () => {
+    const maliciousCode = "# comment \r import os \n print(1)"
+    expect(validatePythonCode(maliciousCode).valid).toBe(false)
+  })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,8 +120,11 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
-      if (nextNewline === -1) {
+      let nextNewline = i;
+      while (nextNewline < stripped.length && stripped[nextNewline] !== '\n' && stripped[nextNewline] !== '\r') {
+        nextNewline++;
+      }
+      if (nextNewline === stripped.length) {
         break // Rest of the line is a comment, end of string
       }
       i = nextNewline // Skip to newline


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Python code execution could bypass security checks by hiding dangerous imports/functions behind carriage return `\r` characters disguised as comments.
🎯 Impact: Attackers could execute arbitrary Python code by exploiting the comment stripping logic.
🔧 Fix: Updated `stripPythonCommentsAndStrings` to handle both `\r` and `\n` as valid newlines.
✅ Verification: Added a test case and ran tests to verify the fix.

---
*PR created automatically by Jules for task [9616488136012434105](https://jules.google.com/task/9616488136012434105) started by @saint2706*