### PR TITLE
⚡ Bolt: Optimize playground scroll synchronization with requestAnimationFrame

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-08-21 - RequestAnimationFrame Optimization for Scroll Synchronization
+**Learning:** High-frequency DOM events like `onScroll` can cause layout thrashing and unnecessary recalculations if synchronous updates directly access layout properties (`scrollTop`/`scrollLeft`) continuously.
+**Action:** Use `requestAnimationFrame` to lock synchronous layout measurements and writes to the browser's refresh rate (typically 60Hz), combined with a `useRef` guard to drop redundant intermediate scroll updates during the same frame.

--- a/src/components/CodePlayground.tsx
+++ b/src/components/CodePlayground.tsx
@@ -116,6 +116,7 @@ const CodePlayground = forwardRef<CodePlaygroundHandle, CodePlaygroundProps>(
     const runnerRef = useRef<PythonRunnerHandle>(null)
     const runCountRef = useRef(0)
     const resetTimeoutRef = useRef<number | null>(null)
+    const isScrollingRef = useRef(false)
 
     /**
      * Resets the code editor to its initial state.
@@ -177,11 +178,19 @@ const CodePlayground = forwardRef<CodePlaygroundHandle, CodePlaygroundProps>(
      * Handles scroll synchronization between textarea and highlight layer.
      */
     const handleScroll = useCallback(() => {
-      const ta = textareaRef.current
-      const pre = preRef.current
-      if (ta && pre) {
-        pre.scrollTop = ta.scrollTop
-        pre.scrollLeft = ta.scrollLeft
+      // Use requestAnimationFrame to throttle synchronous DOM layout reads/writes
+      // (scrollTop/Left) to 60fps, preventing layout thrashing during fast scrolling.
+      if (!isScrollingRef.current) {
+        isScrollingRef.current = true
+        requestAnimationFrame(() => {
+          const ta = textareaRef.current
+          const pre = preRef.current
+          if (ta && pre) {
+            pre.scrollTop = ta.scrollTop
+            pre.scrollLeft = ta.scrollLeft
+          }
+          isScrollingRef.current = false
+        })
       }
     }, [])
 

--- a/src/components/SqlPlayground.tsx
+++ b/src/components/SqlPlayground.tsx
@@ -50,6 +50,7 @@ const SqlPlayground = forwardRef<SqlPlaygroundHandle, SqlPlaygroundProps>(
     const preRef = useRef<HTMLDivElement>(null)
     const runnerRef = useRef<SqlRunnerHandle>(null)
     const resetTimeoutRef = useRef<number | null>(null)
+    const isScrollingRef = useRef(false)
 
     const handleReset = useCallback(() => {
       setCode(initialCode)
@@ -97,11 +98,19 @@ const SqlPlayground = forwardRef<SqlPlaygroundHandle, SqlPlaygroundProps>(
     }, [code])
 
     const handleScroll = useCallback(() => {
-      const ta = textareaRef.current
-      const pre = preRef.current
-      if (ta && pre) {
-        pre.scrollTop = ta.scrollTop
-        pre.scrollLeft = ta.scrollLeft
+      // Use requestAnimationFrame to throttle synchronous DOM layout reads/writes
+      // (scrollTop/Left) to 60fps, preventing layout thrashing during fast scrolling.
+      if (!isScrollingRef.current) {
+        isScrollingRef.current = true
+        requestAnimationFrame(() => {
+          const ta = textareaRef.current
+          const pre = preRef.current
+          if (ta && pre) {
+            pre.scrollTop = ta.scrollTop
+            pre.scrollLeft = ta.scrollLeft
+          }
+          isScrollingRef.current = false
+        })
       }
     }, [])
 


### PR DESCRIPTION
💡 **What:** Replaced the synchronous DOM updates in the `handleScroll` events of `CodePlayground` and `SqlPlayground` with a `requestAnimationFrame` wrapper gated by a `useRef` throttle (`isScrollingRef`).

🎯 **Why:** Previously, scrolling the textarea fired synchronous layout reads (`scrollTop` / `scrollLeft`) and writes to the overlay element potentially hundreds of times per second. This causes rapid, unnecessary layout thrashing on the main thread, leading to jank during fast scrolling.

📊 **Impact:** Reduces layout recalculations significantly by throttling DOM synchronization to the browser's native refresh rate (typically 60fps). Eliminates main-thread blocking during high-frequency scroll events.

🔬 **Measurement:** Scroll the code area in the Playgrounds rapidly. You should observe no stuttering or lag in the syntax highlight overlay staying perfectly aligned with the cursor. Run a Performance profile in Chrome DevTools to verify that `onScroll` event processing time is vastly reduced and layout thrashing warnings are eliminated.

---
*PR created automatically by Jules for task [4252829303362233546](https://jules.google.com/task/4252829303362233546) started by @saint2706*