### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Python Sandbox Bypass via Carriage Return in Comments

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-01 - Python Comment Stripping Carriage Return Bypass
+**Vulnerability:** The `stripPythonCommentsAndStrings` function in `src/utils/codeSecurity.ts` only looked for `\n` to identify the end of a comment. This meant that a comment ending in a carriage return (`\r`) followed by dangerous code on the same physical line (from the perspective of the basic string search) would incorrectly strip the dangerous code.
+**Learning:** Python treats both `\n` and `\r` as newline characters when parsing comments. Relying solely on `\n` allows attackers to hide malicious code behind a `\r`, which the Python runtime will execute.
+**Prevention:** Always use an AST or a state-machine parser that correctly considers all language-specific newline variations (`\n` and `\r`) to accurately distinguish string literals and comments when sanitizing code.

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -250,6 +250,11 @@ print("bad")
     expect(validatePythonCode('getattr(f, "__globals__")').valid).toBe(false)
   })
 
+
+  it('should block carriage returns in comments bypassing checks', () => {
+    expect(validatePythonCode('# comment \rimport js').valid).toBe(false)
+  })
+
   it('should block line continuations bypassing checks', () => {
     expect(validatePythonCode('import \\\njs').valid).toBe(false)
     expect(validatePythonCode('from \\\njs import window').valid).toBe(false)

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -250,7 +250,6 @@ print("bad")
     expect(validatePythonCode('getattr(f, "__globals__")').valid).toBe(false)
   })
 
-
   it('should block carriage returns in comments bypassing checks', () => {
     expect(validatePythonCode('# comment \rimport js').valid).toBe(false)
   })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,8 +120,11 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
-      if (nextNewline === -1) {
+      let nextNewline = i
+      while (nextNewline < stripped.length && stripped[nextNewline] !== '\n' && stripped[nextNewline] !== '\r') {
+        nextNewline++
+      }
+      if (nextNewline === stripped.length) {
         break // Rest of the line is a comment, end of string
       }
       i = nextNewline // Skip to newline

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -121,7 +121,11 @@ export function stripPythonCommentsAndStrings(code: string): string {
 
     if (!inString && char === '#') {
       let nextNewline = i
-      while (nextNewline < stripped.length && stripped[nextNewline] !== '\n' && stripped[nextNewline] !== '\r') {
+      while (
+        nextNewline < stripped.length &&
+        stripped[nextNewline] !== '\n' &&
+        stripped[nextNewline] !== '\r'
+      ) {
         nextNewline++
       }
       if (nextNewline === stripped.length) {


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The python comment stripping code only recognized \n, allowing attackers to hide malicious execution code behind a carriage return \r.
🎯 Impact: Attackers could inject arbitrary code into the pyodide environment, bypassing security filters.
🔧 Fix: Update the stripping logic to stop at both \n and \r.
✅ Verification: Ensure tests pass and the carriage return bypass test succeeds.

---
*PR created automatically by Jules for task [5959393219232341453](https://jules.google.com/task/5959393219232341453) started by @saint2706*