### PR TITLE
🛡️ Sentinel: [HIGH] Fix Python Code Security Validation Bypass via Carriage Return Comment Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-26 - [Bypass Fix] Carriage Return Comment Injection
+**Vulnerability:** Python code validation could be bypassed by injecting malicious code after a carriage return (\r) in a comment. The stripPythonCommentsAndStrings function only recognized \n as a newline, allowing \r to hide code from the security scanner while the Python runtime executed it.
+**Learning:** Python treats \r as a valid newline, but simple parsers often only look for \n. Attackers can hide malicious payloads behind \r inside comments.
+**Prevention:** Always use an AST or handle both \r and \n when stripping comments in custom security parsers.

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -309,4 +309,10 @@ print("bad")
     expect(validatePythonCode('f"{1+1}"').valid).toBe(true)
     expect(validatePythonCode('f"{eval(1)} "').valid).toBe(false)
   })
+
+  it('should treat carriage return as newline when stripping comments', () => {
+    // Malicious code hidden behind \r in a comment. Python treats \r as a newline.
+    // So the parser needs to stop the comment at \r.
+    expect(validatePythonCode('x = 1 # harmless comment\r__import__("os")').valid).toBe(false)
+  })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,7 +120,16 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
+      // Find the next newline character (either \n or \r)
+      const nextN = stripped.indexOf('\n', i)
+      const nextR = stripped.indexOf('\r', i)
+      let nextNewline = -1
+
+      if (nextN !== -1 && nextR !== -1) {
+        nextNewline = Math.min(nextN, nextR)
+      } else {
+        nextNewline = Math.max(nextN, nextR)
+      }
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string
       }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Code validation logic in `stripPythonCommentsAndStrings` failed to recognize `\r` as a newline, allowing malicious code to be hidden inside comments and bypass security checks.
🎯 Impact: Attackers could execute arbitrary Python code bypassing restrictions on Pyodide/system APIs by injecting `\r` followed by restricted code into comments.
🔧 Fix: Updated the parser to properly recognize both `\r` and `\n` as newlines when stripping comments.
✅ Verification: Added tests explicitly asserting that `\r` terminates comments and exposes subsequent code to validation.

---
*PR created automatically by Jules for task [16197940880144483664](https://jules.google.com/task/16197940880144483664) started by @saint2706*