### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOMPurify vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-26 - [DOMPurify Bypass]
+**Vulnerability:** DOMPurify <=3.4.11 has a bypass via `CUSTOM_ELEMENT_HANDLING` bypassing `afterSanitizeElements`.
+**Learning:** Outdated dompurify dependency in package.json exposed this vulnerability. The vulnerability was found through `npm audit`.
+**Prevention:** Regularly run `npm audit` and update dependencies to their patched versions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/mdast": "^4.0.4",
         "canvas-confetti": "^1.9.3",
         "d3": "^7.9.0",
-        "dompurify": "^3.4.11",
+        "dompurify": "^3.4.12",
         "fuse.js": "^7.4.2",
         "katex": "^0.16.45",
         "mermaid": "^11.15.0",
@@ -4773,9 +4773,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -11603,9 +11603,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/mdast": "^4.0.4",
     "canvas-confetti": "^1.9.3",
     "d3": "^7.9.0",
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.12",
     "fuse.js": "^7.4.2",
     "katex": "^0.16.45",
     "mermaid": "^11.15.0",


### PR DESCRIPTION
Updated dompurify dependency to resolve GHSA-c2j3-45gr-mqc4 vulnerability where CUSTOM_ELEMENT_HANDLING bypasses afterSanitizeElements.

---
*PR created automatically by Jules for task [5603525007573465141](https://jules.google.com/task/5603525007573465141) started by @saint2706*