### PR TITLE
⚡ Bolt: Cache DOM query in ScrollProgress

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - [Scroll Event Optimization]
+**Learning:** React scroll event handlers that frequently query the DOM (e.g. `document.querySelector`) can cause significant performance overhead and main-thread layout thrashing if the result isn't cached.
+**Action:** When implementing scroll-based UI (like a progress bar), always cache DOM queries in a `useRef`, ensure the element `isConnected` to avoid stale references, and reset the cache using a `useEffect` dependent on any selector props.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,11 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const targetRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    targetRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +41,13 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        if (
+          !targetRef.current ||
+          !(targetRef.current.isConnected || document.body.contains(targetRef.current))
+        ) {
+          targetRef.current = document.querySelector<HTMLElement>(targetSelector)
+        }
+        const element = targetRef.current
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cache document.querySelector result in a useRef in ScrollProgress component.
🎯 Why: document.querySelector is slow and can cause unnecessary layout trashing on each scroll event if left uncached. It forces recalculation, affecting overall scroll performance.
📊 Impact: Eliminates repetitive DOM queries on scroll, making the scroll progress bar more performant without breaking functionality.
🔬 Measurement: Profile the scroll event with Chrome dev tools before and after, verifying fewer recalculate styles and layout shift hits.

---
*PR created automatically by Jules for task [15921599407193634834](https://jules.google.com/task/15921599407193634834) started by @saint2706*