### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Python comment stripping bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2023-11-20 - [Fix Code Security Bypass using Carriage Return]
+**Vulnerability:** The code security validator `stripPythonCommentsAndStrings` fails to handle carriage return `\r` as a newline character when stripping comments, allowing attackers to hide malicious code behind a carriage return inside a comment.
+**Learning:** Python treats `\r` (carriage return) as a valid newline character. If the code parser only looks for `\n`, malicious code can bypass the validator by using `\r`.
+**Prevention:** Use `\n` and `\r` together or parse all newline tokens natively when manually iterating and identifying end of line symbols in custom parsers.

--- a/src/utils/__tests__/codeSecurity.bypass.test.ts
+++ b/src/utils/__tests__/codeSecurity.bypass.test.ts
@@ -105,12 +105,10 @@ except Exception as e:
     expect(validatePythonCode('z = f_code').valid).toBe(false)
   })
 
-
   it('should block comment bypass using carriage returns', () => {
     // If the comment stripper only looks for newline, it will strip the CR and everything after it as a comment.
     // Python will execute what is after CR.
     expect(validatePythonCode('# comment\reval(1)').valid).toBe(false)
     expect(validatePythonCode('print(1)\n# comment\rimport js').valid).toBe(false)
   })
-
 })

--- a/src/utils/__tests__/codeSecurity.bypass.test.ts
+++ b/src/utils/__tests__/codeSecurity.bypass.test.ts
@@ -104,4 +104,13 @@ except Exception as e:
     expect(validatePythonCode('y = f_builtins').valid).toBe(false)
     expect(validatePythonCode('z = f_code').valid).toBe(false)
   })
+
+
+  it('should block comment bypass using carriage returns', () => {
+    // If the comment stripper only looks for newline, it will strip the CR and everything after it as a comment.
+    // Python will execute what is after CR.
+    expect(validatePythonCode('# comment\reval(1)').valid).toBe(false)
+    expect(validatePythonCode('print(1)\n# comment\rimport js').valid).toBe(false)
+  })
+
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,7 +120,14 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
+      const nextN = stripped.indexOf('\n', i)
+      const nextR = stripped.indexOf('\r', i)
+
+      let nextNewline = -1
+      if (nextN !== -1 && nextR !== -1) nextNewline = Math.min(nextN, nextR)
+      else if (nextN !== -1) nextNewline = nextN
+      else nextNewline = nextR
+
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string
       }


### PR DESCRIPTION
- Severity: CRITICAL
- Vulnerability: The python code security validator `stripPythonCommentsAndStrings` failed to handle carriage return `\r` as a newline character.
- Impact: Attackers could hide malicious Python code execution behind a carriage return inside a comment to bypass the sandbox security check.
- Fix: Updated `stripPythonCommentsAndStrings` to look for both `\n` and `\r` as end of line comment symbols.
- Verification: Run `npm run test` to see tests pass, specifically `src/utils/__tests__/codeSecurity.bypass.test.ts`.

---
*PR created automatically by Jules for task [14610127347188244980](https://jules.google.com/task/14610127347188244980) started by @saint2706*