### PR TITLE
Fix GitHub Actions annotations: pnpm Node 20 deprecation and Lighthouse artifact upload

### DIFF
--- a/.github/actions/node-bootstrap/action.yml
+++ b/.github/actions/node-bootstrap/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Setup Node
       uses: actions/setup-node@v7

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -45,3 +45,4 @@ jobs:
           path: .lighthouseci
           if-no-files-found: warn
           retention-days: 7
+          include-hidden-files: true


### PR DESCRIPTION
## Summary

Audited annotations on the latest run of every workflow (CI, CodeQL, Dependency Review, Deploy to GitHub Pages, Deploy to Surge, Lighthouse CI, Nightly Smoke, Close All Open PRs) and fixed the two real warning annotations that were surfacing:

- **`pnpm/action-setup@v4` Node 20 deprecation warning** — showed up on every job that runs the shared `./.github/actions/node-bootstrap` composite action (CI, CodeQL, Deploy, Lighthouse). `pnpm/action-setup@v4` still targets the Node 20 action runtime, which GitHub now force-runs on Node 24 with a deprecation warning. Bumped to `@v6` (latest major, targets Node 24 natively). Confirmed via the upstream release notes that v5→v6 only bumped the runtime and added pnpm v11 support — no breaking changes for our no-args usage (pnpm version is read from `packageManager` in `package.json`).
- **Lighthouse CI "No files were found with the provided path: `.lighthouseci`"** — the Lighthouse reports were written successfully, but `actions/upload-artifact@v7` defaults `include-hidden-files` to `false`, which silently excludes the dot-prefixed `.lighthouseci` directory. Added `include-hidden-files: true` so the report actually uploads instead of warning and skipping.

Deploy to Surge, Nightly Smoke, and Close All Open PRs already run annotation-free; their most recent runs happened to be on older commits from before the npm→pnpm migration, so they'll pick up this same fix automatically via the shared `node-bootstrap` action on their next run.

## Test plan

- [x] Validated both edited YAML files parse cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Confirmed `pnpm/action-setup@v6` exists upstream and its `action.yml` targets `node24` (checked via `git ls-remote` + raw file fetch)
- [x] Confirmed `include-hidden-files: true` is a valid input for `actions/upload-artifact@v7`
- [ ] Watch the next CI/CodeQL/Deploy/Lighthouse runs on this PR to confirm the annotations are gone

---
_Generated by [Claude Code](https://claude.ai/code/session_015yTpLfb3fJfpReYDnu9YZv)_