### PR TITLE
⚡ Bolt: Optimize ScrollProgress querySelector

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-26 - [Scroll Event Optimization]
+**Learning:** React `useEffect` hooks that query the DOM inside scroll event handlers can cause massive performance issues, as they evaluate `document.querySelector` on every scroll tick.
+**Action:** Use `useRef` to cache the DOM element reference instead of querying the DOM on every scroll event tick, keeping the main thread free. Make sure to reset the ref in a `useEffect` dependant on the target selector prop, in case the target changes. Check the element is connected to the DOM using `element.isConnected` to avoid stale references.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,12 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  // ⚡ Bolt: Cache target element to avoid querying the DOM on every scroll frame
+  const targetRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    targetRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +42,10 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        if (!targetRef.current || !targetRef.current.isConnected) {
+          targetRef.current = document.querySelector<HTMLElement>(targetSelector)
+        }
+        const element = targetRef.current
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cache the DOM element reference using useRef in ScrollProgress.tsx.\n🎯 Why: document.querySelector was being evaluated on every scroll event tick, which causes main thread overhead.\n📊 Impact: Eliminates redundant DOM queries, keeping the main thread free and reducing unnecessary layout thrashing.\n🔬 Measurement: Scroll down a long lesson page and observe lower CPU usage / fewer style recalculations in DevTools.

---
*PR created automatically by Jules for task [10532471240375995559](https://jules.google.com/task/10532471240375995559) started by @saint2706*