### PR TITLE
🛡️ Sentinel: [HIGH] Fix Carriage Return bypass in codeSecurity.ts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-27 - [CRITICAL] Fix Carriage Return Bypass in Code Security Scanner
+**Vulnerability:** The Python code security scanner (`stripPythonCommentsAndStrings` in `src/utils/codeSecurity.ts`) failed to account for carriage returns (`\r`) when stripping comments. An attacker could start a line with a `#`, insert a `\r`, and append malicious code, effectively hiding it from the security scanner but still allowing Pyodide to execute it.
+**Learning:** Always consider all types of line terminators (`\n`, `\r`, `\r\n`) when performing text parsing for security validation, as different parsers and interpreters handle them differently, potentially leading to differential parser vulnerabilities.
+**Prevention:** Explicitly check for both `\n` and `\r` when seeking the end of a line in security scanners.

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,7 +120,17 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
+      const nextNewlineLf = stripped.indexOf('\n', i);
+      const nextNewlineCr = stripped.indexOf('\r', i);
+      let nextNewline = -1;
+
+      if (nextNewlineLf !== -1 && nextNewlineCr !== -1) {
+        nextNewline = Math.min(nextNewlineLf, nextNewlineCr);
+      } else if (nextNewlineLf !== -1) {
+        nextNewline = nextNewlineLf;
+      } else {
+        nextNewline = nextNewlineCr;
+      }
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string
       }

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,16 +120,16 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewlineLf = stripped.indexOf('\n', i);
-      const nextNewlineCr = stripped.indexOf('\r', i);
-      let nextNewline = -1;
+      const nextNewlineLf = stripped.indexOf('\n', i)
+      const nextNewlineCr = stripped.indexOf('\r', i)
+      let nextNewline = -1
 
       if (nextNewlineLf !== -1 && nextNewlineCr !== -1) {
-        nextNewline = Math.min(nextNewlineLf, nextNewlineCr);
+        nextNewline = Math.min(nextNewlineLf, nextNewlineCr)
       } else if (nextNewlineLf !== -1) {
-        nextNewline = nextNewlineLf;
+        nextNewline = nextNewlineLf
       } else {
-        nextNewline = nextNewlineCr;
+        nextNewline = nextNewlineCr
       }
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string


### PR DESCRIPTION
Fix carriage return bypass in python code security scanner

The python security scanner `stripPythonCommentsAndStrings` previously only checked for line feeds (`\n`) to terminate comments. An attacker could use a carriage return (`\r`) to hide malicious python code that Pyodide would execute, but the scanner would skip over. Fixed by checking for both \n and \r.

---
*PR created automatically by Jules for task [8640598809542344162](https://jules.google.com/task/8640598809542344162) started by @saint2706*