### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix carriage return bypass in Python code validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - Fix Comment Stripping Carriage Return Bypass
+**Vulnerability:** The Python comment stripper only recognized `\n` as a newline terminator for comments, ignoring carriage returns (`\r`). This allowed a sandbox bypass where malicious code injected immediately after a `\r` (e.g., `# comment\rimport os`) would be stripped out of validation checks but executed by the Python runtime (which accepts `\r` as a newline).
+**Learning:** When sanitizing code (e.g., Python) before security validation, avoid relying solely on simple regular expressions (like `/#.*/g`) or single character checks for comment stripping. This can inadvertently strip malicious payloads disguised as comments inside strings, or allow bypasses by using alternative newline characters.
+**Prevention:** Always ensure parsers handling newlines treat both carriage return (`\r`) and line feed (`\n`) characters as valid line terminators to accurately distinguish comments from executable code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11603,9 +11603,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -309,4 +309,9 @@ print("bad")
     expect(validatePythonCode('f"{1+1}"').valid).toBe(true)
     expect(validatePythonCode('f"{eval(1)} "').valid).toBe(false)
   })
+
+  it('should block sandbox escape via carriage return in comments', () => {
+    expect(validatePythonCode('# comment\rimport js').valid).toBe(false)
+    expect(validatePythonCode('# comment\r\nimport js').valid).toBe(false)
+  })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,7 +120,16 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
+      const nextLF = stripped.indexOf('\n', i)
+      const nextCR = stripped.indexOf('\r', i)
+
+      let nextNewline = -1
+      if (nextLF !== -1 && nextCR !== -1) {
+        nextNewline = Math.min(nextLF, nextCR)
+      } else {
+        nextNewline = Math.max(nextLF, nextCR)
+      }
+
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string
       }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Python comment stripper ignores carriage returns (\r), allowing malicious code to hide behind comments and execute.
🎯 Impact: Attackers can execute arbitrary restricted Python code (like system commands or reading sensitive files).
🔧 Fix: Updated comment parsing logic to correctly identify both \n and \r as terminators.
✅ Verification: Added unit tests. Run `npm run test` to verify.

---
*PR created automatically by Jules for task [17451881977973040666](https://jules.google.com/task/17451881977973040666) started by @saint2706*