### PR TITLE
⚡ Bolt: Cache DOM query in ScrollProgress

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Caching document.querySelector in Scroll Event Handlers
+**Learning:** `document.querySelector` can be a significant bottleneck when called on every scroll event, especially in a component like `ScrollProgress` where it's executed frequently. The results should be cached, but care must be taken to ensure the cached element is still attached to the DOM, as elements might unmount (e.g., in SPAs).
+**Action:** Always cache the result of `document.querySelector` when used inside high-frequency event handlers like scroll. Use `useRef` to store the element and verify its presence using `element.isConnected` (or `document.body.contains`). Ensure the cache is reset when dependencies (like the target selector prop) change.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,11 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const targetRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    targetRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +41,11 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        let element = targetRef.current
+        if (!element || !element.isConnected) {
+          element = document.querySelector<HTMLElement>(targetSelector)
+          targetRef.current = element
+        }
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cache `document.querySelector` result in a `useRef` in `ScrollProgress` component.
🎯 Why: Calling `document.querySelector` on every scroll event is expensive and causes performance overhead.
📊 Impact: Reduces DOM queries on scroll, improving scroll performance.
🔬 Measurement: Profile scroll event execution time in browser dev tools.

---
*PR created automatically by Jules for task [11368003813574979681](https://jules.google.com/task/11368003813574979681) started by @saint2706*