### PR TITLE
⚡ Bolt: Debounce route prefetch handlers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-30 - Optimize route prefetch handlers
+**Learning:** Attaching heavy event handlers (like route prefetching) to `onMouseEnter`, `onFocus`, or `onTouchStart` across hundreds of DOM elements simultaneously (e.g., links in a large Sidebar) can cause main-thread churn. Rapid bursts of events trigger consecutive immediate state or network deduplication checks.
+**Action:** Consolidate rapid bursts of events by debouncing the calls using a shared/global timeout variable.

--- a/src/utils/prefetchRoutes.ts
+++ b/src/utils/prefetchRoutes.ts
@@ -59,10 +59,22 @@ export function prefetchRoute(path: string) {
  * @param {string} path - The target route path.
  * @returns {{onMouseEnter: () => void, onFocus: () => void, onTouchStart: () => void}} The event handlers.
  */
+// Global debounce to prevent rapid prefetch spam when sweeping cursor across multiple links
+let prefetchTimeout: ReturnType<typeof setTimeout> | null = null
+
 export function createRoutePrefetchHandlers(path: string) {
+  const handlePrefetch = () => {
+    if (prefetchTimeout) {
+      clearTimeout(prefetchTimeout)
+    }
+    prefetchTimeout = setTimeout(() => {
+      prefetchRoute(path)
+    }, 50)
+  }
+
   return {
-    onMouseEnter: () => prefetchRoute(path),
-    onFocus: () => prefetchRoute(path),
-    onTouchStart: () => prefetchRoute(path),
+    onMouseEnter: handlePrefetch,
+    onFocus: handlePrefetch,
+    onTouchStart: handlePrefetch,
   }
 }


### PR DESCRIPTION
💡 What: Adds a global 50ms debounce to the `createRoutePrefetchHandlers` utility.
🎯 Why: Attaching immediate prefetch calls to onMouseEnter/onFocus/onTouchStart on hundreds of links (e.g., in the large Sidebar) causes main-thread churn when hovering or scrolling quickly, triggering rapid state checks or redundant network requests.
📊 Impact: Reduces main-thread execution time by consolidating multiple rapid prefetch triggers into a single invocation when navigating the sidebar.
🔬 Measurement: Profile the UI using Chrome DevTools when rapidly moving the mouse over the sidebar phase groups; observe fewer synchronous `prefetchRoute` execution calls.

---
*PR created automatically by Jules for task [3264072882036863719](https://jules.google.com/task/3264072882036863719) started by @saint2706*