### PR TITLE
⚡ Bolt: Optimize scroll progress by caching DOM queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - [Scroll Event Layout Thrashing]
+**Learning:** High-frequency DOM queries like `document.querySelector` inside `requestAnimationFrame` loops on scroll events can cause layout thrashing and high CPU usage in React applications.
+**Action:** Always cache the result of `document.querySelector` using a `useRef` to prevent querying the DOM on every frame. Ensure to clear the ref when the target selector changes.

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -29,11 +29,11 @@ interface ScrollProgressProps {
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
   // ⚡ Bolt: Cache DOM queries to prevent layout thrashing on high-frequency scroll events
-  const elementRef = useRef<HTMLElement | null>(null);
+  const elementRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
-    elementRef.current = null;
-  }, [targetSelector]);
+    elementRef.current = null
+  }, [targetSelector])
 
   useEffect(() => {
     let ticking = false
@@ -44,9 +44,9 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       if (targetSelector) {
         // ⚡ Bolt: Only query DOM if cache is empty or element was removed from document
         if (!elementRef.current || !document.body.contains(elementRef.current)) {
-          elementRef.current = document.querySelector<HTMLElement>(targetSelector);
+          elementRef.current = document.querySelector<HTMLElement>(targetSelector)
         }
-        const element = elementRef.current;
+        const element = elementRef.current
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight

--- a/src/components/ScrollProgress.tsx
+++ b/src/components/ScrollProgress.tsx
@@ -9,7 +9,7 @@
  * - Provide accessible progress role attributes.
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 
 interface ScrollProgressProps {
   targetSelector?: string
@@ -28,6 +28,12 @@ interface ScrollProgressProps {
  */
 export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgressProps) {
   const [progress, setProgress] = useState(0)
+  // ⚡ Bolt: Cache DOM queries to prevent layout thrashing on high-frequency scroll events
+  const elementRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    elementRef.current = null;
+  }, [targetSelector]);
 
   useEffect(() => {
     let ticking = false
@@ -36,7 +42,11 @@ export default function ScrollProgress({ targetSelector, isLesson }: ScrollProgr
       let calcProgress = 0
 
       if (targetSelector) {
-        const element = document.querySelector<HTMLElement>(targetSelector)
+        // ⚡ Bolt: Only query DOM if cache is empty or element was removed from document
+        if (!elementRef.current || !document.body.contains(elementRef.current)) {
+          elementRef.current = document.querySelector<HTMLElement>(targetSelector);
+        }
+        const element = elementRef.current;
         if (element) {
           const rect = element.getBoundingClientRect()
           const elementHeight = element.clientHeight


### PR DESCRIPTION
💡 **What**: Added `useRef` to cache the `document.querySelector` lookup in `ScrollProgress.tsx`. Clears cache correctly when the `targetSelector` changes or when the element is removed from the document.
🎯 **Why**: Running DOM queries inside a high-frequency `requestAnimationFrame` loop (which fires on scroll events) can trigger excessive layout calculations and CPU spikes, especially on longer lesson pages.
📊 **Impact**: Reduces DOM traversals from O(frames) to O(1) per selector change, preventing potential layout thrashing and reducing scroll latency.
🔬 **Measurement**: Profile a lesson page in Chrome DevTools Performance tab while scrolling; the "Recalculate Style" and JS execution time during scrolling should be noticeably lower.

---
*PR created automatically by Jules for task [5301174011622431368](https://jules.google.com/task/5301174011622431368) started by @saint2706*