### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix comment parsing logic

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - Fix Pyodide comment stripping bypass
+**Vulnerability:** The `stripPythonCommentsAndStrings` function in `src/utils/codeSecurity.ts` only treated `\n` as a comment terminator. An attacker could hide malicious code behind a carriage return (`\r`) in a comment, which the parser would ignore, but the Python runtime would execute.
+**Learning:** When sanitizing code (e.g., Python) before security validation, always ensure the parser treats both carriage return (`\r`) and line feed (`\n`) characters as valid newlines. Relying only on `\n` allows attackers to hide malicious code behind a `\r`, which the Python runtime will execute.
+**Prevention:** Explicitly check for both `\n` and `\r` when determining the end of a comment line in custom parsers, or use an AST parser.

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -278,6 +278,12 @@ print("bad")
     })
   })
 
+  it('should treat both \n and \r as comment terminators to prevent malicious code hiding', () => {
+    // If \r is not handled, the rest of the line is stripped as a comment, bypassing the exec check.
+    const malicious = '# harmless \r exec("import js")'
+    expect(validatePythonCode(malicious).valid).toBe(false)
+  })
+
   describe('Pyodide Internals', () => {
     it('should block import pyodide', () => {
       expect(validatePythonCode('import pyodide').valid).toBe(false)

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,11 +120,14 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
-      if (nextNewline === -1) {
+      let endOfComment = i
+      while (endOfComment < stripped.length && stripped[endOfComment] !== '\n' && stripped[endOfComment] !== '\r') {
+        endOfComment++
+      }
+      if (endOfComment === stripped.length) {
         break // Rest of the line is a comment, end of string
       }
-      i = nextNewline // Skip to newline
+      i = endOfComment // Skip to newline
       continue
     }
 

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -121,7 +121,11 @@ export function stripPythonCommentsAndStrings(code: string): string {
 
     if (!inString && char === '#') {
       let endOfComment = i
-      while (endOfComment < stripped.length && stripped[endOfComment] !== '\n' && stripped[endOfComment] !== '\r') {
+      while (
+        endOfComment < stripped.length &&
+        stripped[endOfComment] !== '\n' &&
+        stripped[endOfComment] !== '\r'
+      ) {
         endOfComment++
       }
       if (endOfComment === stripped.length) {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The parser only treated \n as a comment terminator.
🎯 Impact: Attackers could execute arbitrary code by exploiting the comment stripping logic mismatch.
🔧 Fix: Updated the parser to treat both \n and \r as comment terminators.
✅ Verification: Added a test case and ran vitest suite.

---
*PR created automatically by Jules for task [6076379079274643674](https://jules.google.com/task/6076379079274643674) started by @saint2706*