### PR TITLE
⚡ Bolt: [performance improvement] Cache DOM queries in scroll events

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Caching DOM lookups in scroll events
+**Learning:** `document.querySelector` inside scroll handlers can be expensive, causing layout thrashing or slowdowns during scrolling.
+**Action:** Use `useRef` to cache the DOM element and verify presence with `.isConnected`, resetting it only when the selector prop changes.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,15 +28,22 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  // ⚡ Cache target element to avoid querying the DOM on every scroll frame
+  const targetRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
+    // Reset the cached ref when the selector changes to prevent stale elements
+    targetRef.current = null
     let ticking = false
 
     const updateProgress = () => {
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        if (!targetRef.current || !targetRef.current.isConnected) {
+          targetRef.current = document.querySelector<HTMLElement>(targetSelector)
+        }
+        const element = targetRef.current
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Caches the `document.querySelector` call for the scroll target using `useRef`.
🎯 Why: The scroll event handler runs frequently (every frame) and querying the DOM on every execution is an expensive operation that can cause layout thrashing.
📊 Impact: Eliminates redundant DOM queries on every scroll frame, making scroll performance smoother and reducing CPU usage.
🔬 Measurement: Profile the scroll event in Chrome DevTools to verify reduced scripting time during continuous scrolling.

---
*PR created automatically by Jules for task [7588004418609071785](https://jules.google.com/task/7588004418609071785) started by @saint2706*