### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Python comment parsing bypass via \r

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-09 - Prevent Python Parser CRLF Comment Bypass
+**Vulnerability:** Python allows `\r` (carriage return) as a newline character, but the comment-stripping logic only checked for `\n`. Attackers could hide malicious payloads like `eval()` after a `\r` inside a comment.
+**Learning:** When sanitizing strings or comments, we must consider all newline sequences (`\r`, `\n`, `\r\n`) respected by the target parser.
+**Prevention:** Ensure comment-stripping logic uses AST or checks for both `\r` and `\n` to prevent hiding executable code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11603,9 +11603,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -41,6 +41,11 @@ describe('stripPythonCommentsAndStrings', () => {
     const code = 'print(r"raw")'
     expect(stripPythonCommentsAndStrings(code)).toBe('print(r"")')
   })
+
+  it('should handle carriage returns in comments', () => {
+    const code = 'print(1) # a comment \reval(1)'
+    expect(stripPythonCommentsAndStrings(code).trim()).toBe('print(1) \reval(1)')
+  })
 })
 
 describe('validatePythonCode', () => {
@@ -308,5 +313,9 @@ print("bad")
   it('should handle complex f-strings', () => {
     expect(validatePythonCode('f"{1+1}"').valid).toBe(true)
     expect(validatePythonCode('f"{eval(1)} "').valid).toBe(false)
+  })
+
+  it('should block eval hidden after carriage return comment', () => {
+    expect(validatePythonCode('print(1) # a comment \reval(1)')).toEqual({ valid: false, error: 'Security Error: Usage of dangerous built-in functions is restricted.' })
   })
 })

--- a/src/utils/__tests__/codeSecurity.test.ts
+++ b/src/utils/__tests__/codeSecurity.test.ts
@@ -316,6 +316,9 @@ print("bad")
   })
 
   it('should block eval hidden after carriage return comment', () => {
-    expect(validatePythonCode('print(1) # a comment \reval(1)')).toEqual({ valid: false, error: 'Security Error: Usage of dangerous built-in functions is restricted.' })
+    expect(validatePythonCode('print(1) # a comment \reval(1)')).toEqual({
+      valid: false,
+      error: 'Security Error: Usage of dangerous built-in functions is restricted.',
+    })
   })
 })

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -121,10 +121,20 @@ export function stripPythonCommentsAndStrings(code: string): string {
 
     if (!inString && char === '#') {
       const nextNewline = stripped.indexOf('\n', i)
-      if (nextNewline === -1) {
+      const nextCr = stripped.indexOf('\r', i)
+      let nextLineEnd = -1
+      if (nextNewline !== -1 && nextCr !== -1) {
+        nextLineEnd = Math.min(nextNewline, nextCr)
+      } else if (nextNewline !== -1) {
+        nextLineEnd = nextNewline
+      } else if (nextCr !== -1) {
+        nextLineEnd = nextCr
+      }
+
+      if (nextLineEnd === -1) {
         break // Rest of the line is a comment, end of string
       }
-      i = nextNewline // Skip to newline
+      i = nextLineEnd // Skip to newline
       continue
     }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `stripPythonCommentsAndStrings` regex in `codeSecurity.ts` only recognized line feeds (`\n`) as the end of a comment. An attacker could hide restricted execution (e.g. `eval()`) behind a carriage return (`\r`) inside a comment, which the Python interpreter would still execute.
🎯 Impact: Attackers could bypass code sanitization checks to execute dangerous functions, granting access to browser APIs or system internals via Pyodide.
🔧 Fix: Updated the comment parsing logic to correctly handle `\n` and `\r` as newline terminators.
✅ Verification: Tested via unit tests with `print(1) # a comment \reval(1)` to ensure accurate stripping.

---
*PR created automatically by Jules for task [3571438216003854150](https://jules.google.com/task/3571438216003854150) started by @saint2706*