### PR TITLE
🛡️ Sentinel: [HIGH] Fix reverse tabnabbing vulnerability in Mermaid diagrams

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-15 - Secure Links in DOMPurify
+**Vulnerability:** Reverse Tabnabbing in Mermaid Diagrams
+**Learning:** DOMPurify sanitization in MermaidDiagram.tsx did not enforce `target="_blank"` and `rel="noopener noreferrer"` on generated links. This could allow malicious links inside diagrams to exploit reverse tabnabbing vulnerabilities.
+**Prevention:** Always instantiate a local DOMPurify object and use `addHook` for `afterSanitizeAttributes` to enforce secure link attributes when rendering unstrusted content, taking care not to pollute the global DOMPurify state.

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -79,14 +79,14 @@ function MermaidDiagram({ code }: MermaidDiagramProps) {
           // namespace boundary). DOMPurify's default namespace check only treats
           // <annotation-xml> as a valid HTML integration point, so without this config
           // it silently empties every <foreignObject>, stripping all diagram text.
-          const localPurify = DOMPurify(window);
+          const localPurify = DOMPurify(window)
 
-          localPurify.addHook('afterSanitizeAttributes', function(node) {
+          localPurify.addHook('afterSanitizeAttributes', function (node) {
             if (node.tagName && node.tagName.toLowerCase() === 'a') {
-                node.setAttribute('target', '_blank');
-                node.setAttribute('rel', 'noopener noreferrer');
+              node.setAttribute('target', '_blank')
+              node.setAttribute('rel', 'noopener noreferrer')
             }
-          });
+          })
 
           containerRef.current.innerHTML = localPurify.sanitize(svg, {
             ADD_TAGS: ['foreignObject'],

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -79,7 +79,16 @@ function MermaidDiagram({ code }: MermaidDiagramProps) {
           // namespace boundary). DOMPurify's default namespace check only treats
           // <annotation-xml> as a valid HTML integration point, so without this config
           // it silently empties every <foreignObject>, stripping all diagram text.
-          containerRef.current.innerHTML = DOMPurify.sanitize(svg, {
+          const localPurify = DOMPurify(window);
+
+          localPurify.addHook('afterSanitizeAttributes', function(node) {
+            if (node.tagName && node.tagName.toLowerCase() === 'a') {
+                node.setAttribute('target', '_blank');
+                node.setAttribute('rel', 'noopener noreferrer');
+            }
+          });
+
+          containerRef.current.innerHTML = localPurify.sanitize(svg, {
             ADD_TAGS: ['foreignObject'],
             HTML_INTEGRATION_POINTS: { foreignobject: true },
           })

--- a/src/components/__tests__/MermaidDiagram.test.tsx
+++ b/src/components/__tests__/MermaidDiagram.test.tsx
@@ -99,7 +99,7 @@ describe('MermaidDiagram', () => {
 
   it('adds target="_blank" and rel="noopener noreferrer" to links to prevent reverse tabnabbing', async () => {
     renderMock.mockResolvedValue({
-      svg: '<svg><a href="https://example.com">Link</a></svg>'
+      svg: '<svg><a href="https://example.com">Link</a></svg>',
     })
 
     act(() => {

--- a/src/components/__tests__/MermaidDiagram.test.tsx
+++ b/src/components/__tests__/MermaidDiagram.test.tsx
@@ -96,4 +96,21 @@ describe('MermaidDiagram', () => {
     })
     expect(initializeMock.mock.calls[0]?.[0]).toMatchObject({ theme: 'dark' })
   })
+
+  it('adds target="_blank" and rel="noopener noreferrer" to links to prevent reverse tabnabbing', async () => {
+    renderMock.mockResolvedValue({
+      svg: '<svg><a href="https://example.com">Link</a></svg>'
+    })
+
+    act(() => {
+      root.render(<MermaidDiagram code="graph TD;\nA-->B;" />)
+    })
+
+    await waitFor(() => {
+      const link = container.querySelector('a')
+      expect(link).toBeTruthy()
+      expect(link?.getAttribute('target')).toBe('_blank')
+      expect(link?.getAttribute('rel')).toBe('noopener noreferrer')
+    })
+  })
 })


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Reverse Tabnabbing via Mermaid diagram SVG links
🎯 Impact: A malicious actor could provide a diagram containing a hyperlink. When clicked, the new tab would retain a reference to the `window.opener` object, allowing the untrusted site to navigate the original tab to a malicious URL (e.g., a phishing page).
🔧 Fix: Scoped a local instance of `DOMPurify` to avoid mutating the global state, and added an `afterSanitizeAttributes` hook to automatically enforce `target="_blank"` and `rel="noopener noreferrer"` for all `<a>` tags parsed from the SVG.
✅ Verification: Tested locally via `npm run test -- --run src/components/__tests__/MermaidDiagram.test.tsx` and ran the full build/lint suite successfully. Added a specific test case to prevent regressions.

---
*PR created automatically by Jules for task [9473122002649366254](https://jules.google.com/task/9473122002649366254) started by @saint2706*