### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix comment injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - [Fix code injection via CR comments in codeSecurity]
+**Vulnerability:** The custom Python comment stripping function `stripPythonCommentsAndStrings` in `src/utils/codeSecurity.ts` only treated `\n` as the end of a comment. It failed to account for `\r` (carriage return).
+**Learning:** Python runtime will happily treat `\r` as a newline terminator for comments, executing code on the next line. If a custom parser only checks for `\n`, an attacker can write a payload like `import math # comment \r import os` to bypass the scanner because `import os` is treated as part of the comment by the scanner, but executed by the interpreter.
+**Prevention:** When building state machines or parsers that attempt to model an interpreter's behavior, always ensure you match the exact set of valid token delimiters (such as newlines, which can be `\n`, `\r`, or `\r\n`).

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,11 +120,22 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
+      const nextN = stripped.indexOf('\n', i)
+      const nextR = stripped.indexOf('\r', i)
+
+      let nextNewline = -1
+      if (nextN !== -1 && nextR !== -1) {
+        nextNewline = Math.min(nextN, nextR)
+      } else if (nextN !== -1) {
+        nextNewline = nextN
+      } else {
+        nextNewline = nextR
+      }
+
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string
       }
-      i = nextNewline // Skip to newline
+      i = nextNewline // DO NOT skip over the newline. Leave it to be processed on the next loop iteration.
       continue
     }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Code security comment parsing failed to account for carriage returns (\r).
🎯 Impact: An attacker could hide executable code in what appeared to be a comment, bypassing security filters since python executes it.
🔧 Fix: Handled both \n and \r as valid line terminators during comment parsing.
✅ Verification: Code validated securely with testing.

---
*PR created automatically by Jules for task [18216583636704585685](https://jules.google.com/task/18216583636704585685) started by @saint2706*