### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Python validation bypass via carriage returns in comments

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-03 - Bypass Python Security Check with CR in Comments
+**Vulnerability:** Python security validation bypass via carriage returns (`\r`) in comments.
+**Learning:** `stripPythonCommentsAndStrings` stops stripping a comment at `\n` but the Python runtime treats `\r` (carriage return) as a valid newline as well. By inserting a `\r` within a comment, the remainder of the line is executed by Python, but stripped from the code before the regex check is applied, bypassing module bans like `import os`.
+**Prevention:** Ensure the parser correctly recognizes `\r` as a newline character that ends a comment, just like `\n`.

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -309,4 +309,7 @@ print("bad")
     expect(validatePythonCode('f"{1+1}"').valid).toBe(true)
     expect(validatePythonCode('f"{eval(1)} "').valid).toBe(false)
   })
+  it('should not be bypassed with carriage return inside comment', () => {
+    expect(validatePythonCode('import sys\n# this is a comment \rimport os').valid).toBe(false)
+  })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,15 +120,15 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextLF = stripped.indexOf('\n', i);
-      const nextCR = stripped.indexOf('\r', i);
-      let nextNewline = -1;
+      const nextLF = stripped.indexOf('\n', i)
+      const nextCR = stripped.indexOf('\r', i)
+      let nextNewline = -1
       if (nextLF !== -1 && nextCR !== -1) {
-        nextNewline = Math.min(nextLF, nextCR);
+        nextNewline = Math.min(nextLF, nextCR)
       } else if (nextLF !== -1) {
-        nextNewline = nextLF;
+        nextNewline = nextLF
       } else if (nextCR !== -1) {
-        nextNewline = nextCR;
+        nextNewline = nextCR
       }
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,7 +120,16 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
+      const nextLF = stripped.indexOf('\n', i);
+      const nextCR = stripped.indexOf('\r', i);
+      let nextNewline = -1;
+      if (nextLF !== -1 && nextCR !== -1) {
+        nextNewline = Math.min(nextLF, nextCR);
+      } else if (nextLF !== -1) {
+        nextNewline = nextLF;
+      } else if (nextCR !== -1) {
+        nextNewline = nextCR;
+      }
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string
       }


### PR DESCRIPTION
Severity: CRITICAL
Vulnerability: Python validation bypass via carriage returns (`\r`) in comments.
Impact: Allows execution of banned Python modules like `os` or `sys`.
Fix: Ensure the parser correctly recognizes `\r` as a newline character that ends a comment.
Verification: Run `npm test`

---
*PR created automatically by Jules for task [5721340622551618221](https://jules.google.com/task/5721340622551618221) started by @saint2706*