### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing in Mermaid diagrams

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-08-16 - Prevent Reverse Tabnabbing in Mermaid Diagrams
+**Vulnerability:** External links rendered inside Mermaid diagrams via `foreignObject` integration points were lacking `target="_blank"` and `rel="noopener noreferrer"`.
+**Learning:** Even though DOMPurify sanitizes standard HTML blocks, dynamic SVG integration points like `<foreignObject>` can contain standard anchor tags that might skip global link-safety checks if they're generated deeply inside a third-party graph library wrapper.
+**Prevention:** Always use localized DOMPurify hooks (to avoid polluting global state) when using `innerHTML` on SVGs/HTML from third-party graph generators, ensuring specific rules like `target="_blank"` and `rel="noopener noreferrer"` are enforced on all dynamically rendered anchors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11603,9 +11603,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/components/MermaidDiagram.tsx
+++ b/src/components/MermaidDiagram.tsx
@@ -79,7 +79,19 @@ function MermaidDiagram({ code }: MermaidDiagramProps) {
           // namespace boundary). DOMPurify's default namespace check only treats
           // <annotation-xml> as a valid HTML integration point, so without this config
           // it silently empties every <foreignObject>, stripping all diagram text.
-          containerRef.current.innerHTML = DOMPurify.sanitize(svg, {
+
+          // Use a local DOMPurify instance to add hooks safely without polluting global scope
+          const localPurify = DOMPurify(window)
+
+          // Prevent reverse tabnabbing on links rendered within the diagram
+          localPurify.addHook('afterSanitizeAttributes', (node) => {
+            if (node.tagName && node.tagName.toLowerCase() === 'a') {
+              node.setAttribute('target', '_blank')
+              node.setAttribute('rel', 'noopener noreferrer')
+            }
+          })
+
+          containerRef.current.innerHTML = localPurify.sanitize(svg, {
             ADD_TAGS: ['foreignObject'],
             HTML_INTEGRATION_POINTS: { foreignobject: true },
           })


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** External links rendered inside dynamically generated Mermaid diagrams lacked `target="_blank"` and `rel="noopener noreferrer"`.
🎯 **Impact:** If an attacker creates a link that opens an external malicious site, they could execute a reverse tabnabbing attack via `window.opener` or silently replace the original application context.
🔧 **Fix:** Introduced a scoped, localized instance of `DOMPurify` that registers an `afterSanitizeAttributes` hook exclusively for Mermaid diagrams. The hook automatically enforces `target="_blank"` and `rel="noopener noreferrer"` on all parsed `<a>` tags.
✅ **Verification:** Verified by checking `npm run test` against MermaidDiagram tests and observing no regressions across the `npm run build` sequence.

*Recorded learnings into `.jules/sentinel.md` as per instructions.*

---
*PR created automatically by Jules for task [8714713908122682519](https://jules.google.com/task/8714713908122682519) started by @saint2706*