### PR TITLE
Fix act() warnings and pnpm arg-forwarding bugs in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p test-results coverage
-          pnpm run test:coverage -- \
+          pnpm run test:coverage \
             --reporter=default \
             --reporter=junit \
             --outputFile.junit=./test-results/vitest-junit.xml \

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Serve dist
         run: |
-          VITE_BASE_PATH=/ pnpm run preview -- --host 127.0.0.1 >/tmp/serve.log 2>&1 &
+          VITE_BASE_PATH=/ pnpm run preview --host 127.0.0.1 >/tmp/serve.log 2>&1 &
           pnpm dlx wait-on@9 http://127.0.0.1:4173
 
       - name: Run Lighthouse CI

--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Playwright smoke subset (Chromium)
         if: ${{ github.event.inputs.run_playwright_smoke == 'true' || vars.RUN_NIGHTLY_PLAYWRIGHT_SMOKE == 'true' }}
-        run: pnpm run test:e2e -- --project=chromium --grep '@smoke' --pass-with-no-tests
+        run: pnpm run test:e2e --project=chromium --grep '@smoke' --pass-with-no-tests
 
       - name: Upload Playwright HTML report
         if: ${{ failure() && (github.event.inputs.run_playwright_smoke == 'true' || vars.RUN_NIGHTLY_PLAYWRIGHT_SMOKE == 'true') }}

--- a/tests/unit/App.test.tsx
+++ b/tests/unit/App.test.tsx
@@ -533,6 +533,10 @@ describe('App Suspense fallback', () => {
 
     expect(screen.getByTestId('lesson-skeleton')).toBeInTheDocument()
     expect(screen.queryByTestId('page-skeleton')).not.toBeInTheDocument()
+
+    // Flush the lazy import's resolution inside act() now that the fallback
+    // has been observed, so the state update doesn't leak into a later test.
+    await act(async () => {})
   })
 
   it('shows the generic page skeleton as the Suspense fallback on non-lesson routes', async () => {
@@ -547,5 +551,9 @@ describe('App Suspense fallback', () => {
 
     expect(screen.getByTestId('page-skeleton')).toBeInTheDocument()
     expect(screen.queryByTestId('lesson-skeleton')).not.toBeInTheDocument()
+
+    // Flush the lazy import's resolution inside act() now that the fallback
+    // has been observed, so the state update doesn't leak into a later test.
+    await act(async () => {})
   })
 })


### PR DESCRIPTION
## Summary
- The `unit-test (windows-latest, 22.x)` job logs (run [33188695970](https://github.com/saint2706/Coding-For-MBA/actions/runs/33188695970)) showed repeated `A suspended resource finished loading inside a test, but the event was not wrapped in act(...)` warnings.
  - Both came from `tests/unit/App.test.tsx` in the `App Suspense fallback` describe block: the two tests intentionally call `render()` without wrapping it in `act()` so they can observe the Suspense fallback skeleton before the lazy-loaded route chunk resolves — but they never flushed that later resolution inside `act()` before the test ended, so React logged the warning when the lazy import resolved outside any `act()` boundary.
  - Added `await act(async () => {})` after the fallback assertions in each test to flush the pending lazy-import resolution inside `act()`, eliminating the warnings without changing what the tests verify.
- Same run's `Upload unit test results` step also warned `No files were found with the provided path: test-results/vitest-junit.xml. No artifacts will be uploaded.`
  - Root cause: `.github/workflows/ci.yml` ran `pnpm run test:coverage -- --reporter=junit ...`. Unlike npm, pnpm does not strip the `--` separator before forwarding args to the underlying script, so vitest's CLI received a literal `--` and treated every flag after it as a positional argument instead of an option. The `--reporter=junit`, `--outputFile.junit=...`, and `--coverage.reporter=lcov`/`cobertura` flags were silently dropped, so `test-results/vitest-junit.xml` (and the lcov/cobertura coverage files) never got written.
  - Fix: drop the extra `--` so pnpm forwards the flags directly.
- The same `pnpm run <script> -- <args>` pattern also existed in two other workflows and has the identical bug:
  - `.github/workflows/lighthouse.yml`: `pnpm run preview -- --host 127.0.0.1` silently dropped `--host`, so vite preview ignored the explicit bind address. Verified with a real build: `pnpm run preview --host 127.0.0.1` now correctly binds to `127.0.0.1:4173` (curl returns 200); with the stray `--` present it started on vite's default host instead.
  - `.github/workflows/nightly-smoke.yml`: `pnpm run test:e2e -- --project=chromium --grep '@smoke' --pass-with-no-tests` silently dropped all three flags, since playwright's CLI is also commander-based and treats `--` as an end-of-options marker. Verified with `--list`: with the stray `--`, playwright printed nothing and the command failed; without it, the flags parse and `--list` reports the matching tests correctly.
  - Fixed both by dropping the extra `--`.

## Test plan
- [x] `pnpm exec vitest run tests/unit/App.test.tsx` — 19/19 passing, no act warnings
- [x] `pnpm exec vitest run` — full suite, 778/778 tests passing
- [x] `pnpm exec prettier --check tests/unit/App.test.tsx .github/workflows/lighthouse.yml .github/workflows/nightly-smoke.yml`
- [x] `pnpm exec eslint tests/unit/App.test.tsx`
- [x] Ran the fixed `pnpm run test:coverage <flags>` locally — confirmed `test-results/vitest-junit.xml`, `coverage/lcov.info`, and `coverage/cobertura-coverage.xml` are all generated, with all coverage thresholds met
- [x] Built the site and ran `pnpm run preview --host 127.0.0.1` — confirmed it binds to `127.0.0.1:4173` and responds 200
- [x] Ran `pnpm run test:e2e --list --project=chromium --grep '@smoke' --pass-with-no-tests` — confirmed flags are parsed (vs. failing silently with the stray `--`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
