### PR TITLE
⚡ Bolt: Cache DOM queries in scroll handlers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-09 - Caching querySelector in Scroll Handlers
+**Learning:** In heavily re-rendered or fast-firing components like `ScrollProgress.tsx`, performing `document.querySelector` on every `requestAnimationFrame` interval or scroll event can introduce unnecessary main-thread overhead and GC thrashing.
+**Action:** When implementing scroll listeners or requestAnimationFrame loops that depend on DOM lookups, cache the lookup result in a `useRef` and conditionally re-fetch only if the node becomes disconnected (`!element.isConnected`).

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,11 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const cachedTargetRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    cachedTargetRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +41,11 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        let element = cachedTargetRef.current
+        if (!element || !element.isConnected) {
+          element = document.querySelector<HTMLElement>(targetSelector)
+          cachedTargetRef.current = element
+        }
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Caches document.querySelector results in a useRef for ScrollProgress.
🎯 Why: document.querySelector is called on every scroll frame, causing unnecessary DOM queries and potentially lagging the main thread.
📊 Impact: Reduces expensive DOM lookups significantly during scroll events.
🔬 Measurement: Profile the scrolling performance in React DevTools to observe reduced frame times.

---
*PR created automatically by Jules for task [16813811935224659910](https://jules.google.com/task/16813811935224659910) started by @saint2706*