### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Python security validation bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-15 - CRITICAL: Python Comment Stripping Bypass using Carriage Return (\r)
+**Vulnerability:** The `stripPythonCommentsAndStrings` function in `src/utils/codeSecurity.ts` only looked for `\n` when stripping comments. An attacker could provide a payload like `# \rimport os` which would bypass the comment removal, but when executed by Python, Python treats `\r` as a newline, thereby executing the `import os` command hidden behind a comment.
+**Learning:** Python's AST parser treats both line feed (`\n`) and carriage return (`\r`) as valid newlines, but naive regex or string scanning often only accounts for `\n`.
+**Prevention:** Always consider both `\n` and `\r` when determining line boundaries in code security validation routines, or use an actual AST parser instead of manual string parsing.

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -145,6 +145,12 @@ print("bad")
     expect(validatePythonCode('exec("im" + "port js")').valid).toBe(false)
   })
 
+  it('should prevent carriage return comment bypass (Security Fix)', () => {
+    // Attackers might use \r instead of \n to hide malicious code in a comment
+    expect(validatePythonCode('# comment \rimport os').valid).toBe(false)
+    expect(validatePythonCode('# harmless \r import js').valid).toBe(false)
+  })
+
   it('should block eval/exec assignment (Bypass Fix)', () => {
     expect(validatePythonCode('e = exec').valid).toBe(false)
     expect(validatePythonCode('my_eval = eval').valid).toBe(false)

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,7 +120,12 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
+      let nextNewline = stripped.indexOf('\n', i)
+      const nextCR = stripped.indexOf('\r', i)
+      if (nextNewline === -1 || (nextCR !== -1 && nextCR < nextNewline)) {
+        nextNewline = nextCR
+      }
+
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string
       }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `stripPythonCommentsAndStrings` utility only detected `\n` to mark the end of comments, but Python parses both `\n` and `\r` as newlines. An attacker could append a payload like `# \rimport os` that bypassed validation (as it appeared to be within a comment) but executed within Pyodide.
🎯 Impact: Remote Code Execution / Sandbox Escape within the browser's Pyodide environment.
🔧 Fix: Updated the `stripPythonCommentsAndStrings` logic to check for the first occurrence of either `\n` or `\r` when stripping comments. Added regression tests to `codeSecurity.test.ts`.
✅ Verification: Ran the full vitest suite. Tests for both `\r` payloads correctly fail validation.

Included `.jules/sentinel.md` journal entry.

---
*PR created automatically by Jules for task [11046180035730364957](https://jules.google.com/task/11046180035730364957) started by @saint2706*