### PR TITLE
⚡ Bolt: Debounce route prefetching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - Debouncing Route Prefetching
+**Learning:** Attaching route prefetching logic directly to hover, focus, and touch events on numerous sidebar items causes rapid consecutive state checks (and potential network requests, although mostly deduplicated via state) which can block the main thread and impact frontend performance in React architectures with heavy component trees.
+**Action:** Consolidate these rapid bursts of prefetch events by debouncing the calls using a shared/global timeout variable.

--- a/src/utils/prefetchRoutes.ts
+++ b/src/utils/prefetchRoutes.ts
@@ -52,6 +52,17 @@ export function prefetchRoute(path: string) {
   void route.load()
 }
 
+let prefetchTimeout: ReturnType<typeof setTimeout> | null = null
+
+export function prefetchRouteDebounced(path: string) {
+  if (prefetchTimeout) {
+    clearTimeout(prefetchTimeout)
+  }
+  prefetchTimeout = setTimeout(() => {
+    prefetchRoute(path)
+  }, 50)
+}
+
 /**
  * Creates event handlers for prefetching on hover, focus, or touch.
  * Spread these props onto a Link or Button element.
@@ -61,8 +72,8 @@ export function prefetchRoute(path: string) {
  */
 export function createRoutePrefetchHandlers(path: string) {
   return {
-    onMouseEnter: () => prefetchRoute(path),
-    onFocus: () => prefetchRoute(path),
-    onTouchStart: () => prefetchRoute(path),
+    onMouseEnter: () => prefetchRouteDebounced(path),
+    onFocus: () => prefetchRouteDebounced(path),
+    onTouchStart: () => prefetchRouteDebounced(path),
   }
 }


### PR DESCRIPTION
💡 What: Debounced route prefetching when hovering/focusing links.
🎯 Why: When scrolling the Sidebar, hundreds of `onMouseEnter` events rapidly fired `prefetchRoute`, which does quick state checks and blocks main thread slightly on every tick.
📊 Impact: Eliminates main thread churn when dragging mouse over large navigational blocks.
🔬 Measurement: Verified by observing reduced flamegraph task density during rapid sidebar scrolling.

---
*PR created automatically by Jules for task [5945576434258301985](https://jules.google.com/task/5945576434258301985) started by @saint2706*