### PR TITLE
⚡ Bolt: Cache DOM query in ScrollProgress

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-01-07 - React Scroll Performance and Stale References
+**Learning:** When caching `document.querySelector` inside a frequent event listener (like `onScroll` in `ScrollProgress`), checking `element.isConnected` is crucial because DOM changes might detach the cached element, leading to calculations based on stale layout metrics. Furthermore, it's essential to reset the cache reference when the underlying target prop changes.
+**Action:** Always validate cached DOM element references using `isConnected` inside high-frequency listeners and reset the `useRef` cache when selector props change.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,7 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  const targetElementRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
     let ticking = false
@@ -36,8 +37,12 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
-        if (element) {
+        if (!targetElementRef.current) {
+          targetElementRef.current = document.querySelector<HTMLElement>(targetSelector)
+        }
+        const element = targetElementRef.current
+
+        if (element && element.isConnected) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight
           const windowHeight = window.innerHeight
@@ -52,6 +57,7 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
           }
         } else {
           // Fallback if target is not found
+          targetElementRef.current = null
           const scrollTop = window.scrollY
           const docHeight = document.documentElement.scrollHeight - window.innerHeight
           calcProgress = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0
@@ -73,6 +79,7 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       }
     }
 
+    targetElementRef.current = null
     // Initial calculation
     updateProgress()
 


### PR DESCRIPTION
💡 **What:** Cached `document.querySelector` in the `ScrollProgress` component using a `useRef` hook, ensuring it's valid with `element.isConnected`.

🎯 **Why:** `onScroll` runs frequently (dozens of times per second). Re-querying the DOM on every frame causes unnecessary DOM traversal and layout thrashing overhead. 

📊 **Impact:** Reduces DOM traversal operations significantly on scroll.

🔬 **Measurement:** Verify by running tests, scrolling around the application, and inspecting scroll performance.

---
*PR created automatically by Jules for task [17362190496951203313](https://jules.google.com/task/17362190496951203313) started by @saint2706*