### PR TITLE
⚡ Bolt: Cache DOM query in ScrollProgress

### DIFF
--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,12 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const targetElementRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    // Reset cached element when selector changes
+    targetElementRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +42,13 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        // ⚡ Bolt: Cache DOM query result to avoid expensive queries on every scroll frame
+        let element = targetElementRef.current
+        if (!element || !element.isConnected) {
+          element = document.querySelector<HTMLElement>(targetSelector)
+          targetElementRef.current = element
+        }
+
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cached the result of `document.querySelector` inside the `ScrollProgress` component using a `useRef`.
🎯 Why: The component was querying the DOM synchronously on every animation frame during scrolling, leading to potential layout thrashing and unnecessary repaints.
📊 Impact: Reduces expensive DOM query operations to ~O(1) per component mount rather than O(frames), saving compute cycles during continuous scrolling.
🔬 Measurement: Open a lesson page and profile the scroll events; the `querySelector` overhead will no longer appear inside the `updateProgress` frame loop.

---
*PR created automatically by Jules for task [15741139348410653859](https://jules.google.com/task/15741139348410653859) started by @saint2706*