### PR TITLE
⚡ Bolt: Throttle high-frequency scroll event handlers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-08-17 - Throttling Scroll Event Handlers
+**Learning:** React \`onScroll\` event handlers that fire frequently can cause severe layout thrashing and drop frames, especially when performing multiple synchronous DOM operations (like reading \`scrollTop\`/\`scrollLeft\` and immediately writing them to another element).
+**Action:** When synchronizing scroll positions or performing high-frequency DOM manipulations inside React event handlers, always throttle the updates using \`requestAnimationFrame\` combined with a \`useRef\` guard flag (e.g., \`isScrolling\`) to lock execution to the display refresh rate and prevent layout thrashing.

--- a/src/components/CodePlayground.tsx
+++ b/src/components/CodePlayground.tsx
@@ -179,18 +179,18 @@ const CodePlayground = forwardRef<CodePlaygroundHandle, CodePlaygroundProps>(
      */
     const handleScroll = useCallback(() => {
       if (!isScrollingRef.current) {
-        isScrollingRef.current = true;
+        isScrollingRef.current = true
         requestAnimationFrame(() => {
-          const ta = textareaRef.current;
-          const pre = preRef.current;
+          const ta = textareaRef.current
+          const pre = preRef.current
           if (ta && pre) {
-            pre.scrollTop = ta.scrollTop;
-            pre.scrollLeft = ta.scrollLeft;
+            pre.scrollTop = ta.scrollTop
+            pre.scrollLeft = ta.scrollLeft
           }
-          isScrollingRef.current = false;
-        });
+          isScrollingRef.current = false
+        })
       }
-    }, []);
+    }, [])
 
     /**
      * Handles keyboard shortcuts for running code.

--- a/src/components/CodePlayground.tsx
+++ b/src/components/CodePlayground.tsx
@@ -116,6 +116,7 @@ const CodePlayground = forwardRef<CodePlaygroundHandle, CodePlaygroundProps>(
     const runnerRef = useRef<PythonRunnerHandle>(null)
     const runCountRef = useRef(0)
     const resetTimeoutRef = useRef<number | null>(null)
+    const isScrollingRef = useRef(false)
 
     /**
      * Resets the code editor to its initial state.
@@ -174,16 +175,22 @@ const CodePlayground = forwardRef<CodePlaygroundHandle, CodePlaygroundProps>(
     }, [code])
 
     /**
-     * Handles scroll synchronization between textarea and highlight layer.
+     * Throttles scroll synchronization to prevent layout thrashing
      */
     const handleScroll = useCallback(() => {
-      const ta = textareaRef.current
-      const pre = preRef.current
-      if (ta && pre) {
-        pre.scrollTop = ta.scrollTop
-        pre.scrollLeft = ta.scrollLeft
+      if (!isScrollingRef.current) {
+        isScrollingRef.current = true;
+        requestAnimationFrame(() => {
+          const ta = textareaRef.current;
+          const pre = preRef.current;
+          if (ta && pre) {
+            pre.scrollTop = ta.scrollTop;
+            pre.scrollLeft = ta.scrollLeft;
+          }
+          isScrollingRef.current = false;
+        });
       }
-    }, [])
+    }, []);
 
     /**
      * Handles keyboard shortcuts for running code.

--- a/src/components/SqlPlayground.tsx
+++ b/src/components/SqlPlayground.tsx
@@ -50,6 +50,7 @@ const SqlPlayground = forwardRef<SqlPlaygroundHandle, SqlPlaygroundProps>(
     const preRef = useRef<HTMLDivElement>(null)
     const runnerRef = useRef<SqlRunnerHandle>(null)
     const resetTimeoutRef = useRef<number | null>(null)
+    const isScrollingRef = useRef(false)
 
     const handleReset = useCallback(() => {
       setCode(initialCode)
@@ -96,14 +97,23 @@ const SqlPlayground = forwardRef<SqlPlaygroundHandle, SqlPlaygroundProps>(
       }
     }, [code])
 
+    /**
+     * Throttles scroll synchronization to prevent layout thrashing
+     */
     const handleScroll = useCallback(() => {
-      const ta = textareaRef.current
-      const pre = preRef.current
-      if (ta && pre) {
-        pre.scrollTop = ta.scrollTop
-        pre.scrollLeft = ta.scrollLeft
+      if (!isScrollingRef.current) {
+        isScrollingRef.current = true;
+        requestAnimationFrame(() => {
+          const ta = textareaRef.current;
+          const pre = preRef.current;
+          if (ta && pre) {
+            pre.scrollTop = ta.scrollTop;
+            pre.scrollLeft = ta.scrollLeft;
+          }
+          isScrollingRef.current = false;
+        });
       }
-    }, [])
+    }, []);
 
     const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
       if ((e.shiftKey || e.ctrlKey || e.metaKey) && e.key === 'Enter') {

--- a/src/components/SqlPlayground.tsx
+++ b/src/components/SqlPlayground.tsx
@@ -102,18 +102,18 @@ const SqlPlayground = forwardRef<SqlPlaygroundHandle, SqlPlaygroundProps>(
      */
     const handleScroll = useCallback(() => {
       if (!isScrollingRef.current) {
-        isScrollingRef.current = true;
+        isScrollingRef.current = true
         requestAnimationFrame(() => {
-          const ta = textareaRef.current;
-          const pre = preRef.current;
+          const ta = textareaRef.current
+          const pre = preRef.current
           if (ta && pre) {
-            pre.scrollTop = ta.scrollTop;
-            pre.scrollLeft = ta.scrollLeft;
+            pre.scrollTop = ta.scrollTop
+            pre.scrollLeft = ta.scrollLeft
           }
-          isScrollingRef.current = false;
-        });
+          isScrollingRef.current = false
+        })
       }
-    }, []);
+    }, [])
 
     const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
       if ((e.shiftKey || e.ctrlKey || e.metaKey) && e.key === 'Enter') {

--- a/test_perf.cjs
+++ b/test_perf.cjs
@@ -1,1 +1,0 @@
-console.log('Validating structure')


### PR DESCRIPTION
💡 **What:** Throttled high-frequency `onScroll` event handlers in `CodePlayground` and `SqlPlayground` using `requestAnimationFrame` and a `useRef` guard flag (`isScrollingRef`).

🎯 **Why:** The existing implementation was performing synchronous DOM reads (`ta.scrollTop`) and immediate writes (`pre.scrollTop`) inside an un-throttled scroll event handler. This pattern is notorious for causing layout thrashing and dropped frames, especially during rapid scrolling of large code blocks.

📊 **Impact:** Reduces main-thread blocking time during scrolling by locking DOM updates to the display refresh rate (typically 60fps), eliminating redundant synchronous layout calculations and preventing layout thrashing.

🔬 **Measurement:** Profile the application using Chrome DevTools Performance tab while rapidly scrolling large blocks of code in the playgrounds. The "Layout" and "Update Layer Tree" events should be significantly more uniform, and the frames should remain closer to 16.6ms (60fps) without long tasks.

---
*PR created automatically by Jules for task [14764950058426304224](https://jules.google.com/task/14764950058426304224) started by @saint2706*