### PR TITLE
🛡️ Sentinel: [HIGH] Fix comment stripping vulnerability in code security validator

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - Python Scanner Bypass via Carriage Returns
+**Vulnerability:** The custom Python security scanner (`stripPythonCommentsAndStrings` in `codeSecurity.ts`) stripped comments by looking only for the `\n` (Line Feed) character as the end-of-line terminator.
+**Learning:** Python's parser strictly adheres to cross-platform newline handling, treating both `\n` and `\r` (Carriage Return) as valid statement terminators. Attackers could evade the scanner by using a `\r` immediately after a comment symbol (`#`) followed by malicious payload (e.g., `# comment\ros.system("id")`). The scanner would incorrectly assume the malicious payload was still part of the comment and ignore it.
+**Prevention:** When building custom AST parsers or comment strippers, always validate terminators against the exact specification of the target language runtime, explicitly handling both `\n` and `\r`.

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -122,8 +122,7 @@ export function stripPythonCommentsAndStrings(code: string): string {
     if (!inString && char === '#') {
       const nextLF = stripped.indexOf('\n', i)
       const nextCR = stripped.indexOf('\r', i)
-      const nextNewline =
-        nextLF === -1 ? nextCR : nextCR === -1 ? nextLF : Math.min(nextLF, nextCR)
+      const nextNewline = nextLF === -1 ? nextCR : nextCR === -1 ? nextLF : Math.min(nextLF, nextCR)
 
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string

--- a/src/utils/codeSecurity.ts
+++ b/src/utils/codeSecurity.ts
@@ -120,7 +120,11 @@ export function stripPythonCommentsAndStrings(code: string): string {
     }
 
     if (!inString && char === '#') {
-      const nextNewline = stripped.indexOf('\n', i)
+      const nextLF = stripped.indexOf('\n', i)
+      const nextCR = stripped.indexOf('\r', i)
+      const nextNewline =
+        nextLF === -1 ? nextCR : nextCR === -1 ? nextLF : Math.min(nextLF, nextCR)
+
       if (nextNewline === -1) {
         break // Rest of the line is a comment, end of string
       }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Python comment stripper stopped at line feeds but ignored carriage returns.
🎯 Impact: Attackers could bypass code validation filters by appending malicious code after a carriage return.
🔧 Fix: Updated comment terminator logic to consider both LF and CR characters.
✅ Verification: Handled via the provided unit tests/manual testing.

---
*PR created automatically by Jules for task [3998314594333319514](https://jules.google.com/task/3998314594333319514) started by @saint2706*