### PR TITLE
⚡ Bolt: Cache DOM queries in scroll event handlers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-29 - Optimizing React scroll event handlers by caching DOM queries
+**Learning:** Calling `document.querySelector` inside a highly frequent event like `scroll` can cause performance issues (jank and layout thrashing), even if debounced or within `requestAnimationFrame`.
+**Action:** Always cache the result of DOM queries using `useRef` when used inside scroll event handlers. Ensure the cache validity is checked using `!ref.current || !ref.current.isConnected` to gracefully handle elements dynamically added or removed from the DOM, and reset the ref inside a `useEffect` when the target selector prop changes to avoid stale references.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,15 +28,23 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const elementRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
+    // Reset cached element when targetSelector changes to prevent stale references
+    elementRef.current = null
+
     let ticking = false
 
     const updateProgress = () => {
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        // Cache querySelector result for performance since this runs on scroll
+        if (!elementRef.current || !elementRef.current.isConnected) {
+          elementRef.current = document.querySelector<HTMLElement>(targetSelector)
+        }
+        const element = elementRef.current
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 **What:** Added a `useRef` to cache the result of `document.querySelector(targetSelector)` in the `ScrollProgress` component's scroll event handler. The ref validity is continually checked using `!elementRef.current || !elementRef.current.isConnected`, and resets explicitly when `targetSelector` changes.

🎯 **Why:** The component attached a passive scroll event listener that invoked `document.querySelector` up to 60 times a second (when ticking) while the user scrolled. DOM queries can cause unnecessary layout recalculations and negatively impact frame rates (jank). 

📊 **Impact:** Reduces DOM query calls to essentially O(1) per mounting/prop change instead of O(scroll events). 

🔬 **Measurement:** Verify by running the application, scrolling quickly in a page with a `targetSelector` and checking the Performance tab in DevTools; there should be a visible reduction in Main thread blocking tasks triggered by scroll events.

---
*PR created automatically by Jules for task [14676473239360412360](https://jules.google.com/task/14676473239360412360) started by @saint2706*