### PR TITLE
⚡ Bolt: Cache ScrollProgress DOM query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-10-31 - Scroll Event Ref Caching
+**Learning:** High-frequency event listeners (like scroll) in React components can severely impact performance if they execute DOM queries (e.g., `document.querySelector`) on every tick.
+**Action:** Always cache DOM elements accessed during scroll events using `useRef` and ensure you invalidate the cache correctly when the component or selector changes. Validate the cache using `element.isConnected` to prevent stale reference bugs.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,11 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const elementRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    elementRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +41,12 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        // Cache the DOM query to avoid expensive lookups during high-frequency scroll events
+        let element = elementRef.current
+        if (!element || !element.isConnected) {
+          element = document.querySelector<HTMLElement>(targetSelector)
+          elementRef.current = element
+        }
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cached the `document.querySelector` call inside `ScrollProgress` using `useRef` to avoid executing it on every scroll tick.
🎯 Why: High-frequency scroll events querying the DOM repeatedly causes main-thread churn and reduces scroll performance.
📊 Impact: Eliminates redundant DOM lookups, improving frame rate during scrolling on pages containing the progress bar.
🔬 Measurement: Verify scroll performance using browser DevTools Performance tab, specifically looking for reduced main thread work during scroll events.

---
*PR created automatically by Jules for task [13439534138290284651](https://jules.google.com/task/13439534138290284651) started by @saint2706*