### PR TITLE
⚡ Bolt: Optimize querySelector in ScrollProgress

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-08-10 - Cached document.querySelector in ScrollProgress
+**Learning:** The ScrollProgress component was executing document.querySelector inside an rAF on every scroll event when a targetSelector was provided. This introduces unnecessary layout thrashing/DOM querying.
+**Action:** When a DOM element is queried repeatedly in a scroll handler or requestAnimationFrame loop, cache the element reference using useRef and verify its existence with isConnected to avoid repeated querySelector calls.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -27,6 +27,11 @@ interface ScrollProgressProps {
  * @returns {JSX.Element} The scroll progress bar widget.
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
+  const elementRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    elementRef.current = null
+  }, [targetSelector])
   const [progress, setProgress] = useState(0)
 
   useEffect(() => {
@@ -36,7 +41,11 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        let element = elementRef.current
+        if (!element || !element.isConnected) {
+          element = document.querySelector<HTMLElement>(targetSelector)
+          elementRef.current = element
+        }
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cache document.querySelector result in ScrollProgress using useRef. 🎯 Why: To prevent redundant DOM querying during requestAnimationFrame loop on every scroll event. 📊 Impact: Eliminates O(N) query overhead on every scroll event when a targetSelector is present. 🔬 Measurement: Scroll the lesson view and verify scroll progress bar still renders correctly.

---
*PR created automatically by Jules for task [11754290301200223527](https://jules.google.com/task/11754290301200223527) started by @saint2706*