### PR TITLE
⚡ Bolt: Cache DOM queries in ScrollProgress

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-08-13 - [DOM query cache for scroll optimizations]
+**Learning:** React state inside an onScroll handler causes frequent layout thrashing. document.querySelector is synchronous and slow in long documents.
+**Action:** Use a `useRef` to cache the DOM node reference retrieved by `document.querySelector` inside `useEffect`, reducing layout thrashing in high-frequency scroll handlers.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -29,6 +29,13 @@ interface ScrollProgressProps {
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
 
+  // ⚡ Bolt: Cache DOM query result to avoid expensive queries on every scroll frame
+  const targetElementRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    targetElementRef.current = null
+  }, [targetSelector])
+
   useEffect(() => {
     let ticking = false
 
@@ -36,7 +43,12 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        let element = targetElementRef.current
+        if (!element || !element.isConnected) {
+          element = document.querySelector<HTMLElement>(targetSelector)
+          targetElementRef.current = element
+        }
+
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 What: Cached the DOM node reference via useRef in ScrollProgress.\n🎯 Why: document.querySelector was being called inside the requestAnimationFrame update function, causing unnecessary DOM queries at high frequency.\n📊 Impact: Reduces layout thrashing and overhead during scrolling.\n🔬 Measurement: Scroll the lesson page and measure the layout processing time.

---
*PR created automatically by Jules for task [14447802560373906577](https://jules.google.com/task/14447802560373906577) started by @saint2706*