### PR TITLE
⚡ Bolt: Cache ScrollProgress target element

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-08-05 - Optimize ScrollProgress element selection
+**Learning:** The ScrollProgress component repeatedly calls `document.querySelector` inside a scroll event handler (`updateProgress` via `requestAnimationFrame`), which creates unnecessary DOM queries on every scroll tick.
+**Action:** Cache the queried element in a `useRef`, verifying it with `isConnected` to handle DOM unmounts, and resetting the ref when the `targetSelector` prop changes.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,12 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const targetElementRef = useRef<HTMLElement | null>(null)
+
+  // Reset the cached element when the selector changes
+  useEffect(() => {
+    targetElementRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +42,11 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        let element = targetElementRef.current
+        if (!element || !element.isConnected) {
+          element = document.querySelector<HTMLElement>(targetSelector)
+          targetElementRef.current = element
+        }
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Caches the `document.querySelector` lookup in a `useRef` for the `ScrollProgress` component.
🎯 Why: Calling `document.querySelector` inside a scroll event handler (even inside requestAnimationFrame) triggers unnecessary DOM lookups on every scroll tick.
📊 Impact: Improves scroll performance and reduces main-thread layout thrashing by eliminating repeated DOM queries.
🔬 Measurement: Profile the scroll event handler performance in the browser devtools before and after; notice the absence of repetitive querySelector calls.

---
*PR created automatically by Jules for task [2218409166772924482](https://jules.google.com/task/2218409166772924482) started by @saint2706*