### PR TITLE
⚡ Bolt: [performance improvement] Cache target element in ScrollProgress

### DIFF
--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,13 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  // Cache the target element to avoid expensive DOM queries on every scroll event
+  const targetElementRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    // Reset the cached element when the selector changes
+    targetElementRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +43,11 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        // Reuse cached element if it is still connected to the DOM
+        if (!targetElementRef.current || !targetElementRef.current.isConnected) {
+          targetElementRef.current = document.querySelector<HTMLElement>(targetSelector)
+        }
+        const element = targetElementRef.current
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cached the `document.querySelector` result in a `useRef` within the `ScrollProgress` component.
🎯 Why: To avoid expensive DOM queries on every scroll event, which can lead to main-thread thrashing on pages with complex DOM structures.
📊 Impact: Reduces main-thread blocking during rapid scrolling by reusing the cached element reference.
🔬 Measurement: Profile the main thread during scrolling; the time spent in `updateProgress` will be significantly reduced.

---
*PR created automatically by Jules for task [11258307960214674990](https://jules.google.com/task/11258307960214674990) started by @saint2706*