### PR TITLE
⚡ Bolt: Optimize sidebar scroll effects

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-24 - Avoiding Redundant Scroll Effects in React
+**Learning:** Automatically scrolling an active link into view using a naive `useEffect` on every location change can cause UI layout jumping or performance hits when the user is explicitly navigating deep pages. If the element is already scrolled to or intentionally skipped, scrolling it again is redundant and interrupts standard navigation flow.
+**Action:** Prevent redundant execution of scrolling effects by using a `useRef` to track whether it's the very first render and specifically skipping top-level or unneeded scrolling actions, only running the side-effect when actually required by the deep link layout.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -98,9 +98,20 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
 
   const openPhase = manualOpen !== null ? manualOpen : derivedOpenPhase
 
+  const isFirstRender = useRef(true)
   useEffect(() => {
     const nav = navRef.current
     if (!nav) return
+
+    // Only scroll into view if this is NOT the very first render,
+    // OR if we're on a deep link that needs initial scrolling.
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      if (location.pathname === '/' || location.pathname === '/curriculum') {
+        return // Skip initial scroll for top-level pages
+      }
+    }
+
     const timer = setTimeout(() => {
       const activeLink = nav.querySelector(
         '.day-link.active, .tree-item.active',

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -232,7 +232,7 @@ describe('Sidebar', () => {
     try {
       act(() => {
         root?.render(
-          <MemoryRouter initialEntries={['/']}>
+          <MemoryRouter initialEntries={['/notes']}>
             <Sidebar isOpen={true} onClose={vi.fn()} />
           </MemoryRouter>,
         )


### PR DESCRIPTION
💡 What: Optimized the `Sidebar` scroll effect to prevent redundant execution on the first render for top-level routes.
🎯 Why: A naive `useEffect` ran on every location change and unconditionally triggered `scrollIntoView` for active links. On initial load of top-level pages (like `/` or `/curriculum`), this caused unnecessary layout shifts and main-thread work since there's no deep link to scroll to. 
📊 Impact: Eliminates unnecessary layout calculation and DOM repaints on initial page load, resulting in faster and smoother time-to-interactive for top-level routes.
🔬 Measurement: Profile the initial render of the home page. Observe that layout and paint events related to `scrollIntoView` no longer occur.

---
*PR created automatically by Jules for task [14743495126520114898](https://jules.google.com/task/14743495126520114898) started by @saint2706*